### PR TITLE
jared: switch to native GitHub issue dependencies (Phase 2B)

### DIFF
--- a/skills/jared/assets/issue-body.md.template
+++ b/skills/jared/assets/issue-body.md.template
@@ -16,11 +16,15 @@ Not started.
 
 </details>
 
-## Depends on
-(none)
+<!--
+Dependencies are tracked natively via GitHub's `blockedBy` API, not in body markup.
+Add an edge with: addBlockedBy(issueId, blockingIssueId). See references/dependencies.md.
 
-## Blocks
-(none)
+Add a "## Blocked by" section ONLY when this issue is in the Blocked Status column.
+Format:
+  ## Blocked by
+  Waiting on <person/event>, expected by <date>. <one-line context>
+-->
 
 ## Planning
 (none)

--- a/skills/jared/references/board-sweep.md
+++ b/skills/jared/references/board-sweep.md
@@ -37,9 +37,13 @@ Status in particular is easy to miss: GitHub's auto-add-to-project workflow adds
 - Is the top item **pullable**? Specifically: does it have (a) a clear next action stated in the body, (b) acceptance criteria, (c) all dependencies unblocked? If not, propose reshaping it or pulling the next pullable item instead.
 - Up Next items without Priority set — fix.
 
-### 4. Blocked items
+### 4. Blocked-status items
 
-Every `blocked`-labeled item needs a `## Blocked by` section in its body naming the blocker and the owner of unblocking. If the label is on but the section is missing, flag for fix. If the named blocker issue is now closed, propose unblocking.
+Every item currently in the **Blocked Status column** needs a `## Blocked by` section in its body naming the unblock owner and what specifically is being waited on. If a Blocked-status item lacks this section, flag for fix.
+
+Also flag items that have been in Blocked status for more than 7 days — propose unblocking, punting back to Backlog, or breaking the blocker into a smaller issue.
+
+(The old `blocked` label is retired. A `blockedBy` edge alone does not put an issue in the Blocked column. Items move to Blocked only when actively stuck after being pulled to In Progress.)
 
 ### 5. Aging
 
@@ -67,11 +71,14 @@ For each near-term milestone:
 
 ### 9. Dependency hygiene
 
-For each open issue with dependencies (native GitHub issue dependencies or `## Depends on` body section):
+For each open issue with native `blockedBy` edges:
 
-- Referenced issues still exist?
-- Dependent's Priority higher than or equal to its dependencies' Priority? (Priority inversions are red flags.)
+- Referenced blocker still exists and is open? Edges pointing at closed issues should be removed.
+- Dependent's Priority higher than or equal to its blockers' Priority? (Priority inversions are red flags.)
 - Any circular dependencies? Fix hard.
+- Chains >3 deep? Fragile — slip cascades. Consider parallelizing or cutting scope.
+
+`## Depends on` body sections (if present) are prose context only and are not parsed.
 
 Run `scripts/dependency-graph.py --summary` for a compact view.
 

--- a/skills/jared/references/dependencies.md
+++ b/skills/jared/references/dependencies.md
@@ -53,28 +53,17 @@ gh api graphql -f query='
   }' -F issueId=<dependent-id> -F blockingIssueId=<blocker-id>
 ```
 
-## Fallback: body conventions
+## Body context (not parsed)
 
-Use when native dependencies aren't available or for cross-repo dependencies (which the native feature doesn't handle well).
+A `## Depends on` section may appear in an issue body as human-readable prose explaining *why* the dependency matters (context, sequencing rationale, what breaks if violated). It is **not authoritative** and is not parsed by sweeps or scripts. The canonical relationship is always the native `blockedBy` edge.
 
-Two sections in the issue body:
+The `## Blocks` body section is retired. To express the inverse direction, add a `blockedBy` edge on the dependent issue instead.
 
-```markdown
-## Depends on
-- #42 (what this needs)
-- #47
-
-## Blocks
-- #55 (what this is blocking)
-```
-
-Both are `#<number>` references so GitHub auto-links and creates bidirectional mentions. Parsing is regex `#(\d+)` under each heading.
-
-**For cross-repo:** `<owner>/<repo>#N`.
+**For cross-repo dependencies** (native `blockedBy` doesn't cross repos), a prose note in `## Depends on` is acceptable as a human reminder. The relationship will not appear in native dependency views.
 
 ## Building a dependency graph
 
-`scripts/dependency-graph.py` walks both mechanisms (native + body-convention) and builds a directed graph.
+`scripts/dependency-graph.py` reads native `blockedBy` and builds a directed graph.
 
 ```bash
 # Full summary

--- a/skills/jared/references/operations.md
+++ b/skills/jared/references/operations.md
@@ -9,7 +9,6 @@ Command reference for board operations. All examples assume values that live in 
 - `<project-number>` — integer project number (e.g., 1)
 - `<project-id>` — node ID starting with `PVT_`
 - `<status-field-id>`, `<priority-field-id>` — standard field node IDs
-- `<work-stream-field-id>` — project-specific field node ID (only if the project defines a Work Stream field)
 - `<backlog-option-id>`, `<up-next-option-id>`, etc. — single-select option IDs
 - `<issue-number>` — integer issue number
 - `<item-id>` — project item node ID (different from issue node ID)
@@ -85,9 +84,6 @@ Not started.
 
 </details>
 
-## Depends on
-(none)
-
 ## Planning
 (none)
 EOF
@@ -126,6 +122,18 @@ gh project item-edit \
   --id <item-id> \
   --field-id <status-field-id> \
   --single-select-option-id <target-status-option-id>
+```
+
+## Moving to Blocked status
+
+Use only when an item was pulled to In Progress and then hit an unanticipated stoppage. Always add a `## Blocked by` section to the issue body naming the unblock owner and the specific event being waited on. Remove the section when the item moves back to In Progress or Backlog.
+
+```bash
+gh project item-edit \
+  --project-id <project-id> \
+  --id <item-id> \
+  --field-id <status-field-id> \
+  --single-select-option-id <blocked-option-id>
 ```
 
 ## Closing an issue + verifying auto-move to Done
@@ -219,27 +227,35 @@ gh issue edit <issue-number> --repo <owner>/<repo> --add-label "bug,pipeline-qua
 gh issue edit <issue-number> --repo <owner>/<repo> --remove-label "priority: high"
 ```
 
-## Dependencies — native GitHub issue dependencies
+## Native dependency mutations
 
-GitHub issue dependencies are GA. Prefer them over body conventions.
+`addBlockedBy` / `removeBlockedBy` are the canonical mutations. Verify names via introspection if uncertain — some schema versions use `addIssueDependency` / `issueDependencies` instead.
 
 ```bash
-# Mark issue B blocked by issue A (via the GraphQL API)
+# Verify actual mutation names
+gh api graphql -f query='{ __type(name: "Mutation") { fields { name } } }' \
+  | python3 -c "import sys,json; print('\n'.join(f['name'] for f in json.load(sys.stdin)['data']['__type']['fields'] if 'block' in f['name'].lower() or 'depend' in f['name'].lower()))"
+
+# Mark issue B blocked by issue A
+BLOCKER_ID=$(gh issue view <A> --repo <owner>/<repo> --json id --jq '.id')
+DEPENDENT_ID=$(gh issue view <B> --repo <owner>/<repo> --json id --jq '.id')
 gh api graphql -f query='
   mutation($issueId: ID!, $blockingIssueId: ID!) {
     addBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
       issue { number }
     }
-  }' -F issueId=<issue-b-node-id> -F blockingIssueId=<issue-a-node-id>
+  }' -F issueId="$DEPENDENT_ID" -F blockingIssueId="$BLOCKER_ID"
+
+# Remove an edge
+gh api graphql -f query='
+  mutation($issueId: ID!, $blockingIssueId: ID!) {
+    removeBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
+      issue { number }
+    }
+  }' -F issueId="$DEPENDENT_ID" -F blockingIssueId="$BLOCKER_ID"
 ```
 
-Get issue node IDs via:
-
-```bash
-gh issue view <issue-number> --repo <owner>/<repo> --json id --jq '.id'
-```
-
-If the repo doesn't have dependencies enabled (or you need cross-repo dependencies), fall back to body conventions. See `references/dependencies.md`.
+A `blockedBy` edge does NOT automatically move an item to the Blocked column. Items move to Blocked only when actively stuck during In Progress. See `references/dependencies.md` for the conceptual model.
 
 ## Searching issues
 

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -16,10 +16,11 @@ references/board-sweep.md:
   2. WIP cap — In Progress within limit, flag stalled items
   3. Up Next queue — size and pullable-top check
   4. Aging — High-priority Backlog items >14 days old
-  5. Blocked hygiene — `blocked` label + `## Blocked by` body section
-  6. Legacy priority labels — should be stripped
-  7. Plan/spec drift — active plans citing closed issues, plans without issues
-  8. Session-note freshness — In Progress items without recent Session notes
+  5. Blocked-status hygiene — items in Blocked column have `## Blocked by` section; flag Blocked items >7 days
+  6. Native dependency hygiene — blockedBy edges pointing at closed issues
+  7. Legacy priority labels — should be stripped
+  8. Plan/spec drift — active plans citing closed issues, plans without issues
+  9. Session-note freshness — In Progress items without recent Session notes
 
 Usage:
   sweep.py                             # read config from ./docs/project-board.md
@@ -107,6 +108,41 @@ def fetch_open_issues_bulk(repo: str) -> list[dict]:
     if result.returncode != 0:
         raise RuntimeError(f"gh issue list failed: {result.stderr}")
     return json.loads(result.stdout)
+
+
+def fetch_native_blocked_by(repo: str) -> dict[int, list[dict]]:
+    """One GraphQL call to get blockedBy for all open issues. Returns {number: [{number, state}]}.
+
+    Tries 'blockedBy' first; falls back to 'issueDependencies' on schema error.
+    """
+    owner, name = repo.split("/", 1)
+    for field_name in ("blockedBy", "issueDependencies"):
+        q = (
+            "query($o:String!,$r:String!,$c:String){repository(owner:$o,name:$r){"
+            f"issues(first:100,after:$c,states:OPEN){{pageInfo{{hasNextPage endCursor}}"
+            f"nodes{{number {field_name}(first:20){{nodes{{number state}}}}}}}}}}}}"
+        )
+        result: dict[int, list[dict]] = {}
+        cursor = None
+        try:
+            while True:
+                cmd = ["gh", "api", "graphql", "-f", f"query={q}",
+                       "-F", f"o={owner}", "-F", f"r={name}"]
+                if cursor:
+                    cmd += ["-F", f"c={cursor}"]
+                p = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                data = json.loads(p.stdout)["data"]["repository"]["issues"]
+                for node in data["nodes"]:
+                    result[node["number"]] = node[field_name]["nodes"]
+                if not data["pageInfo"]["hasNextPage"]:
+                    break
+                cursor = data["pageInfo"]["endCursor"]
+            return result
+        except subprocess.CalledProcessError as e:
+            if "Field" in (e.stderr or "") and "doesn" in (e.stderr or ""):
+                continue
+            raise
+    raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
 
 
 def fetch_recent_comments(repo: str, number: int, limit: int = 5) -> list[dict]:
@@ -274,14 +310,48 @@ def check_in_progress_staleness(
     return stale
 
 
-def check_blocked_hygiene(issues_by_number: dict[int, dict]) -> list[str]:
-    findings = []
-    for n, issue in issues_by_number.items():
-        labels = [l["name"] for l in issue.get("labels", [])]
-        if "blocked" in labels:
-            body = issue.get("body", "") or ""
-            if "## Blocked by" not in body:
-                findings.append(f"#{n}: labeled `blocked` but body has no `## Blocked by` section")
+def check_blocked_status_hygiene(
+    items: list[dict],
+    issues_by_number: dict[int, dict],
+    blocked_aging_days: int,
+) -> list[str]:
+    """Items in Blocked Status must have ## Blocked by; flag ones stuck >N days."""
+    findings: list[str] = []
+    today = dt.date.today()
+    for item in items:
+        if (item.get("status") or "").strip() != "Blocked":
+            continue
+        content = item.get("content") or {}
+        n = content.get("number")
+        if not n or n not in issues_by_number:
+            continue
+        issue = issues_by_number[n]
+        body = issue.get("body") or ""
+        if "## Blocked by" not in body:
+            findings.append(f"#{n}: in Blocked status but body has no `## Blocked by` section")
+        updated = issue.get("updatedAt", "")
+        if updated:
+            updated_date = dt.datetime.fromisoformat(updated.replace("Z", "+00:00")).date()
+            age = (today - updated_date).days
+            if age > blocked_aging_days:
+                findings.append(f"#{n}: in Blocked status with no activity for {age} days")
+    return findings
+
+
+def check_native_dependencies(
+    blocked_by: dict[int, list[dict]],
+    issues_by_number: dict[int, dict],
+) -> list[str]:
+    """Flag native blockedBy edges pointing at closed issues — propose removing."""
+    findings: list[str] = []
+    for n, blockers in blocked_by.items():
+        if n not in issues_by_number:
+            continue
+        for b in blockers:
+            if b.get("state") == "CLOSED":
+                findings.append(
+                    f"#{n}: blockedBy #{b['number']} which is closed — propose removing edge"
+                )
     return findings
 
 
@@ -403,6 +473,8 @@ def main() -> int:
     )
     parser.add_argument("--wip-limit", type=int, default=3, help="In Progress cap")
     parser.add_argument("--staleness-days", type=int, default=14, help="High Backlog age threshold")
+    parser.add_argument("--blocked-aging-days", type=int, default=7,
+                        help="Flag Blocked-status items with no activity beyond this (default: 7)")
     args = parser.parse_args()
 
     # Resolve owner/project
@@ -494,12 +566,24 @@ def main() -> int:
             print(f"  {s}")
     print()
 
-    print("== Blocked hygiene ==")
+    print(f"== Blocked-status hygiene (>{args.blocked_aging_days}d) ==")
     if not issues_by_number:
         print("  (skipped — no issue data)")
     else:
-        for f in check_blocked_hygiene(issues_by_number) or ["None"]:
+        for f in check_blocked_status_hygiene(items, issues_by_number, args.blocked_aging_days) or ["None"]:
             print(f"  {f}")
+    print()
+
+    print("== Native dependency hygiene ==")
+    if not repo:
+        print("  (skipped — repo not determined)")
+    else:
+        try:
+            native_blocked_by = fetch_native_blocked_by(repo)
+            for f in check_native_dependencies(native_blocked_by, issues_by_number) or ["None"]:
+                print(f"  {f}")
+        except RuntimeError as e:
+            print(f"  (skipped — {e})")
     print()
 
     print("== Legacy 'priority: *' labels ==")


### PR DESCRIPTION
## Summary

- Companion to [findajob#98](https://github.com/brockamer/findajob/pull/98) (Phase 2A, merged 2026-04-19), which retired body-text deps and deleted the `blocked` label from the live board.
- `issue-body.md.template`: drops `## Depends on` / `## Blocks` scaffolds; HTML comment documents native dep API and `## Blocked by` usage.
- `sweep.py`: replaces `check_blocked_hygiene` (reads `blocked` label) with `check_blocked_status_hygiene` (Blocked-Status column + `## Blocked by` presence + 7-day aging) and `check_native_dependencies` (edges pointing at closed issues). Adds `--blocked-aging-days` flag.
- `references/dependencies.md`: body-conventions section replaced with "Body context (not parsed)"; `## Blocks` convention retired; dep-graph mention updated to native-only.
- `references/operations.md`: drop `<work-stream-field-id>` placeholder; add Status:Blocked move pattern; add native dep mutation examples with introspection note; fix inline filing body to match template.
- `references/board-sweep.md`: check 4 updated to Blocked-status (not blocked-label); check 9 drops body-section parsing, adds closed-edge and chain-depth findings.

## Test plan

- [x] `scripts/sweep.py` runs against findajob without errors; shows `Blocked-status hygiene` and `Native dependency hygiene` sections; old `Blocked hygiene` section is gone
- [x] Native dep check immediately found stale edges (#61, #63) pointing at closed issues — feature is live
- [ ] Filing a new issue via `/jared-file` produces a body without `## Depends on` / `## Blocks` scaffolds
- [ ] Sweep flags a manually-Blocked-status item without `## Blocked by` (manual QA)

See `docs/superpowers/plans/2026-04-19-native-dependencies-migration.md` Phase 2B (findajob repo).