### PR TITLE
fix(archive-plan): accept MERGED PRs as shipped; surface skip reasons on --plan path

### DIFF
--- a/skills/jared/assets/plan-conventions.md.template
+++ b/skills/jared/assets/plan-conventions.md.template
@@ -81,7 +81,7 @@ Both specs and plans are working artifacts. The issue is the permanent record. W
 
 ## After the plan ships
 
-When the issue(s) referenced in the `## Issue` section close:
+When the issue(s) or PR(s) referenced in the `## Issue` section ship (issues closed, PRs merged):
 
 1. **The plan archives.** Move the file to `docs/superpowers/plans/archived/YYYY-MM/` (YYYY-MM is the month the issue closed). Prepend a header:
 

--- a/skills/jared/references/board-sweep.md
+++ b/skills/jared/references/board-sweep.md
@@ -87,7 +87,7 @@ Run `scripts/dependency-graph.py --summary` for a compact view.
 Scan `docs/superpowers/plans/` (or the project's equivalent):
 
 - Active plans (not in `archived/`) with no `## Issue: #N` section — propose filing an issue or deleting the plan.
-- Active plans whose referenced issues are **all closed** — propose archiving to `archived/YYYY-MM/` with a header pointing to the issue(s).
+- Active plans whose referenced issues/PRs have **all shipped** (issues CLOSED, PRs MERGED) — propose archiving to `archived/YYYY-MM/` with a header pointing to them.
 - Active plans whose referenced issues are stale (>30 days no update) — flag for review.
 
 Same check for `specs/` directory.

--- a/skills/jared/references/plan-spec-integration.md
+++ b/skills/jared/references/plan-spec-integration.md
@@ -101,7 +101,7 @@ When you want to amend the plan with a material change to the plan itself (not a
 `references/board-sweep.md` flags:
 
 - Active plans (not in `archived/`) with no `## Issue` section.
-- Active plans whose referenced issues are all closed — propose archival.
+- Active plans whose referenced issues/PRs have all shipped (issues CLOSED, PRs MERGED) — propose archival.
 - Active plans whose referenced issues are stale (>30 days no update) — flag for review.
 - Active specs with no `## Issue(s)` section.
 - Issues with a `## Planning` section pointing to a non-existent file (plan was moved/deleted without updating).
@@ -109,7 +109,7 @@ When you want to amend the plan with a material change to the plan itself (not a
 ## The archival script
 
 ```bash
-# Archive a single plan (assumes all referenced issues are closed)
+# Archive a single plan (assumes all referenced issues/PRs have shipped: CLOSED or MERGED)
 scripts/archive-plan.py --plan docs/superpowers/plans/2026-04-17-feature.md
 
 # Batch — find all plans whose issues are closed, propose archival

--- a/skills/jared/scripts/archive-plan.py
+++ b/skills/jared/scripts/archive-plan.py
@@ -120,10 +120,13 @@ def archive_one(
     if not refs:
         return f"{plan_path}: no ## Issue section; skipping"
 
-    # Check all referenced issue states
+    # Check all referenced issue states. A plan's ## Issues section may
+    # cite an issue (CLOSED when shipped) or a PR (MERGED when shipped);
+    # both count as "shipped" for archival purposes.
+    SHIPPED = ("CLOSED", "MERGED")
     states = {n: issue_state(repo, n) for n in refs}
-    if not all(s[0] == "CLOSED" for s in states.values()):
-        open_ones = [n for n, (s, _) in states.items() if s != "CLOSED"]
+    if not all(s[0] in SHIPPED for s in states.values()):
+        open_ones = [n for n, (s, _) in states.items() if s not in SHIPPED]
         return f"{plan_path}: not all issues closed (open: {open_ones}); skipping"
 
     # Determine ship date from latest closedAt
@@ -222,7 +225,7 @@ def scan_and_archive(
 # ---------- Main ----------
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     parser.add_argument("--plan", help="Single plan file to archive")
     parser.add_argument(
@@ -238,14 +241,19 @@ def main() -> int:
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--yes", action="store_true", help="Skip confirmation prompts")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.plan and not args.scan:
         print("archive-plan: pass --plan <path> or --scan", file=sys.stderr)
         return 1
 
     if args.plan:
-        archive_one(Path(args.plan), args.repo, dry_run=args.dry_run, yes=args.yes)
+        # Surface archive_one's return value on the --plan path so a skip
+        # (e.g. "not all issues closed") is visible instead of vanishing
+        # into exit=0 — matches the --scan loop's reporting.
+        result = archive_one(Path(args.plan), args.repo, dry_run=args.dry_run, yes=args.yes)
+        if result:
+            print(result)
 
     if args.scan:
         plan_dirs = [Path(p) for p in (args.plan_dir or [])] or DEFAULT_PLAN_DIRS

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -1,0 +1,103 @@
+"""Tests for archive-plan.py — accept MERGED PRs as shipped; surface skip reasons.
+
+Regressions targeted:
+- `gh issue view <N>` returns state=MERGED for PRs. A merged PR is a valid
+  "shipped" signal; it must not look like an open blocker.
+- The --plan single-file path previously discarded archive_one's return
+  value, so a skip (e.g. "not all issues closed") produced exit=0 with
+  no output — indistinguishable from success.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests.conftest import patch_gh_by_arg
+
+REPO_ROOT = Path(__file__).parents[1]
+SCRIPT_PATH = REPO_ROOT / "skills" / "jared" / "scripts" / "archive-plan.py"
+
+
+def _import_archive_plan() -> ModuleType:
+    loader = SourceFileLoader("archive_plan", str(SCRIPT_PATH))
+    spec = importlib.util.spec_from_loader("archive_plan", loader)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+ap = _import_archive_plan()
+
+
+def _write_plan(tmp_path: Path, filename: str, refs: list[int]) -> Path:
+    refs_section = "\n".join(f"- #{n}" for n in refs)
+    plan = tmp_path / filename
+    plan.write_text(f"# A plan\n\n## Issues\n\n{refs_section}\n\n## Body\n\nStuff.\n")
+    return plan
+
+
+def test_parse_referenced_issues_extracts_refs_regardless_of_ref_type() -> None:
+    text = "# Plan\n\n## Issues\n\n- #42 (issue)\n- #98 (PR)\n\n## Body\n"
+    assert ap.parse_referenced_issues(text) == [42, 98]
+
+
+def test_archive_one_accepts_merged_pr_as_shipped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan = _write_plan(tmp_path, "2026-04-19-native-deps.md", [98])
+    patch_gh_by_arg(
+        monkeypatch,
+        {"issue view 98": '{"state": "MERGED", "closedAt": "2026-04-20T12:00:00Z"}'},
+    )
+
+    result = ap.archive_one(plan, "brockamer/findajob", dry_run=True, yes=True)
+
+    captured = capsys.readouterr()
+    assert result is not None
+    assert "skipping" not in result, f"merged PR must not be skipped; got: {result}"
+    assert "archived/2026-04" in result
+    assert "2026-04-20" in captured.out
+
+
+def test_archive_one_still_skips_open_issue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    plan = _write_plan(tmp_path, "still-open.md", [10])
+    patch_gh_by_arg(
+        monkeypatch,
+        {"issue view 10": '{"state": "OPEN", "closedAt": null}'},
+    )
+
+    result = ap.archive_one(plan, "brockamer/findajob", dry_run=True, yes=True)
+
+    assert result is not None
+    assert "skipping" in result
+    assert "[10]" in result
+
+
+def test_main_plan_path_surfaces_skip_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan = _write_plan(tmp_path, "plan.md", [11])
+    patch_gh_by_arg(
+        monkeypatch,
+        {"issue view 11": '{"state": "OPEN", "closedAt": null}'},
+    )
+
+    rc = ap.main(["--plan", str(plan), "--repo", "brockamer/findajob", "--dry-run", "--yes"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "skipping" in captured.out, (
+        f"--plan path must surface skip reasons; stdout was {captured.out!r}"
+    )


### PR DESCRIPTION
## Summary

Two related bugs in `skills/jared/scripts/archive-plan.py`, both surfaced by a real repro in `findajob`:

- **Bug 1 — state check too narrow.** `gh issue view <N> --json state` returns `"MERGED"` for PRs and `"CLOSED"` for issues. The archival check only accepted `"CLOSED"`, so a plan referencing a merged PR (e.g. `2026-04-19-native-dependencies-migration.md` → PR #98 MERGED) was skipped as if the work hadn't shipped. Fix: accept `CLOSED` or `MERGED`.
- **Bug 2 — silent exit=0 on the `--plan` path.** `main()`'s `--plan` branch discarded `archive_one`'s return value, so skip messages (`"not all issues closed; skipping"`) vanished. The `--scan` path prints skip reasons; `--plan` now matches.

Small supporting change: `main()` now accepts an `argv` parameter, matching the jared CLI pattern — lets the new tests drive `main()` in-process.

`parse_referenced_issues` is pure regex (`#(\d+)`) and treats PR and issue refs identically at the syntax level; no change needed there, but a test now pins that behavior.

## Changes

- `skills/jared/scripts/archive-plan.py` — accept `MERGED` as shipped; print `archive_one`'s return on the `--plan` path; `main(argv=None)`.
- `tests/test_archive_plan.py` — new, 4 cases.
- `skills/jared/assets/plan-conventions.md.template` — "issue(s) close" → "issue(s) or PR(s) ship".
- `skills/jared/references/plan-spec-integration.md` — grooming checks + script comment mention MERGED PRs.
- `skills/jared/references/board-sweep.md` — plan-alignment check mentions MERGED PRs.

## Test plan

- [x] `pytest` — 42 passed (4 new + 38 pre-existing)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean (new test file formatted)
- [x] `mypy` on touched files — clean; baseline unchanged at 47 errors, all pre-existing in the legacy batch scripts flagged for Phase 3 migration
- [ ] Manual smoke: from `findajob`, re-run `archive-plan.py --plan docs/superpowers/plans/2026-04-19-native-dependencies-migration.md --repo brockamer/findajob --dry-run` — should now propose archival against PR #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)