### PR TITLE
fix(jared): CLI catches typed exceptions at main(), no more raw tracebacks

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -18,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     Board,
+    BoardConfigError,
     FieldNotFound,
     GhInvocationError,
     ItemNotFound,
@@ -523,7 +524,17 @@ def _cmd_summary(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    result: int = args.func(args)
+    try:
+        result: int = args.func(args)
+    except (
+        BoardConfigError,
+        FieldNotFound,
+        OptionNotFound,
+        ItemNotFound,
+        GhInvocationError,
+    ) as e:
+        print(f"jared: {e}", file=sys.stderr)
+        return 1
     return result
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,34 @@
 import subprocess
 import sys
 from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from tests.conftest import import_cli, patch_gh, patch_gh_by_arg
 
 CLI = Path(__file__).parents[1] / "skills" / "jared" / "scripts" / "jared"
+
+
+def _write_board_with_priority(tmp_path: Path) -> Path:
+    board_md = tmp_path / "docs" / "project-board.md"
+    board_md.parent.mkdir(parents=True)
+    board_md.write_text(
+        dedent("""\
+        - Project URL: https://github.com/users/brockamer/projects/7
+        - Project number: 7
+        - Project ID: PVT_kwHO_xyz
+        - Owner: brockamer
+        - Repo: brockamer/findajob
+
+        ### Priority
+        - Field ID: PVTSSF_prio
+        - High: OPTION_high
+        - Medium: OPTION_med
+        - Low: OPTION_low
+    """)
+    )
+    return board_md
 
 
 def test_cli_help_lists_subcommands() -> None:
@@ -32,3 +58,98 @@ def test_cli_unknown_subcommand_exits_nonzero() -> None:
         text=True,
     )
     assert result.returncode != 0
+
+
+# Error-surface invariants: each of the five typed exceptions from lib.board
+# must reach the CLI as a clean one-line stderr message with a non-zero
+# exit. No Python traceback should ever leak for these known error cases —
+# that's the contract CLAUDE.md describes, and main()'s top-level except
+# backstops the per-subcommand catches so a missing catch upstream doesn't
+# regress the user-facing behavior.
+
+
+def _assert_clean_error(out: str, err: str, expected_in_stderr: str) -> None:
+    assert out == "", f"stdout should be empty on error, got: {out!r}"
+    assert "Traceback" not in err, f"stderr leaked a traceback:\n{err}"
+    assert expected_in_stderr in err, (
+        f"expected {expected_in_stderr!r} in stderr, got:\n{err}"
+    )
+
+
+def test_cli_board_config_error_is_clean(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """BoardConfigError reaches main()'s top-level handler (no subcommand catches it)."""
+    missing = tmp_path / "docs" / "project-board.md"  # does not exist
+    mod = import_cli()
+
+    rc = mod.main(["--board", str(missing), "summary"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    _assert_clean_error(captured.out, captured.err, "Missing")
+    assert "jared:" in captured.err, (
+        "main()'s top-level handler should prefix with 'jared:'"
+    )
+
+
+def test_cli_field_not_found_is_clean(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    board_md = _write_board_with_priority(tmp_path)
+    patch_gh_by_arg(
+        monkeypatch,
+        {"item-list": '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}}]}'},
+    )
+    mod = import_cli()
+
+    rc = mod.main(["--board", str(board_md), "set", "42", "Nonexistent", "Anything"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    _assert_clean_error(captured.out, captured.err, "Nonexistent")
+
+
+def test_cli_option_not_found_is_clean(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    board_md = _write_board_with_priority(tmp_path)
+    patch_gh_by_arg(
+        monkeypatch,
+        {"item-list": '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}}]}'},
+    )
+    mod = import_cli()
+
+    rc = mod.main(["--board", str(board_md), "set", "42", "Priority", "Urgent"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    _assert_clean_error(captured.out, captured.err, "Urgent")
+
+
+def test_cli_item_not_found_is_clean(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    board_md = _write_board_with_priority(tmp_path)
+    patch_gh_by_arg(monkeypatch, {"item-list": '{"items": []}'})
+    mod = import_cli()
+
+    rc = mod.main(["--board", str(board_md), "get-item", "999"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    _assert_clean_error(captured.out, captured.err, "999")
+
+
+def test_cli_gh_invocation_error_is_clean(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    board_md = _write_board_with_priority(tmp_path)
+    patch_gh(monkeypatch, stdout="", returncode=1, stderr="HTTP 500 from github")
+    mod = import_cli()
+
+    rc = mod.main(["--board", str(board_md), "summary"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    _assert_clean_error(captured.out, captured.err, "gh")


### PR DESCRIPTION
Closes #8. Follow-up: #12 (unify error-message prefix).

## Summary

`main()` in `skills/jared/scripts/jared` now catches the five typed exceptions defined in `lib/board.py` — `BoardConfigError`, `FieldNotFound`, `OptionNotFound`, `ItemNotFound`, `GhInvocationError` — prints `jared: <message>` to stderr, and exits 1. Any other exception still surfaces its traceback (we want unexpected bugs visible).

Also adds `BoardConfigError` to the CLI's import list — it was the only typed exception missing from there, which is why a missing/malformed `docs/project-board.md` produced a bare Python traceback instead of the clean message the exception already carries.

## Repro (before vs. after)

Before:

```
$ jared move 148 "In Progress"
Traceback (most recent call last):
  File ".../scripts/jared", line 531, in <module>
    sys.exit(main())
  ...
skills.jared.scripts.lib.board.BoardConfigError: Could not find required field
    matching r'Project URL:\s*(\S+)' in docs/project-board.md
```

After:

```
$ jared move 148 "In Progress"
jared: Could not find required field matching r'Project URL:\s*(\S+)' in docs/project-board.md
# exit 1
```

## What's covered by tests

Five new cases in `tests/test_cli.py`, one per typed exception, each asserting:

- exit code 1
- stdout empty
- stderr contains the exception's message
- no `Traceback` substring in stderr

`BoardConfigError` additionally asserts the `jared:` prefix — it's the only exception whose handling path reaches main()'s backstop directly (the other four are currently caught at the subcommand level first, but main()'s catch is still reached if a future subcommand forgets to wrap, which is the point of having the backstop).

## Test plan

- [x] `pytest` — 47 pass (7 in `test_cli.py`, including 5 new).
- [x] `ruff check .` — clean.
- [x] `mypy` — 47 errors, all in the legacy batch scripts (`bootstrap-project.py`, `dependency-graph.py`, `sweep.py`) and identical before my changes; none introduced by this PR.
- [x] Manual repro: `echo "no header" > /tmp/smoke/docs/project-board.md && (cd /tmp/smoke && jared move 148 "In Progress")` → clean one-liner, exit 1.

## Follow-up

Filed as #12: a few subcommands still catch typed exceptions locally and print `str(e)` without the `jared:` prefix the new top-level catch adds, so error-message formatting is now minutely inconsistent across commands. Priority Low, separate unit of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)