### PR TITLE
fix(jared): parser tolerates pre-header-block project-board.md docs

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -45,28 +45,78 @@ class Board:
         if not path.exists():
             raise BoardConfigError(f"Missing {path}. Run /jared-init to bootstrap the project.")
         text = path.read_text()
-        return cls._parse(text, source=str(path))
+        repo_fallback = _infer_repo_from_git(path.parent.parent)
+        return cls._parse(text, source=str(path), repo_fallback=repo_fallback)
 
     @classmethod
-    def _parse(cls, text: str, *, source: str) -> Board:
-        def find(pattern: str) -> str:
+    def _parse(cls, text: str, *, source: str, repo_fallback: str | None = None) -> Board:
+        # Bootstrapped-with-header docs carry machine-readable bullets for all
+        # five fields; older hand-written docs (e.g. pre-bootstrap.py) only
+        # carry the Project ID and put everything else in prose. Each field
+        # tries its bullet first, then a fallback derived from other content
+        # — so canonical docs take the fast path and legacy docs still parse.
+        def find_optional(pattern: str) -> str | None:
             m = re.search(pattern, text, re.MULTILINE)
-            if not m:
-                raise BoardConfigError(
-                    f"Could not find required field matching r'{pattern}' in {source}"
-                )
-            return m.group(1).strip()
+            return m.group(1).strip() if m else None
 
-        project_url = find(r"Project URL:\s*(\S+)")
-        project_number = int(find(r"Project number:\s*(\d+)"))
-        project_id = find(r"Project ID:\s*(\S+)")
-        owner = find(r"Owner:\s*(\S+)")
-        repo = find(r"Repo:\s*(\S+)")
+        # The URL fallback doubles as the source for project_number and owner,
+        # so resolve it first. Accepts either the bullet or the first
+        # github.com/{users,orgs}/<owner>/projects/<N> link in the doc.
+        project_url = find_optional(r"Project URL:\s*(\S+)")
+        url_match: re.Match[str] | None = None
+        if project_url is None:
+            url_match = re.search(
+                r"https?://github\.com/(?:users|orgs)/([^/\s]+)/projects/(\d+)",
+                text,
+            )
+            if url_match is not None:
+                project_url = url_match.group(0)
+        else:
+            url_match = re.search(
+                r"https?://github\.com/(?:users|orgs)/([^/\s]+)/projects/(\d+)",
+                project_url,
+            )
+
+        project_id = find_optional(r"Project ID:\s*(\S+)")
+
+        number_raw = find_optional(r"Project number:\s*(\d+)")
+        project_number_val: int | None = int(number_raw) if number_raw else None
+        if project_number_val is None and url_match is not None:
+            project_number_val = int(url_match.group(2))
+
+        owner = find_optional(r"Owner:\s*(\S+)") or (
+            url_match.group(1) if url_match else None
+        )
+
+        repo = find_optional(r"Repo:\s*(\S+)") or repo_fallback
+
+        missing: list[str] = []
+        if project_url is None:
+            missing.append("Project URL")
+        if project_id is None:
+            missing.append("Project ID")
+        if project_number_val is None:
+            missing.append("Project number")
+        if owner is None:
+            missing.append("Owner")
+        if repo is None:
+            missing.append("Repo")
+        if missing:
+            raise BoardConfigError(
+                f"{source} missing required field(s): {', '.join(missing)}. "
+                "Run /jared-init to bootstrap or patch the file."
+            )
+        # Narrow Optional types after the missing-fields check for mypy.
+        assert project_url is not None
+        assert project_id is not None
+        assert project_number_val is not None
+        assert owner is not None
+        assert repo is not None
 
         field_ids, field_options = cls._parse_field_blocks(text)
 
         return cls(
-            project_number=project_number,
+            project_number=project_number_val,
             project_id=project_id,
             owner=owner,
             repo=repo,
@@ -193,6 +243,33 @@ def run_gh_raw(args: list[str]) -> str:
             f"gh {' '.join(args)} exited {result.returncode}: {result.stderr.strip()}"
         )
     return result.stdout.strip()
+
+
+def _infer_repo_from_git(repo_root: Path) -> str | None:
+    """Return "owner/repo" from `git remote get-url origin`, or None.
+
+    Fallback used when docs/project-board.md doesn't specify a `- Repo:`
+    bullet — older bootstrap-less docs lean on this. Accepts SSH
+    (`git@github.com:owner/repo.git`) and HTTPS
+    (`https://github.com/owner/repo[.git]`) remote forms.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    m = re.search(r"github\.com[:/]([\w.-]+)/([\w.-]+?)(?:\.git)?/?$", url)
+    if not m:
+        return None
+    return f"{m.group(1)}/{m.group(2)}"
 
 
 def run_graphql(query: str, **variables: str | int | bool) -> Any:

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -284,3 +284,168 @@ def test_run_graphql_passes_query_and_vars(monkeypatch: pytest.MonkeyPatch, tmp_
     # Strings use -f; ints use -F so gh infers numeric type.
     assert "-f" in args and "owner=brockamer" in args
     assert "-F" in args and "number=7" in args
+
+
+# Legacy board-doc fallbacks: older docs (pre-bootstrap-project.py) lack
+# the machine-readable bullet block, so the parser has to infer the header
+# fields from prose + git remote. These tests pin the fallback behavior
+# so a canonical doc and a legacy doc pointing at the same project both
+# parse to identical Board values.
+
+
+_LEGACY_FINDAJOB_PROJECT_URL = "https://github.com/users/brockamer/projects/1"
+_LEGACY_FINDAJOB_DOC = dedent(f"""\
+    # Project Board — How It Works
+
+    The GitHub Projects v2 board at [findajob Pipeline]({_LEGACY_FINDAJOB_PROJECT_URL})
+    is the **single source of truth**.
+
+    ## Fields quick reference
+
+    ```
+    Project ID:          PVT_kwHOAgGulc4BUtxZ
+    Status field ID:     PVTSSF_status
+      Backlog:           opt_backlog
+    Priority field ID:   PVTSSF_prio
+      High:              opt_high
+    ```
+""")
+
+
+def test_legacy_doc_parses_via_url_prose_and_repo_fallback() -> None:
+    """URL in a markdown link, ID in a code block, no owner/repo/number bullets.
+
+    The real repro: findajob's own docs/project-board.md. All four bullet-only
+    fields are absent; everything has to come from fallbacks. Passing
+    `repo_fallback` bypasses the git-subprocess call so the test is hermetic.
+    """
+    from skills.jared.scripts.lib.board import Board
+
+    board = Board._parse(
+        _LEGACY_FINDAJOB_DOC,
+        source="<test>",
+        repo_fallback="brockamer/findajob",
+    )
+
+    assert board.project_url == _LEGACY_FINDAJOB_PROJECT_URL
+    assert board.project_number == 1
+    assert board.project_id == "PVT_kwHOAgGulc4BUtxZ"
+    assert board.owner == "brockamer"
+    assert board.repo == "brockamer/findajob"
+
+
+def test_canonical_and_legacy_docs_produce_equivalent_board() -> None:
+    """Canonical (bullets) and legacy (prose) shapes must resolve identically."""
+    from skills.jared.scripts.lib.board import Board
+
+    canonical_text = dedent("""\
+        - Project URL: https://github.com/users/brockamer/projects/1
+        - Project number: 1
+        - Project ID: PVT_kwHOAgGulc4BUtxZ
+        - Owner: brockamer
+        - Repo: brockamer/findajob
+    """)
+
+    canonical = Board._parse(canonical_text, source="<canonical>")
+    legacy = Board._parse(
+        _LEGACY_FINDAJOB_DOC,
+        source="<legacy>",
+        repo_fallback="brockamer/findajob",
+    )
+
+    assert canonical.project_url == legacy.project_url
+    assert canonical.project_number == legacy.project_number
+    assert canonical.project_id == legacy.project_id
+    assert canonical.owner == legacy.owner
+    assert canonical.repo == legacy.repo
+
+
+def test_doc_missing_url_entirely_raises_board_config_error() -> None:
+    """If neither a bullet nor a projects/<N> URL is anywhere in the text, fail."""
+    from skills.jared.scripts.lib.board import Board, BoardConfigError
+
+    text = dedent("""\
+        # Project board
+        Project ID:  PVT_kwHO_xyz
+        (no URL bullet, no markdown link, nothing to infer from)
+    """)
+
+    with pytest.raises(BoardConfigError) as exc:
+        Board._parse(text, source="docs/project-board.md", repo_fallback="brockamer/jared")
+
+    msg = str(exc.value)
+    assert "Project URL" in msg
+    assert "Project number" in msg
+    assert "Owner" in msg
+    # Friendly hint pointing at the fix path.
+    assert "/jared-init" in msg
+
+
+def test_partial_bullet_doc_prefers_bullet_over_fallback() -> None:
+    """If the bullet is present, use its value; don't let the URL-regex fallback win."""
+    from skills.jared.scripts.lib.board import Board
+
+    text = dedent("""\
+        # Header with a link pointing elsewhere:
+        See [sibling project](https://github.com/users/brockamer/projects/99)
+        for context.
+
+        - Project URL: https://github.com/users/brockamer/projects/7
+        - Project number: 7
+        - Project ID: PVT_xyz
+        - Owner: brockamer
+        - Repo: brockamer/jared
+    """)
+
+    board = Board._parse(text, source="<test>")
+
+    # Bullet URL wins; the 99 project in prose must not leak through.
+    assert board.project_number == 7
+    assert board.project_url.endswith("/projects/7")
+
+
+def test_git_remote_inference_parses_common_forms(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_infer_repo_from_git extracts owner/repo from SSH and HTTPS remote URLs."""
+    from skills.jared.scripts.lib.board import _infer_repo_from_git
+    from tests.conftest import FakeGhResult
+
+    cases = [
+        ("git@github.com:brockamer/jared.git\n", "brockamer/jared"),
+        ("https://github.com/brockamer/jared.git\n", "brockamer/jared"),
+        ("https://github.com/brockamer/jared\n", "brockamer/jared"),
+        ("ssh://git@github.com/brockamer/jared.git\n", "brockamer/jared"),
+        ("git@github.com:owner/repo-with-dashes.git\n", "owner/repo-with-dashes"),
+    ]
+
+    for remote_url, expected in cases:
+        fake = FakeGhResult(stdout=remote_url, returncode=0)
+        monkeypatch.setattr(
+            "skills.jared.scripts.lib.board.subprocess.run",
+            lambda *a, _r=fake, **kw: _r,
+        )
+        assert _infer_repo_from_git(tmp_path) == expected, remote_url
+
+
+def test_git_remote_inference_returns_none_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If `git remote get-url origin` fails or git is absent, return None."""
+    from skills.jared.scripts.lib.board import _infer_repo_from_git
+    from tests.conftest import FakeGhResult
+
+    failed = FakeGhResult(
+        stdout="", returncode=128, stderr="fatal: No such remote 'origin'"
+    )
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: failed,
+    )
+    assert _infer_repo_from_git(tmp_path) is None
+
+    def _raise_fnf(*a: object, **kw: object) -> None:
+        raise FileNotFoundError("git not on PATH")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", _raise_fnf)
+    assert _infer_repo_from_git(tmp_path) is None

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -417,6 +417,10 @@ def test_git_remote_inference_parses_common_forms(
         ("https://github.com/brockamer/jared\n", "brockamer/jared"),
         ("ssh://git@github.com/brockamer/jared.git\n", "brockamer/jared"),
         ("git@github.com:owner/repo-with-dashes.git\n", "owner/repo-with-dashes"),
+        # Repo names with dots (e.g. `claude.vim`) must not confuse the
+        # optional `.git` suffix stripper.
+        ("git@github.com:someone/claude.vim.git\n", "someone/claude.vim"),
+        ("https://github.com/someone/claude.vim\n", "someone/claude.vim"),
     ]
 
     for remote_url, expected in cases:


### PR DESCRIPTION
Closes #9. Follow-up split: #13 (jared-init detects legacy shape and offers to patch).

## Summary

`Board._parse` now treats the five header fields as bullet-first-then-fallback:

- **Project URL** — falls back to the first `github.com/{users,orgs}/<owner>/projects/<N>` link in the doc (findajob's doc carries it in a markdown link at the top).
- **Project number** — falls back to the URL's `/projects/<N>` segment.
- **Owner** — falls back to the URL's `/users|orgs/<owner>/` segment.
- **Repo** — falls back to `git remote get-url origin` from the doc's repo root.
- **Project ID** — stays required (findajob's doc has it in a fenced code block that already matches the existing regex).

If after all fallbacks a field is still missing, `BoardConfigError` names *every* missing field (not just the first) and points the user at `/jared-init`. The `main()` catch from #8 prints it cleanly with no traceback.

## Design decision

Captured on #9's body: permissive parser + optional init migration (split to #13). Rationale: the parser-only fix unblocks today's crash without asking anyone to re-run init, and it also handles docs that got hand-edited post-bootstrap, which an init-time migration alone wouldn't.

## Tests

New in `tests/test_board.py`:

- Canonical + legacy doc produce **equivalent** `Board` values pointing at the same project.
- Legacy findajob-shape doc parses successfully via fallbacks.
- Fully-malformed doc (no URL anywhere) raises with an error naming all missing fields and mentioning `/jared-init`.
- Partial-bullet doc: bullet wins over a conflicting URL elsewhere in the doc (no fallback leakage).
- `_infer_repo_from_git` parses SSH (`git@...`), HTTPS (`https://...[.git]`), and `ssh://` forms, plus dashes in repo names.
- `_infer_repo_from_git` returns None when git fails or is absent from PATH.

## Live smoke test

```
$ cd ~/Code/findajob && jared summary
Board: https://github.com/users/brockamer/projects/1

In Progress (1):
  #214 [Medium] Applied tab: 'Not Selected' status selection reverts without a reject reason

Up Next (top 3 of 2):
  #151 [Medium] De-jargon notify.py subcommand output for non-technical users
  #196 [Medium] web stats: application throughput dashboard (/stats/throughput)

Blocked (1):
  #11 Write user-facing documentation (setup, usage, tuning, troubleshooting)
```

Same command pre-fix produced the traceback in #8's repro. Findajob's `docs/project-board.md` was not touched.

## Test plan

- [x] `pytest` — 53 pass (10 existing + 6 new in `test_board.py`, and 37 unchanged elsewhere).
- [x] `ruff check .` — clean.
- [x] `mypy` — identical error count (47, all in pre-existing legacy batch scripts `bootstrap-project.py`, `dependency-graph.py`, `sweep.py`); no new errors introduced.
- [x] Live smoke test against findajob's actual `docs/project-board.md` (read-only): now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)