### PR TITLE
feat(jared-init): detect legacy project-board.md shape and offer patch

### DIFF
--- a/commands/jared-init.md
+++ b/commands/jared-init.md
@@ -16,6 +16,8 @@ Flow:
    ```
    This introspects the board's fields and emits `docs/project-board.md` with IDs filled in. For a fresh project, offers to create Status and Priority. Work Stream is optional — useful when the project has multiple distinct categories of work; skipped when it doesn't. For an existing convention doc, shows a diff.
 
+   If the existing `docs/project-board.md` predates the machine-readable bullet block (URL only in a markdown link, Project ID in a code fence, no `- Project URL:` / `- Project number:` / `- Owner:` / `- Repo:` bullets), the script enters **patch mode**: it proposes inserting just the bullet block near the top of the file, preserving all prose and custom sections verbatim. See `references/new-board.md` → "Upgrading an older project-board.md".
+
 3. **Run the migration pass** (see `references/migration.md`). Scan for and propose fixing:
 
    - **tmp handoff prompts** (`tmp/next-session-prompt-*.md`, `docs/session-prompts/*`, anything matching the pattern) — propose filing content as retro Session notes on referenced issues, or as new issues for unfiled scope, then delete the source files.

--- a/skills/jared/references/new-board.md
+++ b/skills/jared/references/new-board.md
@@ -38,6 +38,19 @@ For a genuinely blank project (just created), the script proposes creating:
 
 For existing boards with custom fields, the script preserves them and records them in the convention doc; the user can tell Jared how to interpret any non-standard fields.
 
+### Upgrading an older project-board.md
+
+Projects that were paired with Jared before the machine-readable bullet block existed have a `docs/project-board.md` that carries the project URL only in a markdown link and the Project ID in a code fence, but no `- Project URL:` / `- Project number:` / `- Owner:` / `- Repo:` bullets. The jared CLI's parser tolerates that shape via fallbacks (URL regex, git-remote inference), but the convention doc itself is better off canonical.
+
+Re-running `bootstrap-project.py` on a project whose `docs/project-board.md` is missing any of the five bullets triggers a **patch mode** instead of a full-template rewrite:
+
+1. The script reads the existing doc, detects which bullets are absent, and renders only the five-line bullet block.
+2. It writes a `<output>.new` file containing the existing doc with the bullet block inserted just after the H1 heading.
+3. It shows a unified diff so you can verify nothing else changed.
+4. You approve by `mv`-ing the `.new` over the original (or re-running with `--force`).
+
+All prose, custom sections, code fences, and links are preserved verbatim; only the bullet block is added. After the patch, the doc parses via the canonical path (no fallback code needed), which the unit tests in `tests/test_bootstrap_project_patch.py` pin.
+
 ### 3. Optional: scaffold Superpowers-style planning
 
 If the user wants plan/spec artifacts (many software projects do), offer to scaffold:

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -293,6 +293,90 @@ This file is the minimum. See the skill's references for:
 """
 
 
+# ---------- Legacy-doc detection and patching ----------
+#
+# Some projects (e.g. findajob) have a `docs/project-board.md` that predates
+# the machine-readable bullet block: the URL lives in a markdown link, the
+# Project ID is buried in a code fence, and the other three fields aren't
+# written down at all. `lib/board.py` tolerates that shape at parse-time via
+# fallbacks (see #9), but we still want the convention doc itself to be
+# canonicalized when the user opts in. Instead of rewriting the whole doc
+# (which destroys custom prose), we detect the missing bullets and offer a
+# minimal patch that inserts the bullet block near the top, preserving the
+# rest verbatim.
+
+
+HEADER_BULLETS = ["Project URL", "Project number", "Project ID", "Owner", "Repo"]
+
+
+def detect_missing_header_bullets(text: str) -> list[str]:
+    """Return the bullet-field names that aren't present as `- <field>: <val>` lines.
+
+    A bullet is "present" only when it appears as a list item with a non-empty
+    value — e.g., `- Project URL: https://github.com/users/.../projects/1`.
+    Code-fence occurrences (`Project ID:          PVT_...`) don't count
+    because the jared CLI's parser only consults the bullet form; the fallback
+    from #9 handles inference from prose but doesn't make the convention doc
+    canonical. Returned list preserves HEADER_BULLETS' order.
+    """
+    missing: list[str] = []
+    for field_name in HEADER_BULLETS:
+        pattern = rf"^\s*-\s*{re.escape(field_name)}:\s*\S+"
+        if not re.search(pattern, text, flags=re.MULTILINE):
+            missing.append(field_name)
+    return missing
+
+
+def render_header_block(
+    *, project_url: str, project_number: int, project_id: str, owner: str, repo: str
+) -> str:
+    """Render the five machine-readable bullets exactly as the full template emits."""
+    return (
+        f"- Project URL: {project_url}\n"
+        f"- Project number: {project_number}\n"
+        f"- Project ID: {project_id}\n"
+        f"- Owner: {owner}\n"
+        f"- Repo: {repo}\n"
+    )
+
+
+def find_header_insertion_point(text: str) -> int:
+    """Return a char offset where the header bullet block should land.
+
+    Heuristic: just after the first H1 heading (and a trailing blank line if
+    present). No H1? Insert at the top. This keeps the block near the file's
+    start — where the jared parser's regex scans hit it first — without
+    displacing a document's leading title or intro paragraph.
+    """
+    m = re.search(r"^#[^\n]*\n", text, flags=re.MULTILINE)
+    if m is None:
+        return 0
+    end = m.end()
+    # If the line after the H1 is blank, skip past it so we don't produce
+    # `# Title\n- Project URL: ...`.
+    if end < len(text) and text[end] == "\n":
+        end += 1
+    return end
+
+
+def patch_legacy_doc(existing: str, header_block: str) -> str:
+    """Insert `header_block` into `existing` at the computed insertion point.
+
+    The inserted content is bracketed by blank lines so the bullets never
+    butt up against surrounding prose or headings. All original prose,
+    headings, code fences, and links are preserved verbatim.
+    """
+    pos = find_header_insertion_point(existing)
+    before = existing[:pos]
+    after = existing[pos:]
+    # Trailing blank line ensures separation from whatever prose follows.
+    separator = "" if after.startswith("\n") else "\n"
+    return f"{before}{header_block}{separator}{after}"
+
+
+# ---------- Full-doc template rendering ----------
+
+
 def options_block(field: dict | None) -> str:
     if not field:
         return "  (field not present)\n"
@@ -413,6 +497,12 @@ def main() -> int:
         return 1
 
     project_id = project.get("id")
+    if not isinstance(project_id, str):
+        print(
+            f"bootstrap: project response missing 'id' field: {project}",
+            file=sys.stderr,
+        )
+        return 1
     project_title = project.get("title", f"Project {number}")
     print(f"  Project: {project_title}")
     print(f"  Fields found: {', '.join(f['name'] for f in fields)}")
@@ -488,7 +578,43 @@ def main() -> int:
         if existing == content:
             print(f"\n{output}: already up to date.")
             return 0
-        # Show diff
+        # Legacy-shape detection: if the existing doc is missing some of the
+        # machine-readable header bullets, propose a minimal patch that
+        # inserts just those bullets, preserving the rest of the file. A
+        # full-template rewrite (the else branch) would destroy custom
+        # prose a project has accumulated.
+        missing_bullets = detect_missing_header_bullets(existing)
+        if missing_bullets:
+            header = render_header_block(
+                project_url=args.url,
+                project_number=int(number),
+                project_id=project_id,
+                owner=owner,
+                repo=args.repo,
+            )
+            patched = patch_legacy_doc(existing, header)
+            print(
+                f"\n{output} is missing the jared header block "
+                f"({', '.join(missing_bullets)})."
+            )
+            print("Proposed patch — insert five machine-readable bullets near the top:\n")
+            for line in difflib.unified_diff(
+                existing.splitlines(keepends=True),
+                patched.splitlines(keepends=True),
+                fromfile=f"{output} (existing)",
+                tofile=f"{output} (patched)",
+            ):
+                sys.stdout.write(line)
+            new_path = output.with_suffix(output.suffix + ".new")
+            new_path.write_text(patched)
+            print(f"\nPatched content written to {new_path}")
+            print(f"Review, then: mv {new_path} {output}   (or re-run with --force)")
+            print(
+                "Note: the rest of your doc (prose, custom sections) is preserved verbatim; "
+                "only the bullet block is added."
+            )
+            return 0
+        # Full-template diff (existing doc has all bullets but differs from template)
         print(f"\n{output} already exists. Diff (existing → new):\n")
         for line in difflib.unified_diff(
             existing.splitlines(keepends=True),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,23 @@ def import_cli() -> ModuleType:
     return mod
 
 
+def import_bootstrap() -> ModuleType:
+    """Load `bootstrap-project.py` as a module.
+
+    The hyphen in the filename blocks a normal `import`, and the script
+    isn't on sys.path; SourceFileLoader sidesteps both so tests can exercise
+    the pure helpers (legacy-doc detection, header rendering, etc.) without
+    running the full gh-backed main().
+    """
+    path = SKILL_SCRIPTS / "bootstrap-project.py"
+    loader = SourceFileLoader("bootstrap_project", str(path))
+    spec = importlib.util.spec_from_loader("bootstrap_project", loader)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
 def write_minimal_board(tmp_path: Path) -> Path:
     """Write a minimal valid docs/project-board.md into tmp_path/docs/.
 

--- a/tests/test_bootstrap_project_patch.py
+++ b/tests/test_bootstrap_project_patch.py
@@ -1,0 +1,194 @@
+"""Tests for bootstrap-project.py's legacy-doc patch helpers.
+
+The patch path is what kicks in when `/jared-init` is run against a project
+whose `docs/project-board.md` predates the machine-readable bullet block
+(e.g. findajob's doc — URL in a markdown link, ID in a code fence). The
+goal is to insert the five bullets near the top of the file and leave the
+rest verbatim, rather than rewriting the whole doc and destroying prose.
+"""
+
+from textwrap import dedent
+
+from tests.conftest import import_bootstrap
+
+CANONICAL_DOC = dedent("""\
+    # Project Board — How It Works
+
+    - Project URL: https://github.com/users/brockamer/projects/1
+    - Project number: 1
+    - Project ID: PVT_kwHOAgGulc4BUtxZ
+    - Owner: brockamer
+    - Repo: brockamer/findajob
+
+    Some narrative below.
+""")
+
+
+LEGACY_FINDAJOB_DOC = dedent("""\
+    # Project Board — How It Works
+
+    The GitHub Projects v2 board at [findajob Pipeline](https://github.com/users/brockamer/projects/1)
+    is the **single source of truth for execution state**.
+
+    This document describes the conventions.
+
+    ## Columns (Status field)
+
+    Five columns, left to right.
+
+    ## Fields quick reference
+
+    ```
+    Project ID:          PVT_kwHOAgGulc4BUtxZ
+    Status field ID:     PVTSSF_status
+      Backlog:           opt_backlog
+    ```
+""")
+
+
+def test_detect_missing_header_bullets_canonical_returns_empty() -> None:
+    mod = import_bootstrap()
+    assert mod.detect_missing_header_bullets(CANONICAL_DOC) == []
+
+
+def test_detect_missing_header_bullets_legacy_returns_all_five() -> None:
+    mod = import_bootstrap()
+    # Findajob-shape: URL in a markdown link, ID in a code fence, no bullet
+    # form of any of the five fields. Every header bullet should register
+    # as missing, in HEADER_BULLETS order.
+    assert mod.detect_missing_header_bullets(LEGACY_FINDAJOB_DOC) == [
+        "Project URL",
+        "Project number",
+        "Project ID",
+        "Owner",
+        "Repo",
+    ]
+
+
+def test_detect_missing_header_bullets_partial() -> None:
+    mod = import_bootstrap()
+    partial = dedent("""\
+        # Project board
+
+        - Project URL: https://github.com/users/brockamer/projects/1
+        - Project number: 1
+        Some prose where Owner, Repo, and Project ID never appear as bullets.
+    """)
+    assert mod.detect_missing_header_bullets(partial) == [
+        "Project ID",
+        "Owner",
+        "Repo",
+    ]
+
+
+def test_render_header_block_exact_bytes() -> None:
+    mod = import_bootstrap()
+    out = mod.render_header_block(
+        project_url="https://github.com/users/brockamer/projects/1",
+        project_number=1,
+        project_id="PVT_kwHOAgGulc4BUtxZ",
+        owner="brockamer",
+        repo="brockamer/findajob",
+    )
+    assert out == (
+        "- Project URL: https://github.com/users/brockamer/projects/1\n"
+        "- Project number: 1\n"
+        "- Project ID: PVT_kwHOAgGulc4BUtxZ\n"
+        "- Owner: brockamer\n"
+        "- Repo: brockamer/findajob\n"
+    )
+
+
+def test_find_header_insertion_point_after_h1_and_blank_line() -> None:
+    mod = import_bootstrap()
+    text = "# Title\n\nBody paragraph.\n"
+    pos = mod.find_header_insertion_point(text)
+    # Insertion lands between the blank line and "Body paragraph."
+    assert text[:pos] == "# Title\n\n"
+
+
+def test_find_header_insertion_point_h1_without_blank_line() -> None:
+    mod = import_bootstrap()
+    text = "# Title\nBody paragraph with no blank.\n"
+    pos = mod.find_header_insertion_point(text)
+    # Just past the H1 line, even without a trailing blank.
+    assert text[:pos] == "# Title\n"
+
+
+def test_find_header_insertion_point_no_h1() -> None:
+    mod = import_bootstrap()
+    text = "No heading, just prose.\n"
+    assert mod.find_header_insertion_point(text) == 0
+
+
+def test_patch_legacy_doc_preserves_prose_verbatim() -> None:
+    mod = import_bootstrap()
+    header = mod.render_header_block(
+        project_url="https://github.com/users/brockamer/projects/1",
+        project_number=1,
+        project_id="PVT_kwHOAgGulc4BUtxZ",
+        owner="brockamer",
+        repo="brockamer/findajob",
+    )
+    patched = mod.patch_legacy_doc(LEGACY_FINDAJOB_DOC, header)
+
+    # Every line of the original prose must still be present, in order.
+    for line in LEGACY_FINDAJOB_DOC.splitlines():
+        assert line in patched, f"lost line during patch: {line!r}"
+
+    # The five bullets are now present in canonical form.
+    assert "- Project URL: https://github.com/users/brockamer/projects/1" in patched
+    assert "- Project number: 1" in patched
+    assert "- Project ID: PVT_kwHOAgGulc4BUtxZ" in patched
+    assert "- Owner: brockamer" in patched
+    assert "- Repo: brockamer/findajob" in patched
+
+    # And they land after the H1, not before it.
+    h1_pos = patched.find("# Project Board")
+    url_bullet_pos = patched.find("- Project URL:")
+    assert h1_pos < url_bullet_pos, "bullets must not precede the H1"
+
+
+def test_patched_legacy_doc_parses_via_lib_board() -> None:
+    """End-to-end: after patching, the lib/board.py parser reads all five fields
+    from the bullet block (the canonical path), not via the legacy fallbacks.
+    This is the key user-visible win — the doc is now canonical.
+    """
+    mod = import_bootstrap()
+    from skills.jared.scripts.lib.board import Board
+
+    header = mod.render_header_block(
+        project_url="https://github.com/users/brockamer/projects/1",
+        project_number=1,
+        project_id="PVT_kwHOAgGulc4BUtxZ",
+        owner="brockamer",
+        repo="brockamer/findajob",
+    )
+    patched = mod.patch_legacy_doc(LEGACY_FINDAJOB_DOC, header)
+
+    # No repo_fallback passed — the patched doc must carry all five fields
+    # in bullet form, so parsing succeeds without reaching the git-remote
+    # fallback code path.
+    board = Board._parse(patched, source="<patched>")
+    assert board.project_url == "https://github.com/users/brockamer/projects/1"
+    assert board.project_number == 1
+    assert board.project_id == "PVT_kwHOAgGulc4BUtxZ"
+    assert board.owner == "brockamer"
+    assert board.repo == "brockamer/findajob"
+
+
+def test_detect_and_patch_is_idempotent() -> None:
+    """Patching twice doesn't duplicate the bullet block — once the first
+    patch lands, the five bullets are present, so detect_missing returns []
+    and the second invocation would no-op at the script level."""
+    mod = import_bootstrap()
+    header = mod.render_header_block(
+        project_url="https://github.com/users/brockamer/projects/1",
+        project_number=1,
+        project_id="PVT_xyz",
+        owner="brockamer",
+        repo="brockamer/findajob",
+    )
+    once = mod.patch_legacy_doc(LEGACY_FINDAJOB_DOC, header)
+    # After the first patch, detection returns [] — no further insert needed.
+    assert mod.detect_missing_header_bullets(once) == []


### PR DESCRIPTION
Closes #13.

## Summary

Follow-up to #9 (parser fallbacks). The parser now tolerates pre-machine-readable-header project-board.md docs, but the convention doc itself is still better off canonical. This adds a patch path to `bootstrap-project.py` that detects missing bullets and proposes inserting just the bullet block near the top — preserving all prose and custom sections verbatim.

## Mechanism

Four pure helpers in `bootstrap-project.py`:

- `HEADER_BULLETS` — the five required bullet-field names.
- `detect_missing_header_bullets(text)` — regex-checks each bullet form; returns missing names in `HEADER_BULLETS` order. Code-fence occurrences don't count — only the bullet form does, because that's the canonical path the jared CLI parser uses.
- `render_header_block(...)` — the exact five-line bullet block.
- `find_header_insertion_point(text)` — char offset; after H1 + blank line, else 0.
- `patch_legacy_doc(existing, header)` — returns patched text with the bullet block inserted at that offset and separated from surrounding prose by a blank line.

`main()` branches when an existing output file is missing any bullets: it prints a unified diff showing just the header-block insertion, writes `<output>.new`, and prompts the user to `mv` it in place. If every bullet is present, the original full-template-diff path runs unchanged.

## Tests (tests/test_bootstrap_project_patch.py, 10 new)

- `detect` on canonical doc → `[]`.
- `detect` on findajob-shape doc → all 5 fields.
- `detect` on partial doc → only the missing subset.
- `render_header_block` exact-bytes.
- `find_header_insertion_point`: with-H1, H1-without-blank-line, no-H1.
- `patch_legacy_doc`: prose preserved verbatim, bullets land after H1.
- **End-to-end**: `Board._parse` reads patched doc via canonical path (no fallback needed).
- Idempotence: patching a canonical doc detects `[]`; no duplicate block.

`conftest.py` gains `import_bootstrap()` — same `SourceFileLoader` pattern `import_cli()` already uses — so tests can exercise the helpers despite the hyphenated filename.

## Docs

- `references/new-board.md` gains **"Upgrading an older project-board.md"** subsection.
- `commands/jared-init.md` cross-references it.

## Test plan

- [x] `pytest` — 65 pass (10 new + 55 existing).
- [x] `ruff check .` — clean.
- [x] `mypy` — 46 errors, down from 47 before this PR (isinstance-str narrowing on `project.get("id")` incidentally fixes one pre-existing error). No new errors introduced.
- [x] Manual verification: helpers tested against a freshly-seen legacy-shape fixture that matches the pattern found in pre-canonical docs; `Board._parse` succeeds on the patched output via the canonical path (no fallback code reached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)