### PR TITLE
fix(jared): drop post-create item-list verify from jared file

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -175,10 +175,6 @@ def _cmd_move(args: argparse.Namespace) -> int:
 _CLOSE_VERIFY_ATTEMPTS = 3
 _CLOSE_VERIFY_SLEEP_SECS = 1.0
 
-_FILE_VERIFY_ATTEMPTS = 3
-_FILE_VERIFY_SLEEP_SECS = 1.0
-
-
 def _poll_for_project_item(
     board: Board,
     issue_number: int,
@@ -357,38 +353,14 @@ def _cmd_file(args: argparse.Namespace) -> int:
             ]
         )
 
-    # 4. Verification: poll until the item appears on the project. The retry
-    # handles eventual-consistency lag between item-add and the next item-list
-    # read. After the helper returns, check Status separately with its own
-    # error message — null Status is a genuine regression (the level-up
-    # atomicity guarantee), not propagation lag, so it deserves a distinct
-    # alarm that names the regression rather than being quietly folded into
-    # the "could not confirm" path.
-    seen = _poll_for_project_item(
-        board,
-        issue_number,
-        predicate=lambda item: True,
-        attempts=_FILE_VERIFY_ATTEMPTS,
-        sleep_secs=_FILE_VERIFY_SLEEP_SECS,
-    )
-    if seen is None:
-        total_wait = _FILE_VERIFY_SLEEP_SECS * (_FILE_VERIFY_ATTEMPTS - 1)
-        print(
-            f"error: filed issue #{issue_number}; post-create verification could "
-            f"not confirm it on project {board.project_number} within {total_wait:g}s. "
-            f"The issue may still be on the board — inspect manually with "
-            f"`jared get-item {issue_number}`.",
-            file=sys.stderr,
-        )
-        return 2
-    if not seen.get("status"):
-        print(
-            f"error: filed issue #{issue_number} is on the project but Status "
-            f"is null. This is the regression the level-up guards against.",
-            file=sys.stderr,
-        )
-        return 2
-
+    # No post-create verification: `gh project item-add` returned the item-id
+    # without error (caught above as GhInvocationError), and each item-edit
+    # mutation either returned exit 0 (write landed server-side) or raised.
+    # Re-reading via `item-list --limit 500` to confirm was the hot path that
+    # drained the GraphQL budget and rate-limited ~11 issues into any batch
+    # filing (#4). If a real write-path regression ever surfaces, a single
+    # `node(id: <item-id>)` GraphQL query would be the cheap verify shape —
+    # one call, not a list-all scan.
     print(f"OK: filed #{issue_number} → {status}, Priority={args.priority}")
     print(f"URL: {issue_url}")
     return 0

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -103,7 +103,7 @@ def test_file_sequences_create_add_status_priority(
     captured = capsys.readouterr()
     assert rc == 0, captured.err
 
-    # Must invoke all four essentials (plus verification item-list).
+    # Must invoke the three essentials: issue create, item-add, field edits.
     assert any("issue" in c and "create" in c for c in calls)
     assert any("item-add" in c for c in calls)
 
@@ -113,8 +113,9 @@ def test_file_sequences_create_add_status_priority(
     assert "PVTSSF_prio" in joined_edits and "OPTION_high" in joined_edits
     assert "PVTSSF_status" in joined_edits and "OPTION_backlog" in joined_edits
 
-    # Verification item-list was made AFTER the edits (enforce ordering).
-    assert "item-list" in " ".join(calls[-1]), "last call should be verification item-list"
+    # No item-list in the filing path — that's the #4 regression we guard
+    # against. See test_file_makes_no_item_list_calls for the explicit pin.
+    assert not any("item-list" in " ".join(c) for c in calls)
 
 
 def test_file_with_custom_status_and_extra_field(
@@ -150,93 +151,30 @@ def test_file_with_custom_status_and_extra_field(
     assert "PVTSSF_ws" in joined_edits and "OPTION_plan" in joined_edits
 
 
-def test_file_verification_failure_exits_nonzero(
+def test_file_makes_no_item_list_calls(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # No real sleeping — the verify-retry loop now iterates a few times
-    # with a sleep between attempts.
-    monkeypatch.setattr("time.sleep", lambda _s: None)
-    board_md = _write_full_board(tmp_path)
-    body_file = tmp_path / "body.md"
-    body_file.write_text("Body.")
+    """Regression test for #4: `jared file` must not call `gh project item-list`.
 
-    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
-        joined = " ".join(args)
-        if "issue create" in joined:
-            return FakeGhResult(stdout="https://github.com/brockamer/findajob/issues/42\n")
-        if "item-add" in joined:
-            return FakeGhResult(stdout='{"id": "PVTI_new"}')
-        if "item-list" in joined:
-            # Simulated regression: issue is on the board but Status is null
-            return FakeGhResult(stdout='{"items": [{"id": "PVTI_new", "content": {"number": 42}}]}')
-        return FakeGhResult(stdout="{}")
-
-    monkeypatch.setattr(
-        "skills.jared.scripts.lib.board.subprocess.run",
-        fake_run,
-    )
-
-    mod = import_cli()
-    rc = mod.main(
-        [
-            "--board",
-            str(board_md),
-            "file",
-            "--title",
-            "Test",
-            "--body-file",
-            str(body_file),
-            "--priority",
-            "Low",
-        ]
-    )
-    captured = capsys.readouterr()
-    assert rc == 2
-    # This test simulates the specific null-Status regression (item present
-    # on the board but Status never got set) — distinct from propagation lag.
-    # The error message must name the regression, not the generic "may still
-    # be on the board" wording used for stale-read failures.
-    assert "null" in captured.err.lower()
-    assert "regression" in captured.err.lower()
-
-
-def test_file_verification_retries_through_eventual_consistency(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A stale first item-list followed by a fresh one must succeed.
-
-    Models the real flake observed when filing #9: item-add succeeded, but the
-    immediate item-list hadn't propagated yet. With retries, the second poll
-    returns the fresh state and the file-command reports success.
+    Before the fix, `_cmd_file` re-read the whole project (up to 500 items, up
+    to 3 times via poll-with-backoff) to verify the item landed and Status was
+    set. That scan drained the 5,000/hr GraphQL budget inside ~11 issues during
+    batch filing. Removing the verify entirely drops the filing cost to just
+    the writes (item-add + N field-edits); gh's exit-0 on each mutation is the
+    proof the write landed.
     """
-    sleep_calls: list[float] = []
-    monkeypatch.setattr("time.sleep", lambda s: sleep_calls.append(s))
-
     board_md = _write_full_board(tmp_path)
     body_file = tmp_path / "body.md"
     body_file.write_text("Body.")
-
-    item_list_calls = 0
+    calls: list[list[str]] = []
 
     def fake_run(args: list[str], **kw: object) -> FakeGhResult:
-        nonlocal item_list_calls
+        calls.append(args)
         joined = " ".join(args)
         if "issue create" in joined:
             return FakeGhResult(stdout="https://github.com/brockamer/findajob/issues/42\n")
         if "item-add" in joined:
             return FakeGhResult(stdout='{"id": "PVTI_new"}')
-        if "item-list" in joined:
-            item_list_calls += 1
-            if item_list_calls == 1:
-                # Stale first read — item-add hasn't propagated yet.
-                return FakeGhResult(stdout='{"items": []}')
-            # Second read: propagation caught up, Status is set.
-            return FakeGhResult(
-                stdout=(
-                    '{"items": [{"id": "PVTI_new", '
-                    '"content": {"number": 42}, "status": "Backlog"}]}'
-                )
-            )
         return FakeGhResult(stdout="{}")
 
     monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
@@ -255,61 +193,21 @@ def test_file_verification_retries_through_eventual_consistency(
             "Low",
         ]
     )
+
     captured = capsys.readouterr()
     assert rc == 0, captured.err
-    assert item_list_calls == 2, (
-        f"expected exactly 2 polls (stale, fresh); got {item_list_calls}"
+    # Nothing in the call stream should scan the project via `item-list`.
+    for c in calls:
+        joined = " ".join(c)
+        assert "item-list" not in joined, (
+            f"`jared file` should not call item-list; got: {joined!r}"
+        )
+    # Expected call ceiling: issue create + item-add + item-edit × 2 (Status,
+    # Priority) = 4. Gives AC headroom of 1 for an extra --field if present.
+    # Allow the test to flex by asserting an upper bound rather than equality,
+    # since argparse or gh version changes could introduce an extra query we
+    # haven't noticed.
+    assert len(calls) <= 5, (
+        f"`jared file` made {len(calls)} gh calls; expected ≤5. Calls:\n"
+        + "\n".join(" ".join(c) for c in calls)
     )
-    # Exactly one sleep between the two attempts.
-    assert sleep_calls == [1.0], f"expected one 1.0s sleep, got {sleep_calls}"
-    assert "OK:" in captured.out
-
-
-def test_file_verification_failure_message_is_honest_about_ambiguity(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """When all polls are stale, the error message must acknowledge the ambiguity.
-
-    The original bug (#10) shipped a misleading "could not find it on project"
-    message that implied the issue wasn't there — when in fact the file call
-    succeeded and the propagation lag was the only problem. The new message
-    must say "may still be on the board" and point the user at `jared get-item`.
-    """
-    monkeypatch.setattr("time.sleep", lambda _s: None)
-    board_md = _write_full_board(tmp_path)
-    body_file = tmp_path / "body.md"
-    body_file.write_text("Body.")
-
-    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
-        joined = " ".join(args)
-        if "issue create" in joined:
-            return FakeGhResult(stdout="https://github.com/brockamer/findajob/issues/42\n")
-        if "item-add" in joined:
-            return FakeGhResult(stdout='{"id": "PVTI_new"}')
-        if "item-list" in joined:
-            # Never propagates within the retry window.
-            return FakeGhResult(stdout='{"items": []}')
-        return FakeGhResult(stdout="{}")
-
-    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
-
-    mod = import_cli()
-    rc = mod.main(
-        [
-            "--board",
-            str(board_md),
-            "file",
-            "--title",
-            "Test",
-            "--body-file",
-            str(body_file),
-            "--priority",
-            "Low",
-        ]
-    )
-    captured = capsys.readouterr()
-    assert rc == 2
-    assert "may still be on the board" in captured.err
-    assert "jared get-item 42" in captured.err
-    # The old misleading "could not find it on project" phrasing must be gone.
-    assert "could not find it" not in captured.err


### PR DESCRIPTION
Closes #4.

## Summary

`_cmd_file`'s post-create verification fetched the full project item-list (up to 500 rows, up to 3 times via PR #15's poll-with-backoff) as proof that `item-add` and the Status/Priority edits took effect. That scan is the hot path the rate-limit bug is about — ~11 sequential `jared file` invocations drain the 5,000/hr GraphQL budget before the twelfth can run. This session has hit the rate limit several times while filing its own issues; #4 was itself inflight as we ran into the ceiling.

Fix: remove the verify entirely. `gh project item-add --format json` already returns the item-id without error (would raise `GhInvocationError` otherwise), and each `item-edit` mutation either returns exit 0 (write landed server-side) or raises. Re-reading via `item-list` to confirm was defending against a theoretical "gh exit-0 but server didn't apply" case that doesn't show up in practice. The eventual-consistency flakes we did observe were all on the read-back side, not the write path.

## Cost delta

| | Before | After |
|---|---|---|
| item-add | 1 call | 1 call |
| item-edit (Status, Priority) | 2 calls | 2 calls |
| item-edit (extras via `--field`) | N calls | N calls |
| item-list verify (up to 3 retries × 500 rows) | 1–3 calls | **0 calls** |
| **Typical total per filed issue** | ~6 calls | ~3 calls |

Under #4's ≤5-point ceiling, with headroom for one or two `--field` extras.

## Future belt-and-suspenders

If a real write-path regression ever surfaces, a single GraphQL `node(id: <item-id>)` query is the right shape for a cheap verify — one targeted call, not a list-all-500 scan. Noted in the code comment where the verify used to be. Not doing it now; there's no evidence it's needed.

## Tests

**New** — `test_file_makes_no_item_list_calls`: asserts no call in the filing path contains `"item-list"` and that total gh calls are ≤5. This is the direct regression pin.

**Updated** — `test_file_sequences_create_add_status_priority`: no longer expects `item-list` as the last call; now explicitly asserts `item-list` is *absent* from the call stream.

**Removed** — three tests from PR #15:
- `test_file_verification_retries_through_eventual_consistency`
- `test_file_verification_failure_message_is_honest_about_ambiguity`
- `test_file_verification_failure_exits_nonzero`

All three exercised the verify retry loop / ambiguity error / null-Status alarm, which this PR deletes.

Also removes `_FILE_VERIFY_ATTEMPTS` / `_FILE_VERIFY_SLEEP_SECS` constants. `_poll_for_project_item` itself stays — `_cmd_close` still uses it, and the close-auto-move path is genuinely eventually-consistent on the read side (the board workflow has real propagation latency).

## Test plan

- [x] `pytest` — 68 pass (was 70 pre-PR; 70 − 3 deleted + 1 new = 68).
- [x] `ruff check .` — clean.
- [x] `mypy` — 47 errors, identical count to pre-PR. All pre-existing in legacy batch scripts.
- [ ] Live batch-file smoke test (20+ filings without rate-limiting) — skipped because running it now would burn the very budget we're restoring. The unit test pins the behavior; the user can run the repro script from #4's body after merge to confirm end-to-end.

## Follow-up

Version bump — the `jared file` cost drop is user-facing; this should ship as part of the `0.2.0 → 0.3.0` release I mentioned alongside #20's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)