### PR TITLE
release(jared): v0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.2.0"
+version = "0.3.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Version bump 0.2.0 → 0.3.0. Makes `/plugin update jared` in other Claude Code sessions actually pull this session's work.

## Headlines since v0.2.0

### Parser + board-doc (#9, #13, #14, #17)
- `lib/board.py` tolerates pre-header-block `project-board.md`: URL from prose, number from URL, owner from URL, repo from git remote. Project ID stays required. Makes findajob-shape docs parseable without needing a full rewrite.
- `bootstrap-project.py` detects legacy shape and proposes a minimal patch that inserts the five bullet lines near the top, preserving all prose and custom sections.

### Error surface (#8, #11, #12, #16)
- `main()` in the jared CLI catches `BoardConfigError` / `FieldNotFound` / `OptionNotFound` / `ItemNotFound` / `GhInvocationError` uniformly and prints `jared: <msg>` to stderr — no raw tracebacks for known errors.
- Removed redundant per-subcommand catches so error format is consistent across all commands.

### `jared file` (#4, #10, #15, #21)
- `_cmd_file`'s post-create verify used to fetch the full project item-list, up to 3 retries, on every single filing. That scan drained the 5,000/hr GraphQL budget inside ~11 sequential calls (the symptom #4 describes).
- PR #15 added a retry-with-backoff to handle eventual-consistency flakes. PR #21 removed the verify entirely — trust gh mutation exit codes for the write-path guarantee. Filing cost dropped from ~6 GraphQL points to ~3 per issue.
- Follow-up #22 filed for the symmetric pattern in `_cmd_close`.

### Sweep / groom (#18, #20)
- `sweep.py`'s `check_closed_not_done` now returns structured entries; a render-site formatter adds `Propose: jared set <N> Status Done` per stuck item. `/jared-groom` can propose concrete fixes alongside its report.
- `bootstrap-project.py` queries the project's workflows at init and warns loudly when "Item closed → Done" is disabled — the root cause behind stuck-in-pre-close-column drift.

### Docs (#7, #19)
- README rewrite with pain-point framing, commands table, visible board model.
- `docs/jared-social-image.png` committed. Activate via github.com/brockamer/jared/settings#repo-social-preview (separate manual upload).
- `references/new-board.md` gained "Upgrading an older project-board.md" and "Auto-move workflow dependency" subsections.

## Test plan

- [x] `pytest` — 68 pass.
- [x] `ruff check .` — clean.
- [x] `mypy` — 47 errors, all pre-existing in legacy batch scripts.
- [x] `.claude-plugin/plugin.json` and `pyproject.toml` both bumped in lockstep.

## After merge

1. `git tag v0.3.0 && git push origin v0.3.0` — I'll run this once the PR lands.
2. Upload `docs/jared-social-image.png` to the GitHub social-preview slot (web UI only; no API).
3. In other Claude Code sessions that use jared: `/plugin update jared && /reload-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)