### PR TITLE
fix(jared): comment uses run_gh_raw; print returned URL (#24)

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -420,7 +420,8 @@ def _cmd_comment(args: argparse.Namespace) -> int:
         tf.write(body)
         tmp_path = tf.name
     try:
-        board.run_gh(
+        # gh issue comment prints the new comment's URL as plain text, not JSON.
+        comment_url = board.run_gh_raw(
             [
                 "issue",
                 "comment",
@@ -433,7 +434,7 @@ def _cmd_comment(args: argparse.Namespace) -> int:
         )
     finally:
         Path(tmp_path).unlink(missing_ok=True)
-    print(f"OK: commented on #{args.issue_number}")
+    print(f"OK: commented on #{args.issue_number} ({comment_url})")
     return 0
 
 

--- a/tests/test_cmd_comment.py
+++ b/tests/test_cmd_comment.py
@@ -87,3 +87,43 @@ def test_comment_from_stdin(
     captured = capsys.readouterr()
     assert rc == 0, captured.err
     assert bodies == ["comment from stdin"]
+
+
+def test_comment_handles_plain_text_url_response(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """gh issue comment returns a plain-text URL on stdout, not JSON.
+
+    Regression for #24: _cmd_comment used the JSON-parsing wrapper and every
+    successful invocation printed `gh returned non-JSON output: <url>` to
+    stderr, making the user think the post failed.
+    """
+    board_md = write_minimal_board(tmp_path)
+    body_file = tmp_path / "note.md"
+    body_file.write_text("hello")
+
+    url = "https://github.com/brockamer/findajob/issues/42#issuecomment-4312200024"
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        return FakeGhResult(stdout=url)
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "comment",
+            "42",
+            "--body-file",
+            str(body_file),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.err == ""
+    assert "OK:" in captured.out
+    assert "42" in captured.out
+    assert url in captured.out


### PR DESCRIPTION
## Summary

- `jared comment` was calling the JSON-parsing `run_gh` wrapper, but `gh issue comment` returns the new comment's URL as plain text. Every successful post raised `GhInvocationError` at JSON parse time and surfaced as `jared: gh returned non-JSON output: <url>` on stderr — the comment landed correctly but the user saw an error.
- Switch `_cmd_comment` to `run_gh_raw` (matches `_cmd_file`, which handles the same plain-text-URL shape from `gh issue create`).
- Include the returned URL in the success line: `OK: commented on #42 (https://github.com/.../issuecomment-...)`.

## Test plan

- [x] `pytest tests/test_cmd_comment.py` — 3 pass (existing 2 + new regression)
- [x] `pytest` — full suite, 69 pass
- [x] `mypy` on touched files — clean (pre-existing errors in legacy scripts only)

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)