### PR TITLE
fix(jared): close poll uses single-item GraphQL, drops item-list scan (#22)

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -175,6 +175,51 @@ def _cmd_move(args: argparse.Namespace) -> int:
 _CLOSE_VERIFY_ATTEMPTS = 3
 _CLOSE_VERIFY_SLEEP_SECS = 1.0
 
+_POLL_ITEM_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      projectItems(first: 10) {
+        nodes {
+          id
+          project { number }
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _extract_item_for_project(
+    data: Any, *, project_number: int
+) -> dict[str, Any] | None:
+    """Pick the projectItems node belonging to `project_number` and flatten
+    its fieldValues into {"id", "status", ...}. Status comes from the
+    single-select field literally named "Status"."""
+    issue = ((data or {}).get("data") or {}).get("repository", {}).get("issue")
+    if not issue:
+        return None
+    for node in issue.get("projectItems", {}).get("nodes", []):
+        if (node.get("project") or {}).get("number") != project_number:
+            continue
+        flat: dict[str, Any] = {"id": node.get("id")}
+        for fv in (node.get("fieldValues") or {}).get("nodes", []):
+            field_name = (fv.get("field") or {}).get("name")
+            if field_name:
+                flat[field_name.lower()] = fv.get("name")
+        return flat
+    return None
+
+
 def _poll_for_project_item(
     board: Board,
     issue_number: int,
@@ -183,38 +228,27 @@ def _poll_for_project_item(
     attempts: int,
     sleep_secs: float,
 ) -> dict[str, Any] | None:
-    """Poll `gh project item-list` until predicate(item) is truthy or attempts run out.
+    """Poll a single-item GraphQL query until predicate(item) holds or
+    attempts run out.
 
-    GitHub's project operations are eventually-consistent: item-add, auto-move
-    on close, and status writes can all lag the next read by hundreds of
-    milliseconds. Both _cmd_close and _cmd_file need the same "poll-with-sleep
-    until the mirror reflects reality" pattern — sharing it here keeps the
-    timing shape identical and gives the next verify-site a ready reference.
+    GitHub's project operations are eventually-consistent: auto-move on close
+    can lag the next read by hundreds of milliseconds. Fix for #22: query only
+    the issue's projectItems (scoped to this board's project_number) instead
+    of scanning `gh project item-list --limit 500`, which rate-limits under
+    close sprees.
 
-    Sleep only happens *between* attempts, not after the final one.
+    Returns a dict with at least `id` and `status` keys (other single-select
+    fields flattened by lowercased name), or None if no match passes the
+    predicate within `attempts` tries. Sleep only happens *between* attempts.
     """
     for i in range(attempts):
-        data = board.run_gh(
-            [
-                "project",
-                "item-list",
-                str(board.project_number),
-                "--owner",
-                board.owner,
-                "--limit",
-                "500",
-                "--format",
-                "json",
-            ]
+        data = board.run_graphql(
+            _POLL_ITEM_QUERY,
+            owner=board.owner,
+            repo=board.repo.split("/", 1)[1],
+            number=issue_number,
         )
-        match: dict[str, Any] | None = next(
-            (
-                item
-                for item in data.get("items", [])
-                if (item.get("content") or {}).get("number") == issue_number
-            ),
-            None,
-        )
+        match = _extract_item_for_project(data, project_number=board.project_number)
         if match is not None and predicate(match):
             return match
         if i < attempts - 1:

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from textwrap import dedent
 
@@ -27,6 +28,38 @@ def _write_board_with_status(tmp_path: Path) -> Path:
     return board_md
 
 
+def _graphql_item_response(
+    *, project_number: int, status: str, item_id: str = "PVTI_aaa"
+) -> str:
+    """Build a repository.issue(number).projectItems graphql payload."""
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "id": item_id,
+                                    "project": {"number": project_number},
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "name": status,
+                                                "field": {"name": "Status"},
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+
 def test_close_succeeds_when_board_auto_moves(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -35,9 +68,7 @@ def test_close_succeeds_when_board_auto_moves(
         monkeypatch,
         {
             "issue close": "",
-            "item-list": (
-                '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}, "status": "Done"}]}'
-            ),
+            "api graphql": _graphql_item_response(project_number=7, status="Done"),
         },
     )
 
@@ -48,6 +79,8 @@ def test_close_succeeds_when_board_auto_moves(
     assert rc == 0, captured.err
     # Must have invoked gh issue close
     assert any("issue" in c and "close" in c for c in calls)
+    # Polling must use graphql, NOT the wide item-list scan that #22 fixes.
+    assert not any("item-list" in " ".join(c) for c in calls)
     # Must NOT have invoked item-edit — auto-move handled it
     assert not any("item-edit" in c for c in calls)
     assert "#42" in captured.out
@@ -60,13 +93,17 @@ def test_close_falls_back_to_explicit_move_when_auto_move_lags(
     monkeypatch.setattr("time.sleep", lambda _s: None)
 
     board_md = _write_board_with_status(tmp_path)
-    # Board never auto-moves to Done.
+    # Board never auto-moves to Done — graphql keeps returning Backlog.
+    # _cmd_set fallback then uses item-list (find_item_id) + item-edit; that
+    # path is out of scope for #22.
     calls = patch_gh_by_arg(
         monkeypatch,
         {
             "issue close": "",
+            "api graphql": _graphql_item_response(project_number=7, status="Backlog"),
             "item-list": (
-                '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}, "status": "Backlog"}]}'
+                '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}, '
+                '"status": "Backlog"}]}'
             ),
             "item-edit": "{}",
         },
@@ -77,9 +114,83 @@ def test_close_falls_back_to_explicit_move_when_auto_move_lags(
 
     captured = capsys.readouterr()
     assert rc == 0, captured.err
+    # Poll retried 3 times then fell back — 3 graphql calls for the polling.
+    graphql_calls = [c for c in calls if "graphql" in " ".join(c)]
+    assert len(graphql_calls) == 3
     # Fallback path: explicit item-edit to Status=Done
     edit = next((c for c in calls if "item-edit" in c), None)
     assert edit is not None, "expected explicit item-edit fallback"
     joined = " ".join(edit)
     assert "PVTSSF_status" in joined
     assert "OPTION_done" in joined
+
+
+def test_close_filters_graphql_to_current_project(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue may belong to multiple ProjectV2 items; only the one whose
+    project.number matches the board counts as the auto-move target."""
+    board_md = _write_board_with_status(tmp_path)
+    # Same issue attached to two projects: Done on project 99 (unrelated),
+    # Backlog on project 7 (our board). Fixture must return Backlog.
+    multi_project_response = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "id": "PVTI_other",
+                                    "project": {"number": 99},
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "name": "Done",
+                                                "field": {"name": "Status"},
+                                            }
+                                        ]
+                                    },
+                                },
+                                {
+                                    "id": "PVTI_ours",
+                                    "project": {"number": 7},
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "name": "Backlog",
+                                                "field": {"name": "Status"},
+                                            }
+                                        ]
+                                    },
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    )
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    calls = patch_gh_by_arg(
+        monkeypatch,
+        {
+            "issue close": "",
+            "api graphql": multi_project_response,
+            "item-list": (
+                '{"items": [{"id": "PVTI_ours", "content": {"number": 42}, '
+                '"status": "Backlog"}]}'
+            ),
+            "item-edit": "{}",
+        },
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42"])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    # Must have fallen back — project 99's Done doesn't satisfy the predicate
+    # because we scope to project_number=7.
+    assert any("item-edit" in c for c in calls)


### PR DESCRIPTION
## Summary

- `_cmd_close` polled `gh project item-list --limit 500` up to 3x per close to confirm GitHub's auto-move-to-Done workflow. Same rate-limit ceiling as #4, one function over. Unlike #4 the verify is load-bearing (auto-move is eventually consistent), so we replace the query instead of dropping it.
- New polling query: `repository.issue(number).projectItems(first: 10)` → flatten `fieldValues` into `{id, status, ...}`, filtered to the current board's `project_number`. Keeps the 3-attempt / 1s-between retry policy.
- Cost per close drops from up to 3× full-project scans to up to 3 single-item GraphQL calls.
- Scope: `_cmd_close` only. `_cmd_file`'s verify was already dropped in #4. `find_item_id` (used by the fallback `Status=Done` set) still does `item-list`; out of scope for #22.

## Test plan

- [x] `pytest tests/test_cmd_close.py` — 3 pass (2 rewritten + 1 new for multi-project filtering)
- [x] `pytest` — full suite, 69 pass
- [x] `mypy` on touched files — clean
- [ ] Live smoke: close 50 issues in sequence without rate-limiting (AC item; before closing #22, not before merging)

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)