### PR TITLE
feat(jared-init): link Projects v2 board to repo on bootstrap (#25)

### DIFF
--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -103,6 +103,54 @@ def fetch_workflows(owner_type: str, owner: str, number: str) -> list[dict]:
     return nodes if isinstance(nodes, list) else []
 
 
+def link_project_to_repo(project_id: str, repo_slug: str) -> tuple[bool, str]:
+    """Link a ProjectV2 to a repository so it appears under <repo> → Projects tab.
+
+    GitHub's `linkProjectV2ToRepository` mutation is idempotent — re-running
+    against an already-linked pair returns the same node and no error. Per
+    #25, callers should always attempt the link when both IDs are in scope
+    and treat failures as warnings (permissions, transient network), not
+    aborts.
+
+    Returns (ok, message). ok=True on successful link (including no-op
+    re-link). ok=False with a diagnostic when the repo can't be resolved or
+    the mutation errors.
+    """
+    if "/" not in repo_slug:
+        return False, f"invalid repo slug (expected owner/repo): {repo_slug}"
+    owner, name = repo_slug.split("/", 1)
+
+    try:
+        repo_data = board_run_graphql(
+            "query($owner: String!, $name: String!) {"
+            " repository(owner: $owner, name: $name) { id }"
+            " }",
+            owner=owner,
+            name=name,
+        )
+    except GhInvocationError as e:
+        return False, f"could not resolve repo id for {repo_slug}: {e}"
+
+    repo_node = ((repo_data or {}).get("data") or {}).get("repository")
+    repo_id = (repo_node or {}).get("id")
+    if not isinstance(repo_id, str):
+        return False, f"repo id not found for {repo_slug}"
+
+    mutation = (
+        "mutation($projectId: ID!, $repositoryId: ID!) {"
+        " linkProjectV2ToRepository("
+        " input: {projectId: $projectId, repositoryId: $repositoryId}"
+        " ) { repository { id } }"
+        " }"
+    )
+    try:
+        board_run_graphql(mutation, projectId=project_id, repositoryId=repo_id)
+    except GhInvocationError as e:
+        return False, str(e)
+
+    return True, f"linked project to {repo_slug}"
+
+
 def find_single_select_field(fields: list[dict], name: str) -> dict | None:
     """Case-insensitive, space-insensitive match on field name."""
     target = name.lower().replace(" ", "")
@@ -561,6 +609,17 @@ def main() -> int:
     project_title = project.get("title", f"Project {number}")
     print(f"  Project: {project_title}")
     print(f"  Fields found: {', '.join(f['name'] for f in fields)}")
+
+    # Link the project to the repo so it appears under <repo> → Projects tab.
+    # Idempotent on GitHub's side; warn but don't abort on failure (#25).
+    ok, link_msg = link_project_to_repo(project_id, args.repo)
+    if ok:
+        print(f"  Linked project #{number} to {args.repo}")
+    else:
+        print(
+            f"  WARNING: could not link project to {args.repo}: {link_msg}",
+            file=sys.stderr,
+        )
 
     # Identify or create standard fields
     status = find_single_select_field(fields, "Status")

--- a/tests/test_link_project_to_repo.py
+++ b/tests/test_link_project_to_repo.py
@@ -1,0 +1,94 @@
+"""Tests for bootstrap-project.py's link_project_to_repo helper (#25)."""
+
+import json
+
+import pytest
+
+from tests.conftest import FakeGhResult, import_bootstrap
+
+
+def _patch_graphql_responses(
+    monkeypatch: pytest.MonkeyPatch, responses: dict[str, str]
+) -> list[list[str]]:
+    """Route `gh api graphql` calls by substring match on the serialized
+    query payload. Responses are raw JSON strings.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        for substring, stdout in responses.items():
+            if substring in joined:
+                return FakeGhResult(stdout=stdout)
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        fake_run,
+    )
+    return calls
+
+
+def test_link_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = import_bootstrap()
+    calls = _patch_graphql_responses(
+        monkeypatch,
+        {
+            "repository(owner:": json.dumps(
+                {"data": {"repository": {"id": "R_kgDOabc"}}}
+            ),
+            "linkProjectV2ToRepository": json.dumps(
+                {"data": {"linkProjectV2ToRepository": {"repository": {"id": "R_kgDOabc"}}}}
+            ),
+        },
+    )
+
+    ok, msg = mod.link_project_to_repo("PVT_test", "brockamer/trailscribe")
+
+    assert ok is True, msg
+    assert "brockamer/trailscribe" in msg
+    # Must have made both the repo-id lookup and the mutation.
+    assert any("repository(owner:" in " ".join(c) for c in calls)
+    assert any("linkProjectV2ToRepository" in " ".join(c) for c in calls)
+
+
+def test_link_invalid_slug_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = import_bootstrap()
+    calls = _patch_graphql_responses(monkeypatch, {})
+
+    ok, msg = mod.link_project_to_repo("PVT_test", "just-a-repo")
+
+    assert ok is False
+    assert "invalid" in msg.lower() or "slug" in msg.lower()
+    # No gh calls on malformed input.
+    assert calls == []
+
+
+def test_link_repo_id_missing_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = import_bootstrap()
+    _patch_graphql_responses(
+        monkeypatch,
+        {"repository(owner:": json.dumps({"data": {"repository": None}})},
+    )
+
+    ok, msg = mod.link_project_to_repo("PVT_test", "brockamer/nonexistent")
+
+    assert ok is False
+
+
+def test_link_gh_error_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Permission / already-linked / network errors should return (False, msg),
+    not propagate — #25 requires warn-don't-abort behavior."""
+    mod = import_bootstrap()
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        # Simulate gh api failure (nonzero exit).
+        return FakeGhResult(stdout="", returncode=1, stderr="HTTP 403")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    ok, msg = mod.link_project_to_repo("PVT_test", "brockamer/restricted")
+
+    assert ok is False
+    assert msg  # Some diagnostic, not empty.


### PR DESCRIPTION
## Summary

- After `jared-init`, the bootstrapped project doesn't appear under `<repo>` → Projects tab. Projects v2 are owned by the user/org, not the repo; adding issues doesn't create the back-link.
- Fix: during `bootstrap-project.py`, after both project id and repo slug are known, resolve the repo id and call `linkProjectV2ToRepository`. Mutation is idempotent on GitHub's side — safe to run on every bootstrap invocation.
- Failure mode: print WARNING to stderr, don't abort init. Link is independent of the rest of the flow.

## Test plan

- [x] `pytest tests/test_link_project_to_repo.py` — 4 pass (happy + 3 failure shapes)
- [x] `pytest` — full suite, 72 pass
- [x] `mypy` on touched files — no new errors (bootstrap-project.py has pre-existing type-arg warnings; my additions are clean)
- [ ] Live verification: re-run `bootstrap-project.py` against `brockamer/trailscribe`, confirm the project now appears under the repo's Projects tab (deferred to reviewer — idempotent re-run)

Closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)