### PR TITLE
release(jared): v0.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.3.0"
+version = "0.3.1"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

v0.3.1 bundles three targeted fixes since v0.3.0:

- **#24 — `jared comment` JSON parse error on success.** Switched `_cmd_comment` to `run_gh_raw`; success line now includes the returned comment URL.
- **#22 — `jared close` poll rate-limit risk.** Replaced the `item-list --limit 500` scan in `_poll_for_project_item` with a single-item GraphQL query scoped to the current board. Cost per close drops from up to 3× full-project scans to up to 3 single-item calls. Retry policy unchanged.
- **#25 — `jared-init` didn't link project to repo.** `bootstrap-project.py` now calls `linkProjectV2ToRepository` after both IDs are known. Idempotent; warns on failure instead of aborting.

## Test plan

- [x] `pytest` — 73 unit tests pass (up from 69; 2 rewritten + 5 new)
- [x] `mypy` on touched files — clean
- [x] Board: all three issues auto-closed and moved to Done on merge
- [ ] Live smoke for #22 (50-close sequence without rate-limiting) — deferred per that issue's AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)