### PR TITLE
fix(jared-init): align bootstrap defaults with Blocked-is-a-column invariant

### DIFF
--- a/docs/superpowers/plans/archived/2026-04/2026-04-22-jared-levelup.md
+++ b/docs/superpowers/plans/archived/2026-04/2026-04-22-jared-levelup.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #4, #8, #9, #10, #12, #13, #18, #22, #24, #25 on 2026-04-24. Final decisions captured in issue body.**
+---
+
 # Jared Level-Up Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -11,6 +15,19 @@
 **Spec:** `docs/superpowers/specs/2026-04-22-jared-levelup-design.md` — read it first. This plan implements that spec phase-by-phase.
 
 **Convention:** Scripts invoked from skill/command context use `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared <subcommand>`. Never hardcode `~/.claude/skills/...` paths.
+
+## Issue(s)
+
+- #4 — jared file: GraphQL rate limit during batch filing
+- #8 — jared CLI: leaked tracebacks from typed exceptions
+- #9 — jared parser: pre-header-block project-board.md rejection
+- #10 — jared file: single-shot verification vs. eventual-consistency lag
+- #12 — jared CLI: inconsistent error-message prefix
+- #13 — jared-init: legacy project-board.md detect + patch
+- #18 — Closed issues stuck in pre-close Status column
+- #22 — jared close: poll retry + symmetric rate-limit handling
+- #24 — jared comment: parses gh plain-text URL response as JSON
+- #25 — jared-init: link Projects v2 board to repo
 
 ---
 

--- a/docs/superpowers/specs/archived/2026-04/2026-04-22-jared-levelup-design.md
+++ b/docs/superpowers/specs/archived/2026-04/2026-04-22-jared-levelup-design.md
@@ -1,8 +1,25 @@
+---
+**Shipped in #4, #8, #9, #10, #12, #13, #18, #22, #24, #25 on 2026-04-24. Final decisions captured in issue body.**
+---
+
 # Jared Level-Up — Design Spec
 
 **Date:** 2026-04-22
 **Author:** Daniel Brock (with Claude Opus 4.7)
 **Status:** Approved for implementation planning
+
+## Issue(s)
+
+- #4 — jared file: GraphQL rate limit during batch filing
+- #8 — jared CLI: leaked tracebacks from typed exceptions
+- #9 — jared parser: pre-header-block project-board.md rejection
+- #10 — jared file: single-shot verification vs. eventual-consistency lag
+- #12 — jared CLI: inconsistent error-message prefix
+- #13 — jared-init: legacy project-board.md detect + patch
+- #18 — Closed issues stuck in pre-close Status column
+- #22 — jared close: poll retry + symmetric rate-limit handling
+- #24 — jared comment: parses gh plain-text URL response as JSON
+- #25 — jared-init: link Projects v2 board to repo
 
 ## Summary
 

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -40,7 +40,7 @@ from lib.board import (
 )
 
 STANDARD_FIELDS = {
-    "Status": ["Backlog", "Up Next", "In Progress", "Done"],
+    "Status": ["Backlog", "Up Next", "In Progress", "Blocked", "Done"],
     "Priority": ["High", "Medium", "Low"],
     "Work Stream": [],  # User-defined
 }
@@ -290,7 +290,7 @@ file directly.
 
 - In Progress stays small. More than ~{wip_limit} items means focus is scattered.
 - Up Next is ordered — top item is what gets worked next. Priority field breaks ties.
-- Nothing in In Progress without Priority and Work Stream set.
+- {in_progress_rule}
 - When an issue closes, it moves to Done automatically.
 
 ## Priority field
@@ -305,12 +305,7 @@ file directly.
 
 ## Work Stream field
 
-{work_stream_table}
-
-**Rules:**
-
-- Work streams are project-specific and describe the kind of work, not its priority or status.
-- Every open issue should belong to exactly one work stream.
+{work_stream_section}
 
 ## Labels
 
@@ -325,7 +320,9 @@ Suggested defaults (create via `gh label create` as needed):
 | `enhancement` | New capability |
 | `refactor` | Restructuring without behavior change |
 | `documentation` | Docs-only change |
-| `blocked` | Waiting on a dependency (must pair with `## Blocked by` in body) |
+
+**Do not** create a `blocked` label. Blocked is a Status column on this
+board, not a label — see Status above.
 
 Project-specific scope labels (e.g., `infra`, `frontend`, `customer-facing`) belong here
 too — add them as needed.
@@ -334,14 +331,9 @@ too — add them as needed.
 
 When a new issue is filed:
 
-1. **Auto-add to board.** `gh issue create` does not auto-add; use
-   `gh project item-add {project_number} --owner {owner} --url <issue-url>`.
-2. **Set Priority** — High / Medium / Low.
-3. **Set Work Stream** — per the fields above.
-4. **Leave Status as Backlog** unless explicitly scheduling.
-5. **Apply labels** for issue type and scope.
+{triage_checklist}
 
-An issue without Priority and Work Stream sorts to the bottom and disappears.
+{triage_disappears}
 
 ## Fields quick reference (for gh project CLI)
 
@@ -490,6 +482,11 @@ def status_table(field: dict | None) -> str:
         "Backlog": "Captured but not yet scheduled.",
         "Up Next": "Scheduled to be picked up next. The on-deck queue.",
         "In Progress": "Actively being worked on right now.",
+        "Blocked": (
+            "Waiting on a dependency. Pair with a `## Blocked by` section "
+            "in the issue body, or use `jared blocked-by` to record a native "
+            "GitHub issue dependency."
+        ),
         "Done": "Closed issues. Auto-populated when an issue closes.",
     }
     for opt in field.get("options", []):
@@ -526,6 +523,59 @@ def work_stream_table(field: dict | None) -> str:
     return "\n".join(rows)
 
 
+def work_stream_section(field: dict | None) -> str:
+    """Render the body of the `## Work Stream field` section.
+
+    When no Work Stream field exists on the board, jared treats the concept as
+    unused: the section survives as a marker (to flag projects that later want
+    to add one) but carries no rules or table.
+    """
+    if field is None:
+        return "_Not used on this project._"
+    return (
+        f"{work_stream_table(field)}\n"
+        "\n"
+        "**Rules:**\n"
+        "\n"
+        "- Work streams are project-specific and describe the kind of work, "
+        "not its priority or status.\n"
+        "- Every open issue should belong to exactly one work stream."
+    )
+
+
+def in_progress_rule(has_work_stream: bool) -> str:
+    """The In Progress rule bullet. Drops Work Stream when the field is absent."""
+    if has_work_stream:
+        return "Nothing in In Progress without Priority and Work Stream set."
+    return "Nothing in In Progress without Priority set."
+
+
+def triage_checklist(has_work_stream: bool, project_number: str, owner: str) -> str:
+    """Numbered triage checklist. Drops step 3 (Set Work Stream) when absent."""
+    steps = [
+        (
+            "**Auto-add to board.** `gh issue create` does not auto-add; use\n"
+            f"   `gh project item-add {project_number} --owner {owner} --url <issue-url>`."
+        ),
+        "**Set Priority** — High / Medium / Low.",
+    ]
+    if has_work_stream:
+        steps.append("**Set Work Stream** — per the fields above.")
+    steps.extend(
+        [
+            "**Leave Status as Backlog** unless explicitly scheduling.",
+            "**Apply labels** for issue type and scope.",
+        ]
+    )
+    return "\n".join(f"{i}. {step}" for i, step in enumerate(steps, 1))
+
+
+def triage_disappears(has_work_stream: bool) -> str:
+    """Final footer line of the triage section. Drops Work Stream when absent."""
+    required = "Priority and Work Stream" if has_work_stream else "Priority"
+    return f"An issue without {required} sorts to the bottom and disappears."
+
+
 def option_id(field: dict | None, name: str) -> str:
     if not field:
         return "<unset>"
@@ -533,6 +583,55 @@ def option_id(field: dict | None, name: str) -> str:
         if opt["name"].lower() == name.lower():
             return opt["id"]
     return "<unset>"
+
+
+def render_doc(
+    *,
+    project_title: str,
+    project_url: str,
+    project_number: str,
+    project_id: str,
+    owner: str,
+    repo: str,
+    bootstrap_date: str,
+    wip_limit: int,
+    status: dict | None,
+    priority: dict | None,
+    work_stream: dict | None,
+) -> str:
+    """Render the full project-board.md convention doc from introspected fields.
+
+    Factored out of `main` so tests can exercise conditional rendering
+    (Work Stream present vs. absent, Blocked column description, etc.)
+    without stubbing `gh` calls.
+    """
+    has_ws = work_stream is not None
+    return TEMPLATE.format(
+        project_title=project_title,
+        project_url=project_url,
+        project_number=project_number,
+        project_id=project_id,
+        owner=owner,
+        repo=repo,
+        bootstrap_date=bootstrap_date,
+        wip_limit=wip_limit,
+        status_columns_table=status_table(status),
+        priority_table=priority_table(priority),
+        work_stream_section=work_stream_section(work_stream),
+        status_field_id=status.get("id", "<unset>") if status else "<unset>",
+        priority_field_id=priority.get("id", "<unset>") if priority else "<unset>",
+        work_stream_field_id=work_stream.get("id", "<unset>") if work_stream else "<unset>",
+        status_options_kv=options_kv_block(status),
+        priority_options_kv=options_kv_block(priority),
+        work_stream_options_kv=options_kv_block(work_stream),
+        status_options_block=options_block(status),
+        priority_options_block=options_block(priority),
+        work_stream_options_block=options_block(work_stream),
+        up_next_option_id=option_id(status, "Up Next"),
+        in_progress_rule=in_progress_rule(has_ws),
+        triage_checklist=triage_checklist(has_ws, project_number, owner),
+        triage_disappears=triage_disappears(has_ws),
+    )
 
 
 # ---------- Main ----------
@@ -659,7 +758,7 @@ def main() -> int:
         print(f"  Note: {[m[0] for m in missing]} missing — skipped creation.")
 
     # Generate convention doc
-    content = TEMPLATE.format(
+    content = render_doc(
         project_title=project_title,
         project_url=args.url,
         project_number=number,
@@ -668,19 +767,9 @@ def main() -> int:
         repo=args.repo,
         bootstrap_date=dt.date.today().isoformat(),
         wip_limit=args.wip_limit,
-        status_columns_table=status_table(status),
-        priority_table=priority_table(priority),
-        work_stream_table=work_stream_table(work_stream),
-        status_field_id=status.get("id", "<unset>") if status else "<unset>",
-        priority_field_id=priority.get("id", "<unset>") if priority else "<unset>",
-        work_stream_field_id=work_stream.get("id", "<unset>") if work_stream else "<unset>",
-        status_options_kv=options_kv_block(status),
-        priority_options_kv=options_kv_block(priority),
-        work_stream_options_kv=options_kv_block(work_stream),
-        status_options_block=options_block(status),
-        priority_options_block=options_block(priority),
-        work_stream_options_block=options_block(work_stream),
-        up_next_option_id=option_id(status, "Up Next"),
+        status=status,
+        priority=priority,
+        work_stream=work_stream,
     )
 
     # Write

--- a/tests/test_bootstrap_project_defaults.py
+++ b/tests/test_bootstrap_project_defaults.py
@@ -1,0 +1,135 @@
+"""Tests for bootstrap-project.py's standard field defaults and conditional rendering.
+
+Covers #5: the script must emit a doc consistent with Jared's invariants on
+the first run — Blocked is a Status column (not a label), the Labels table
+must not list a `blocked` label, and Work Stream references must be
+conditional on the board actually having a Work Stream field.
+"""
+
+from typing import Any
+
+from tests.conftest import import_bootstrap
+
+Field = dict[str, Any]
+
+
+def _fake_field(name: str, options: list[str]) -> Field:
+    """Minimal shape fetch_fields returns — enough for render_doc's helpers."""
+    return {
+        "id": f"FIELD_{name.upper().replace(' ', '_')}",
+        "name": name,
+        "options": [{"id": f"opt_{o.lower().replace(' ', '_')}", "name": o} for o in options],
+    }
+
+
+def _status_field() -> Field:
+    return _fake_field("Status", ["Backlog", "Up Next", "In Progress", "Blocked", "Done"])
+
+
+def _priority_field() -> Field:
+    return _fake_field("Priority", ["High", "Medium", "Low"])
+
+
+def _render_kwargs(
+    status: Field | None, priority: Field | None, work_stream: Field | None
+) -> dict[str, Any]:
+    return {
+        "project_title": "Test Board",
+        "project_url": "https://github.com/users/alice/projects/7",
+        "project_number": "7",
+        "project_id": "PVT_test",
+        "owner": "alice",
+        "repo": "alice/demo",
+        "bootstrap_date": "2026-04-24",
+        "wip_limit": 3,
+        "status": status,
+        "priority": priority,
+        "work_stream": work_stream,
+    }
+
+
+def test_standard_status_field_includes_blocked() -> None:
+    mod = import_bootstrap()
+    assert "Blocked" in mod.STANDARD_FIELDS["Status"]
+    # Order is meaningful — Blocked sits between In Progress and Done.
+    order = mod.STANDARD_FIELDS["Status"]
+    assert order.index("In Progress") < order.index("Blocked") < order.index("Done")
+
+
+def test_status_table_blocked_has_real_description() -> None:
+    mod = import_bootstrap()
+    table = mod.status_table(_status_field())
+    # The Blocked row must not emit the (describe) placeholder.
+    blocked_line = next(line for line in table.splitlines() if "**Blocked**" in line)
+    assert "(describe)" not in blocked_line
+    assert "dependency" in blocked_line.lower()
+
+
+def test_render_doc_omits_blocked_label_row() -> None:
+    mod = import_bootstrap()
+    content = mod.render_doc(**_render_kwargs(_status_field(), _priority_field(), None))
+    # The emitted Labels table must not contain a `blocked` row.
+    assert "| `blocked` |" not in content
+    # And the Do-not-create callout must be present so future users don't add one.
+    assert "Do not" in content and "`blocked` label" in content
+
+
+def test_render_doc_with_work_stream_present() -> None:
+    mod = import_bootstrap()
+    ws = _fake_field("Work Stream", ["Backend", "Frontend"])
+    content = mod.render_doc(**_render_kwargs(_status_field(), _priority_field(), ws))
+    # In Progress rule includes Work Stream
+    assert "without Priority and Work Stream set" in content
+    # Triage checklist includes the Set Work Stream step
+    assert "**Set Work Stream**" in content
+    # Disappears footer includes Work Stream
+    assert "without Priority and Work Stream sorts" in content
+    # Work Stream section has rules, not the "Not used" line
+    assert "_Not used on this project._" not in content
+    assert "project-specific and describe the kind of work" in content
+
+
+def test_render_doc_without_work_stream_omits_it_from_rules() -> None:
+    mod = import_bootstrap()
+    content = mod.render_doc(**_render_kwargs(_status_field(), _priority_field(), None))
+    # In Progress rule drops Work Stream
+    assert "Nothing in In Progress without Priority set." in content
+    assert "without Priority and Work Stream set" not in content
+    # Triage checklist skips Set Work Stream entirely
+    assert "**Set Work Stream**" not in content
+    # Disappears footer drops Work Stream
+    assert "An issue without Priority sorts to the bottom" in content
+    assert "Priority and Work Stream sorts" not in content
+    # Work Stream section is marked unused
+    assert "_Not used on this project._" in content
+
+
+def test_render_doc_triage_checklist_renumbers_without_work_stream() -> None:
+    """With Work Stream absent, the numbered triage steps must stay contiguous.
+
+    Regression guard — the original hand-patched output had 'Set Work Stream'
+    simply deleted, leaving '1. Auto-add / 2. Set Priority / 4. Leave Status'
+    with a missing 3. The conditional renderer must renumber.
+    """
+    mod = import_bootstrap()
+    content = mod.render_doc(**_render_kwargs(_status_field(), _priority_field(), None))
+    # Find the triage section block
+    triage_block = content.split("## Triage checklist")[1].split("## Fields quick reference")[0]
+    assert "1. **Auto-add to board.**" in triage_block
+    assert "2. **Set Priority**" in triage_block
+    assert "3. **Leave Status as Backlog**" in triage_block
+    assert "4. **Apply labels**" in triage_block
+    # Make sure no phantom "5." step sneaks in
+    assert "5. **" not in triage_block
+
+
+def test_render_doc_triage_checklist_numbers_with_work_stream() -> None:
+    mod = import_bootstrap()
+    ws = _fake_field("Work Stream", ["Backend"])
+    content = mod.render_doc(**_render_kwargs(_status_field(), _priority_field(), ws))
+    triage_block = content.split("## Triage checklist")[1].split("## Fields quick reference")[0]
+    assert "1. **Auto-add to board.**" in triage_block
+    assert "2. **Set Priority**" in triage_block
+    assert "3. **Set Work Stream**" in triage_block
+    assert "4. **Leave Status as Backlog**" in triage_block
+    assert "5. **Apply labels**" in triage_block


### PR DESCRIPTION
## Summary

- Seed `STANDARD_FIELDS["Status"]` with `Blocked` so fresh bootstraps produce a 5-column board on day one.
- Give the Blocked Status column a real description and strip the `blocked` label row from the emitted Labels table (adding a Do-not-create callout).
- Make Work Stream references in the emitted convention doc conditional on the field existing — `## Work Stream field` section, triage checklist step, In Progress rule, disappears footer.
- Extract `render_doc()` so conditional rendering is unit-testable without stubbing `gh`.

Closes #5.

## Notes

This PR also carries a second commit (`2727a29 chore(docs): archive jared-levelup plan and spec`) from the same session — it archived the completed v0.2.0 level-up plan and spec to `docs/superpowers/{plans,specs}/archived/2026-04/` and repointed 10 issues' `## Planning` sections at the archived paths. Kept as a separate commit to make the history reviewable.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy` — no new errors (baseline 56 → 51, 5 pre-existing cleared incidentally by the `render_doc` extraction)
- [x] `pytest` — 81/81 pass; 7 new tests cover both with/without Work Stream rendering, Blocked description, and the label-row removal
- [ ] Manual: rerun bootstrap against this board (`/jared-init`) post-merge and confirm the emitted diff matches the hand-patched `docs/project-board.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)