### PR TITLE
fix(archive-plan): recognize **Issue:** bold-line spec/plan format (#38)

### DIFF
--- a/docs/superpowers/plans/archived/2026-04/2026-04-25-jared-wrap-next-session-prompt.md
+++ b/docs/superpowers/plans/archived/2026-04/2026-04-25-jared-wrap-next-session-prompt.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #35 on 2026-04-25. Final decisions captured in issue body.**
+---
+
 # /jared-wrap Optional Session Handoff Prompt — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/archived/2026-04/2026-04-25-jared-wrap-next-session-prompt-design.md
+++ b/docs/superpowers/specs/archived/2026-04/2026-04-25-jared-wrap-next-session-prompt-design.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #35 on 2026-04-25. Final decisions captured in issue body.**
+---
+
 # Design: `/jared-wrap` produces an optional session handoff prompt
 
 **Issue:** brockamer/jared#35

--- a/skills/jared/scripts/archive-plan.py
+++ b/skills/jared/scripts/archive-plan.py
@@ -79,16 +79,41 @@ def write_issue_body(repo: str, number: int, body: str) -> None:
 # ---------- Plan parsing ----------
 
 
+_BOLD_ISSUE_LINE_LOOKAHEAD = 15
+_BOLD_ISSUE_LINE_RE = re.compile(
+    r"^\*\*(?:Tracking\s+)?Issues?:\*\*\s+(.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_ISSUE_REF_RE = re.compile(
+    r"(?:https?://github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d+)"
+    r"|(?:[\w.-]+/[\w.-]+)?#(\d+))"
+)
+
+
 def parse_referenced_issues(plan_text: str) -> list[int]:
-    """Extract issue numbers from ## Issue / ## Issues / ## Issue(s) section."""
+    """Extract issue numbers from a plan/spec.
+
+    Primary: a `## Issue` / `## Issues` / `## Issue(s)` section heading.
+    Fallback: a `**Issue:**` / `**Issues:**` / `**Tracking issue:**` bold
+    line near the top of the file (scanned across the first
+    `_BOLD_ISSUE_LINE_LOOKAHEAD` non-empty lines).
+
+    Refs are recognized in `#N`, `owner/repo#N`, and full GitHub URL forms.
+    Heading wins when both forms are present.
+    """
     m = re.search(
         r"^#{1,3}\s+Issue[s()]*\s*$([\s\S]+?)(?=^#{1,3}\s|\Z)",
         plan_text,
         re.MULTILINE,
     )
-    if not m:
+    if m:
+        return [int(n) for n in re.findall(r"#(\d+)", m.group(1))]
+
+    head = "\n".join(plan_text.splitlines()[:_BOLD_ISSUE_LINE_LOOKAHEAD])
+    bold = _BOLD_ISSUE_LINE_RE.search(head)
+    if not bold:
         return []
-    return [int(n) for n in re.findall(r"#(\d+)", m.group(1))]
+    return [int(n) for ref in _ISSUE_REF_RE.findall(bold.group(1)) for n in ref if n]
 
 
 def already_archived(path: Path) -> bool:

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -47,6 +47,44 @@ def test_parse_referenced_issues_extracts_refs_regardless_of_ref_type() -> None:
     assert ap.parse_referenced_issues(text) == [42, 98]
 
 
+def test_parse_referenced_issues_heading_only() -> None:
+    text = "# Plan\n\n## Issue\n\n- #7\n\n## Body\n"
+    assert ap.parse_referenced_issues(text) == [7]
+
+
+def test_parse_referenced_issues_bold_line_issue() -> None:
+    text = "# Design\n\n**Issue:** brockamer/jared#35\n**Status:** Spec\n"
+    assert ap.parse_referenced_issues(text) == [35]
+
+
+def test_parse_referenced_issues_bold_line_tracking_issue() -> None:
+    text = "# Plan\n\n**Goal:** ship X.\n\n**Tracking issue:** brockamer/jared#35.\n"
+    assert ap.parse_referenced_issues(text) == [35]
+
+
+def test_parse_referenced_issues_bold_line_plural_with_multiple_refs() -> None:
+    text = "# Plan\n\n**Issues:** #12, owner/repo#13, https://github.com/o/r/issues/14\n"
+    assert ap.parse_referenced_issues(text) == [12, 13, 14]
+
+
+def test_parse_referenced_issues_heading_wins_over_bold_line() -> None:
+    text = (
+        "# Plan\n\n**Issue:** #99\n\n## Issues\n\n- #1\n- #2\n\n## Body\n"
+    )
+    assert ap.parse_referenced_issues(text) == [1, 2]
+
+
+def test_parse_referenced_issues_neither_form_returns_empty() -> None:
+    text = "# Plan\n\nNo issue references at all.\n\n## Body\n"
+    assert ap.parse_referenced_issues(text) == []
+
+
+def test_parse_referenced_issues_bold_line_only_scanned_near_top() -> None:
+    filler = "\n".join(f"line {i}" for i in range(40))
+    text = f"# Plan\n\n{filler}\n\n**Issue:** #99\n"
+    assert ap.parse_referenced_issues(text) == []
+
+
 def test_archive_one_accepts_merged_pr_as_shipped(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- `archive-plan.py` now recognizes `**Issue:**` / `**Issues:**` / `**Tracking issue:**` bold lines near the top of a plan/spec, in addition to the existing `## Issue` heading. Refs accepted in `#N`, `owner/repo#N`, and full GitHub URL forms. Heading wins when both are present; bold-line scan is bounded to the first 15 lines to prevent mid-prose false positives.
- Archives the two stranded 2026-04-25-* spec/plan files that surfaced the bug at the close of #35.

Closes #38.

## Test plan

- [x] `pytest tests/test_archive_plan.py` — 11 passed (4 new shape tests + 1 lookahead-bound test + 1 heading-wins test + 1 heading-only test, plus 4 pre-existing)
- [x] `pytest` full suite — 99 passed
- [x] `ruff check .` — clean
- [x] `mypy` — no new errors in changed files (51 pre-existing errors all live in `bootstrap-project.py`, queued for the Phase 3 batch-script migration on #33)
- [x] Live in-tree verification: `archive-plan.py --scan --repo brockamer/jared --dry-run` recognizes both stranded files; `--yes` archives them and updates #35's `## Planning` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)