### PR TITLE
docs: template Frame note + jared-wrap closing trim (#37)

### DIFF
--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -88,4 +88,4 @@ Flow:
 
    **Important contract.** The prompt is **derived**, not authoritative. Session notes on issues, plans, specs, and memory entries are the durable records. The prompt is a one-shot bridge between sessions and is regenerated next wrap. **Do not edit the prompt to record decisions** — capture them on issues, in plans, or as memory entries. The prompt's footer reminds the reader of this; honor it.
 
-The next session's `/jared` or auto-orientation reads these Session notes directly. The handoff prompt is an additional convenience for queue-heavy projects — Session notes remain the durable record.
+The next session's `/jared` or auto-orientation reads these Session notes directly; the handoff prompt is an optional convenience layered on top.

--- a/skills/jared/assets/next-session-prompt.md.template
+++ b/skills/jared/assets/next-session-prompt.md.template
@@ -7,7 +7,10 @@
 
 <1–3 sentence narrative synthesized by /jared-wrap from the prior session's
 conversation: release context, what shipped, what's load-bearing right now.
-Falls back to a board-derived bullet list when no synthesis is available.>
+The release-context portion is grounded in the CLI's `## Recently closed
+(last 7 days)` block (produced by `jared next-session-prompt`), which the
+slash command consumes as input to this synthesis. Falls back to a
+board-derived bullet list when no synthesis is available.>
 
 ## What's likely to want attention this session
 


### PR DESCRIPTION
Closes #37.

## Summary

Two cosmetic doc edits flagged Minor by the PR #36 reviewer and deferred to keep that PR focused.

- **`skills/jared/assets/next-session-prompt.md.template`** — extend the `## Frame` guidance with one sentence noting that the CLI's `## Recently closed (last 7 days)` block (produced by `jared next-session-prompt`) is the grounding input for the release-context synthesis. Without this, a maintainer reading just the template would think the CLI's Recently-closed output is unused.
- **`commands/jared-wrap.md` step 7** — trim the closing paragraph to a single sentence. The dropped clause (*"Session notes remain the durable record"*) was already stated in the "Important contract" callout four lines above.

Both items are explicitly listed in #37's acceptance criteria.

## Test plan

- [x] `git diff` reviewed — only the two intended doc edits, no behavior change
- [ ] Reviewer eyeballs the template's new sentence reads cleanly in context
- [ ] Reviewer confirms the trimmed `jared-wrap.md` closer no longer overlaps the contract callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)