### PR TITLE
Tighten batch-script types: 51 mypy errors → 0 (#33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ mypy                            # strict type-check (config in pyproject.toml)
 
 `pyproject.toml` sets `addopts = "-m 'not integration'"` — integration tests are opt-in only; they hit a real `brockamer/jared-testbed` GitHub project and need `tests/testbed.env` (see `tests/testbed-setup.md`).
 
-Several legacy batch scripts (`sweep.py`, `bootstrap-project.py`, `archive-plan.py`, `capture-context.py`, `dependency-graph.py`) are excluded from ruff via `extend-exclude` — Phase 3 will migrate them onto the new `Board` helper. Don't reintroduce lint coverage over them piecemeal without doing the migration.
+The batch scripts (`sweep.py`, `bootstrap-project.py`, `archive-plan.py`, `capture-context.py`, `dependency-graph.py`) all route their `gh` calls through `lib/board.py`'s `run_gh` / `run_gh_raw` / `run_graphql` (imported as `board_run_gh*`). They pass `ruff` and `mypy --strict` cleanly alongside the rest of the tree — no lint or type-check excludes.
 
 ## Architecture — the three-tier operations model
 
@@ -94,7 +94,7 @@ skills/jared/
     jared                 Unified CLI (argparse entry point)
     lib/board.py          Shared Board helper — parse + gh wrapper + lookups
     sweep.py, bootstrap-project.py, dependency-graph.py, capture-context.py, archive-plan.py
-                          Batch scripts — legacy, pre-Board, ruff-excluded
+                          Batch scripts — go through lib/board.py wrappers; pytest + ruff + mypy clean
   assets/                 Templates: issue-body, session-note, project-board.md, plan-conventions
 tests/                    pytest unit + integration suite; conftest has import helpers
 docs/superpowers/         Specs and plans governing this plugin's own work (2026-04-22-jared-levelup)

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -725,7 +725,7 @@ def main() -> int:
     priority = find_single_select_field(fields, "Priority")
     work_stream = find_single_select_field(fields, "Work Stream")
 
-    missing = []
+    missing: list[tuple[str, list[str] | None]] = []
     if not status:
         missing.append(("Status", STANDARD_FIELDS["Status"]))
     if not priority:

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -25,6 +25,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 # Make sibling lib/ importable regardless of cwd — same pattern as the jared CLI.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -63,12 +64,15 @@ def parse_url(url: str) -> tuple[str, str, str]:
 
 
 def fetch_project(owner: str, number: str) -> dict:
-    return board_run_gh(["project", "view", number, "--owner", owner, "--format", "json"])
+    return cast(
+        dict[Any, Any],
+        board_run_gh(["project", "view", number, "--owner", owner, "--format", "json"]),
+    )
 
 
 def fetch_fields(owner: str, number: str) -> list[dict]:
     data = board_run_gh(["project", "field-list", number, "--owner", owner, "--format", "json"])
-    return data.get("fields", [])
+    return cast(list[dict[Any, Any]], data.get("fields", []))
 
 
 def fetch_workflows(owner_type: str, owner: str, number: str) -> list[dict]:
@@ -237,7 +241,7 @@ def create_single_select_field(project_id: str, name: str, options: list[str]) -
     field = result.get("data", {}).get("createProjectV2Field", {}).get("projectV2Field", {})
     if not field:
         raise RuntimeError(f"Field creation for {name!r} returned no data: {result}")
-    return field
+    return cast(dict[Any, Any], field)
 
 
 # ---------- Doc generation ----------
@@ -581,7 +585,7 @@ def option_id(field: dict | None, name: str) -> str:
         return "<unset>"
     for opt in field.get("options", []):
         if opt["name"].lower() == name.lower():
-            return opt["id"]
+            return cast(str, opt["id"])
     return "<unset>"
 
 

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -63,19 +63,19 @@ def parse_url(url: str) -> tuple[str, str, str]:
 # ---------- Introspection ----------
 
 
-def fetch_project(owner: str, number: str) -> dict:
+def fetch_project(owner: str, number: str) -> dict[str, Any]:
     return cast(
         dict[Any, Any],
         board_run_gh(["project", "view", number, "--owner", owner, "--format", "json"]),
     )
 
 
-def fetch_fields(owner: str, number: str) -> list[dict]:
+def fetch_fields(owner: str, number: str) -> list[dict[str, Any]]:
     data = board_run_gh(["project", "field-list", number, "--owner", owner, "--format", "json"])
     return cast(list[dict[Any, Any]], data.get("fields", []))
 
 
-def fetch_workflows(owner_type: str, owner: str, number: str) -> list[dict]:
+def fetch_workflows(owner_type: str, owner: str, number: str) -> list[dict[str, Any]]:
     """Return [{name, enabled, number}, ...] for the project's built-in workflows.
 
     Returns an empty list (not an error) if the response shape is unexpected
@@ -155,7 +155,7 @@ def link_project_to_repo(project_id: str, repo_slug: str) -> tuple[bool, str]:
     return True, f"linked project to {repo_slug}"
 
 
-def find_single_select_field(fields: list[dict], name: str) -> dict | None:
+def find_single_select_field(fields: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
     """Case-insensitive, space-insensitive match on field name."""
     target = name.lower().replace(" ", "")
     for f in fields:
@@ -191,7 +191,7 @@ def prompt_work_streams() -> list[str]:
     return streams
 
 
-def create_single_select_field(project_id: str, name: str, options: list[str]) -> dict:
+def create_single_select_field(project_id: str, name: str, options: list[str]) -> dict[str, Any]:
     """
     Create a single-select field with the given options via GraphQL.
     Returns the created field's details.
@@ -456,7 +456,7 @@ def patch_legacy_doc(existing: str, header_block: str) -> str:
 # ---------- Full-doc template rendering ----------
 
 
-def options_block(field: dict | None) -> str:
+def options_block(field: dict[str, Any] | None) -> str:
     if not field:
         return "  (field not present)\n"
     lines = []
@@ -465,7 +465,7 @@ def options_block(field: dict | None) -> str:
     return "\n".join(lines) + "\n"
 
 
-def options_kv_block(field: dict | None) -> str:
+def options_kv_block(field: dict[str, Any] | None) -> str:
     """Render a field's options as `- <name>: <id>` lines, one per option.
 
     This is the machine-readable form Board._parse_field_blocks consumes:
@@ -478,7 +478,7 @@ def options_kv_block(field: dict | None) -> str:
     return "\n".join(lines) if lines else "- (no options defined)"
 
 
-def status_table(field: dict | None) -> str:
+def status_table(field: dict[str, Any] | None) -> str:
     if not field:
         return "_(Status field not present — see bootstrap output.)_"
     rows = ["| Column | Meaning |", "|---|---|"]
@@ -499,7 +499,7 @@ def status_table(field: dict | None) -> str:
     return "\n".join(rows)
 
 
-def priority_table(field: dict | None) -> str:
+def priority_table(field: dict[str, Any] | None) -> str:
     if not field:
         return "_(Priority field not present.)_"
     rows = ["| Value | Meaning |", "|---|---|"]
@@ -514,7 +514,7 @@ def priority_table(field: dict | None) -> str:
     return "\n".join(rows)
 
 
-def work_stream_table(field: dict | None) -> str:
+def work_stream_table(field: dict[str, Any] | None) -> str:
     if not field or not field.get("options"):
         return (
             "_(Work Stream field has no options defined yet. Add options describing "
@@ -527,7 +527,7 @@ def work_stream_table(field: dict | None) -> str:
     return "\n".join(rows)
 
 
-def work_stream_section(field: dict | None) -> str:
+def work_stream_section(field: dict[str, Any] | None) -> str:
     """Render the body of the `## Work Stream field` section.
 
     When no Work Stream field exists on the board, jared treats the concept as
@@ -580,7 +580,7 @@ def triage_disappears(has_work_stream: bool) -> str:
     return f"An issue without {required} sorts to the bottom and disappears."
 
 
-def option_id(field: dict | None, name: str) -> str:
+def option_id(field: dict[str, Any] | None, name: str) -> str:
     if not field:
         return "<unset>"
     for opt in field.get("options", []):
@@ -599,9 +599,9 @@ def render_doc(
     repo: str,
     bootstrap_date: str,
     wip_limit: int,
-    status: dict | None,
-    priority: dict | None,
-    work_stream: dict | None,
+    status: dict[str, Any] | None,
+    priority: dict[str, Any] | None,
+    work_stream: dict[str, Any] | None,
 ) -> str:
     """Render the full project-board.md convention doc from introspected fields.
 

--- a/skills/jared/scripts/dependency-graph.py
+++ b/skills/jared/scripts/dependency-graph.py
@@ -43,7 +43,7 @@ from lib.board import (
 # ---------- gh helpers ----------
 
 
-def fetch_open_issues(repo: str, milestone: str | None) -> list[dict]:
+def fetch_open_issues(repo: str, milestone: str | None) -> list[dict[str, Any]]:
     cmd = [
         "issue",
         "list",
@@ -127,11 +127,11 @@ def parse_section_refs(body: str, section: str) -> list[int]:
     return [int(n) for n in re.findall(r"#(\d+)", m.group(1))]
 
 
-def body_dependencies(issue: dict) -> list[int]:
+def body_dependencies(issue: dict[str, Any]) -> list[int]:
     return parse_section_refs(issue.get("body", "") or "", "Depends on")
 
 
-def issue_priority(issue: dict) -> str | None:
+def issue_priority(issue: dict[str, Any]) -> str | None:
     for label in issue.get("labels", []):
         name: str = label.get("name", "").lower()
         if name.startswith("priority:"):

--- a/skills/jared/scripts/dependency-graph.py
+++ b/skills/jared/scripts/dependency-graph.py
@@ -28,6 +28,7 @@ import re
 import sys
 from collections import defaultdict, deque
 from pathlib import Path
+from typing import Any, cast
 
 # Make sibling lib/ importable regardless of cwd — same pattern as the jared CLI.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -57,13 +58,13 @@ def fetch_open_issues(repo: str, milestone: str | None) -> list[dict]:
     ]
     if milestone:
         cmd += ["--milestone", milestone]
-    return board_run_gh(cmd)
+    return cast(list[dict[Any, Any]], board_run_gh(cmd))
 
 
 def fetch_issue_state(repo: str, number: int) -> str:
     try:
         data = board_run_gh(["issue", "view", str(number), "--repo", repo, "--json", "state"])
-        return data.get("state", "UNKNOWN")
+        return cast(str, data.get("state", "UNKNOWN"))
     except GhInvocationError:
         return "UNKNOWN"
 
@@ -132,7 +133,7 @@ def body_dependencies(issue: dict) -> list[int]:
 
 def issue_priority(issue: dict) -> str | None:
     for label in issue.get("labels", []):
-        name = label.get("name", "").lower()
+        name: str = label.get("name", "").lower()
         if name.startswith("priority:"):
             return name.split(":", 1)[1].strip()
     return None

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -45,7 +45,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 # Make sibling lib/ importable regardless of cwd — same pattern as the jared CLI.
 # mypy can't follow the sys.path manipulation; types are still enforced inside lib.board.
@@ -114,7 +114,7 @@ def fetch_items(owner: str, project: str) -> list[dict]:
             "json",
         ]
     )
-    return data.get("items", [])
+    return cast(list[dict[Any, Any]], data.get("items", []))
 
 
 def fetch_open_issues_bulk(repo: str) -> list[dict]:
@@ -203,7 +203,7 @@ def field(item: dict, *keys: str) -> str | None:
     for k in keys:
         v = item.get(k)
         if v:
-            return v
+            return cast(str, v)
     return None
 
 
@@ -212,7 +212,7 @@ def guess_repo_from_items(items: list[dict]) -> str | None:
         content = i.get("content") or {}
         repo = content.get("repository")
         if repo:
-            return repo.replace("https://github.com/", "")
+            return cast(str, repo.replace("https://github.com/", ""))
     return None
 
 

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -337,6 +337,8 @@ def check_stale_high_backlog(
         if field(i, "priority") != "High":
             continue
         n = content.get("number")
+        if n is None:
+            continue
         issue = issues_by_number.get(n)
         if not issue:
             continue
@@ -360,6 +362,8 @@ def check_in_progress_staleness(
         if i.get("status") != "In Progress":
             continue
         n = content.get("number")
+        if n is None:
+            continue
         issue = issues_by_number.get(n)
         if not issue:
             continue
@@ -663,6 +667,8 @@ def main() -> int:
     existing_plan_dirs = [p for p in plan_dirs if p.exists()]
     if not existing_plan_dirs:
         print("  (no plan/spec directories found — skipping)")
+    elif not repo:
+        print("  (skipped — repo not determined)")
     else:
         findings = check_plan_spec_drift(existing_plan_dirs, repo)
         for f in findings or ["  None"]:

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -100,7 +100,7 @@ def find_config() -> Path | None:
 # response, not field IDs from the convention doc.
 
 
-def fetch_items(owner: str, project: str) -> list[dict]:
+def fetch_items(owner: str, project: str) -> list[dict[str, Any]]:
     data = board_run_gh(
         [
             "project",
@@ -117,7 +117,7 @@ def fetch_items(owner: str, project: str) -> list[dict]:
     return cast(list[dict[Any, Any]], data.get("items", []))
 
 
-def fetch_open_issues_bulk(repo: str) -> list[dict]:
+def fetch_open_issues_bulk(repo: str) -> list[dict[str, Any]]:
     """One API call to get all open issues with the data we need."""
     stdout = board_run_gh_raw(
         [
@@ -136,7 +136,7 @@ def fetch_open_issues_bulk(repo: str) -> list[dict]:
     return json.loads(stdout) if stdout else []
 
 
-def fetch_native_blocked_by(repo: str) -> dict[int, list[dict]]:
+def fetch_native_blocked_by(repo: str) -> dict[int, list[dict[str, Any]]]:
     """One GraphQL call to get blockedBy for all open issues. Returns {number: [{number, state}]}.
 
     Tries 'blockedBy' first; falls back to 'issueDependencies' on schema error.
@@ -148,7 +148,7 @@ def fetch_native_blocked_by(repo: str) -> dict[int, list[dict]]:
             f"issues(first:100,after:$c,states:OPEN){{pageInfo{{hasNextPage endCursor}}"
             f"nodes{{number {field_name}(first:20){{nodes{{number state}}}}}}}}}}}}"
         )
-        result: dict[int, list[dict]] = {}
+        result: dict[int, list[dict[str, Any]]] = {}
         cursor: str | None = None
         try:
             while True:
@@ -170,7 +170,7 @@ def fetch_native_blocked_by(repo: str) -> dict[int, list[dict]]:
     raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
 
 
-def fetch_recent_comments(repo: str, number: int, limit: int = 5) -> list[dict]:
+def fetch_recent_comments(repo: str, number: int, limit: int = 5) -> list[dict[str, Any]]:
     """Get recent comments on an issue (for session-note freshness)."""
     try:
         stdout = board_run_gh_raw(
@@ -198,7 +198,7 @@ def fetch_recent_comments(repo: str, number: int, limit: int = 5) -> list[dict]:
 # ---------- Item helpers ----------
 
 
-def field(item: dict, *keys: str) -> str | None:
+def field(item: dict[str, Any], *keys: str) -> str | None:
     """Look up a field value across the variant key names gh returns."""
     for k in keys:
         v = item.get(k)
@@ -207,7 +207,7 @@ def field(item: dict, *keys: str) -> str | None:
     return None
 
 
-def guess_repo_from_items(items: list[dict]) -> str | None:
+def guess_repo_from_items(items: list[dict[str, Any]]) -> str | None:
     for i in items:
         content = i.get("content") or {}
         repo = content.get("repository")
@@ -219,7 +219,7 @@ def guess_repo_from_items(items: list[dict]) -> str | None:
 # ---------- Checks ----------
 
 
-def check_metadata(items: list[dict]) -> list[str]:
+def check_metadata(items: list[dict[str, Any]]) -> list[str]:
     # Detect whether Work Stream is in use on this board. If no open item
     # has Work Stream set, assume the project doesn't define the field and
     # skip the Work Stream check. Projects without a Work Stream field (a
@@ -252,7 +252,7 @@ def check_metadata(items: list[dict]) -> list[str]:
     return missing
 
 
-def check_closed_not_done(items: list[dict]) -> list[dict]:
+def check_closed_not_done(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Closed issues should auto-move to Done. If they don't, return them.
 
     Detection-only. Each entry is {number, title, current_status} — callers
@@ -299,7 +299,7 @@ def format_closed_not_done_line(entry: dict[str, Any]) -> str:
     )
 
 
-def check_wip(items: list[dict], limit: int) -> list[str]:
+def check_wip(items: list[dict[str, Any]], limit: int) -> list[str]:
     in_progress = [i for i in items if i.get("status") == "In Progress"]
     findings = []
     if len(in_progress) > limit:
@@ -313,7 +313,7 @@ def check_wip(items: list[dict], limit: int) -> list[str]:
     return findings
 
 
-def check_up_next_size(items: list[dict], limit: int = 3) -> list[str]:
+def check_up_next_size(items: list[dict[str, Any]], limit: int = 3) -> list[str]:
     up_next = [i for i in items if i.get("status") == "Up Next"]
     if len(up_next) > limit:
         return [
@@ -324,7 +324,7 @@ def check_up_next_size(items: list[dict], limit: int = 3) -> list[str]:
 
 
 def check_stale_high_backlog(
-    items: list[dict], issues_by_number: dict[int, dict], days: int
+    items: list[dict[str, Any]], issues_by_number: dict[int, dict[str, Any]], days: int
 ) -> list[str]:
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=days)
     stale = []
@@ -351,7 +351,7 @@ def check_stale_high_backlog(
 
 
 def check_in_progress_staleness(
-    items: list[dict], issues_by_number: dict[int, dict], days: int = 7
+    items: list[dict[str, Any]], issues_by_number: dict[int, dict[str, Any]], days: int = 7
 ) -> list[str]:
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=days)
     stale = []
@@ -376,8 +376,8 @@ def check_in_progress_staleness(
 
 
 def check_blocked_status_hygiene(
-    items: list[dict],
-    issues_by_number: dict[int, dict],
+    items: list[dict[str, Any]],
+    issues_by_number: dict[int, dict[str, Any]],
     blocked_aging_days: int,
 ) -> list[str]:
     """Items in Blocked Status must have ## Blocked by; flag ones stuck >N days."""
@@ -404,8 +404,8 @@ def check_blocked_status_hygiene(
 
 
 def check_native_dependencies(
-    blocked_by: dict[int, list[dict]],
-    issues_by_number: dict[int, dict],
+    blocked_by: dict[int, list[dict[str, Any]]],
+    issues_by_number: dict[int, dict[str, Any]],
 ) -> list[str]:
     """Flag native blockedBy edges pointing at closed issues — propose removing."""
     findings: list[str] = []
@@ -420,7 +420,7 @@ def check_native_dependencies(
     return findings
 
 
-def check_legacy_priority_labels(issues_by_number: dict[int, dict]) -> list[str]:
+def check_legacy_priority_labels(issues_by_number: dict[int, dict[str, Any]]) -> list[str]:
     findings = []
     for n, issue in issues_by_number.items():
         labels = [lbl["name"] for lbl in issue.get("labels", [])]
@@ -487,7 +487,9 @@ def check_plan_spec_drift(plan_dirs: list[Path], repo: str) -> list[str]:
     return findings
 
 
-def check_session_note_freshness(items: list[dict], repo: str | None, days: int = 3) -> list[str]:
+def check_session_note_freshness(
+    items: list[dict[str, Any]], repo: str | None, days: int = 3
+) -> list[str]:
     """Look for In Progress issues without a recent Session note comment."""
     if not repo:
         return ["(skipping session-note check — repo not determined)"]


### PR DESCRIPTION
Closes #33.

## Summary

Phase-3 follow-up: the gh-routing half of the batch-script migration shipped incidentally during recent work, but left behind 51 `mypy --strict` errors in `sweep.py` (25), `bootstrap-project.py` (20), and `dependency-graph.py` (6). This PR clears them and updates the CLAUDE.md language that was framing the migration as still-pending.

Phase-numbered commits, by mypy error code:

| Phase | Commit | Errors fixed | Net |
|---|---|---|---|
| 1 | `fe3d0f0` fix [arg-type] | 4 | 51 → 47 |
| 2 | `c098f15` fix [no-any-return] | 10 | 47 → 37 |
| 3 | `13c3851` fix [type-arg] | 37 | 37 → 0 |
| 4 | `2d7ecd4` docs(CLAUDE) | — | doc update |

The 4 `[arg-type]` errors got individual review per the issue's acceptance criteria — none were latent bugs. Two were `dict.get("number")` results lacking a None-narrow before downstream lookup; one was a `repo: str | None` reaching a `repo: str` callee that internally guarded against None but mypy couldn't see it; one was a sentinel-None being appended to a too-narrow list type. Details in each commit message.

The 10 `[no-any-return]` errors all stem from `board_run_gh` returning `Any` by design (gh JSON shape varies per subcommand). Resolved with `typing.cast` at the function boundaries that promise concrete return types.

The 37 `[type-arg]` errors were mechanical — bare `dict` annotations widened to `dict[str, Any]` (and `list[dict]` → `list[dict[str, Any]]`).

## Verification

- `mypy` — 51 errors → 0 (`Success: no issues found in 25 source files`)
- `ruff check .` — clean
- `pytest -q` — 99 passed (no test changes; existing coverage exercises every changed function)
- `CLAUDE.md` — Phase-3 / `extend-exclude` language replaced with present-tense statement of the actual contract

## Test plan

- [x] `mypy` shows 0 errors
- [x] `ruff check .` passes
- [x] Full unit test suite green
- [ ] Reviewer eyeballs the `cast()` placements (10 sites) for "is this asserting a fact mypy can't see, or papering over a bug?"
- [ ] Reviewer eyeballs the 4 `[arg-type]` fixes for the "individual review, not blanket cast" criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)