### PR TITLE
chore(release): bump version 0.4.0 → 0.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.3.1"
+version = "0.5.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Cuts v0.5.0.

## Summary

Anchors the v0.5.x line on the Phase-3 type-tightening work shipped in PR #41 (mypy `--strict` on `skills/jared/scripts/`: 51 errors → 0) and rolls in the smaller v0.4.x follow-ups that landed without their own version bumps:

- **#41** (closes #33) — batch-script type tightening; `CLAUDE.md` "Phase 3" / ruff-excluded language retired.
- **#40** (closes #37) — docs polish: template Frame note + `jared-wrap` closing-paragraph trim.
- **#39** (closes #38) — `archive-plan` recognizer for `**Issue:**` bold-line format (post-v0.4.0 fix that never got its own v0.4.1 tag).

`pyproject.toml` was drifted at 0.3.1; this brings it back into sync with `.claude-plugin/plugin.json`.

## Test plan

- [x] `mypy` clean
- [x] `ruff check .` clean
- [x] `pytest -q` green (99 tests)
- [ ] After merge: tag `v0.5.0` and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)