### PR TITLE
feat(commands): /jared-start picks up most recent handoff prompt (#44)

### DIFF
--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -2,33 +2,70 @@
 description: Begin work on an issue — move to In Progress, load full context (body, latest Session note, linked plan/spec), announce the session plan.
 ---
 
-Invoke the Jared skill to start work on an issue. Takes an argument: the issue reference (number or URL).
+Invoke the Jared skill to start work on an issue. Takes an optional argument: the issue reference (number or URL).
 
-Argument parsing: `$ARGUMENTS` may contain `#14`, `14`, a URL, or a short string like "the excluded employers issue". Resolve to a specific issue number, asking to clarify if ambiguous.
+Argument parsing: `$ARGUMENTS` may contain `#14`, `14`, a URL, a short string like "the excluded employers issue", or be empty. Resolve to a specific issue number, asking to clarify if ambiguous.
 
 Flow:
 
-1. **Check WIP.** Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared summary` and read the `In Progress (N)` header — that `N` is the current count. If it's already at the project's configured cap (default 3), STOP and ask what moves out or pauses. Do NOT silently exceed WIP.
+1. **Look for the most recent handoff prompt.** Glob `tmp/next-session-prompt-*.md`. The filename's `YYYY-MM-DD-HHMM` is monotonic, so lex-sort descending and take the first match. If no match, set `prompt = None` and skip to step 2.
 
-2. **Check pullable state.** Read the target issue's body and verify:
+   When a prompt is found, parse the following sections by `##` headers (omit any missing section — never fabricate):
+   - **Frame** — content under `## Frame`. Condense to 2–3 sentences if longer.
+   - **Anti-targets** — bullets under `## What NOT to do`.
+   - **Context pointers** — bullets under `## Context you'll need`.
+   - **Recommended issue** — within the section under `## To start`, find a fenced code block containing a line matching `/jared-start\s+(\d+)` and capture the number.
+   - **Relative time** — parse the filename's `YYYY-MM-DD-HHMM` and render relative to now ("6h ago", "yesterday", "3d ago"). Fall back to the absolute timestamp on parse failure.
+
+   Resolve the target issue:
+   - If `$ARGUMENTS` is non-empty: use it. No drift check on the prompt's recommendation.
+   - If `$ARGUMENTS` is empty AND a recommended issue was parsed: drift-check by running `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared get-item <N>`. If the issue is closed on GitHub or its Status is `Done`, the recommendation is stale — output the **posture block** (see step 6) followed by:
+
+     ```
+     Handoff prompt recommends #<N>, but #<N> is now <closed|Done>.
+     The prompt's posture is still useful context for whatever you pull next.
+
+     Which issue would you like to pull?
+     ```
+
+     Wait for user input, then resume the flow at step 2 with the user-supplied issue. If the recommended issue is pullable, set it as the target and continue.
+
+   - If `$ARGUMENTS` is empty AND no recommended issue was parseable (or no prompt found): ask which issue. When a prompt was found but had no parseable `## To start`, the posture block is still surfaced in step 6.
+
+2. **Check WIP.** Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared summary` and read the `In Progress (N)` header — that `N` is the current count. If it's already at the project's configured cap (default 3), STOP and ask what moves out or pauses. Do NOT silently exceed WIP.
+
+3. **Check pullable state.** Read the target issue's body and verify:
    - First paragraph is a clear summary
    - `## Acceptance criteria` is populated (not empty or placeholder)
    - `## Depends on` — all referenced issues are closed or already done
    If any is missing, pause and propose reshaping the issue first. Pullable is a discipline, not a formality.
 
-3. **Move to In Progress.** One call:
+4. **Move to In Progress.** One call:
 
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared move <N> "In Progress"
    ```
 
-4. **Load context.** Fetch:
+5. **Load context.** Fetch:
    - Full issue body (including `## Current state`, `## Decisions`, acceptance criteria in `<details>`)
    - Most recent Session note comment (matches `## Session YYYY-MM-DD` header)
    - Any plan or spec linked from `## Planning` — read and summarize
    - Git state: current branch, uncommitted changes, last 5 commits touching related files
 
-5. **Announce the session plan.** Output something like:
+6. **Announce the session plan.** When a prompt was found in step 1, prepend a **posture block**:
+
+   ```
+   Handoff posture (tmp/next-session-prompt-<TIMESTAMP>.md, <relative-time>):
+     Frame: <Frame, condensed to 2-3 sentences>
+     Anti-targets:
+       - <bullet from "What NOT to do">
+       - ...
+     Context pointers:
+       - <bullet from "Context you'll need">
+       - ...
+   ```
+
+   Then the per-issue announcement:
 
    ```
    Starting #<N>: <title>
@@ -54,6 +91,8 @@ Flow:
    Git: branch <name>, <clean | N modified>, last relevant commit <hash> <msg>
    ```
 
-6. **Wait for confirmation** before starting work. User may amend the plan, ask questions, or say "go."
+   The posture block is omitted when no prompt was found in step 1. Two visually-separated blocks when both are present: cross-issue posture above, issue-specific below.
 
-This replaces the pattern of manually reading the issue, the plan, and a handoff prompt before starting. The board + latest Session note is the handoff.
+7. **Wait for confirmation** before starting work. User may amend the plan, ask questions, or say "go."
+
+This replaces the pattern of manually reading the issue, the plan, and a handoff prompt before starting. The board + latest Session note + (when present) the most recent handoff prompt is the handoff.

--- a/docs/superpowers/plans/2026-04-26-jared-start-handoff-pickup.md
+++ b/docs/superpowers/plans/2026-04-26-jared-start-handoff-pickup.md
@@ -1,0 +1,325 @@
+# /jared-start handoff-prompt pickup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Alter `/jared-start` so it looks for the most recent `tmp/next-session-prompt-*.md` and surfaces its synthesis (Frame, anti-targets, context pointers) as a Handoff posture block above the per-issue announcement, honoring the prompt's `## To start` recommendation when no `$ARGUMENTS` is given (with a drift check for stale recommendations).
+
+**Architecture:** This is a **doc-as-code** edit. The "code" is markdown documentation in `commands/jared-start.md` that the model invoking the slash command reads and executes step-by-step. There is no Python implementation, no CLI subcommand, and no automated test layer. The verification surface is (a) reading the modified file end-to-end for coherence, (b) the existing `ruff` + `mypy` invariants (untouched by this change), and (c) live invocation of `/jared-start` in a fresh Claude Code session post-merge.
+
+**Tech Stack:** Markdown command-prompt template only. No Python, no shell, no test framework.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-jared-start-handoff-pickup-design.md` (commit 880e945)
+**Issue:** [#44](https://github.com/brockamer/jared/issues/44)
+
+---
+
+## File Structure
+
+This change touches one file. No new files, no deletions.
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `commands/jared-start.md` | Modify | Add Step 1 (look for handoff prompt + drift check + parse posture sections), modify Step 6 (announcement) to prepend the posture block when a prompt was found, renumber existing Steps 1–6 to 2–7. |
+
+The existing 6-step flow becomes a 7-step flow. Steps shift down by 1; only the new Step 1 is logically inserted, and the prior Step 5 (now Step 6, "Announce the session plan") is the only existing step whose body changes.
+
+---
+
+## Branch + Commit Strategy
+
+Per memory `feedback_jared_git_workflow`: feature branch off `main`, PR to `main` via `--merge`, phase-numbered commits if multiple phases.
+
+This is a single-phase change (one atomic edit), so one commit on `feature/44-jared-start-handoff-pickup`, then PR. No phase prefix needed since there is only one phase; conventional commit prefix `feat(commands)` is sufficient.
+
+---
+
+## Tasks
+
+### Task 1: Create feature branch
+
+**Files:**
+- (none yet — git operation)
+
+- [ ] **Step 1: Verify clean working tree on `main`**
+
+Run:
+```bash
+git status
+```
+
+Expected: branch `main`, working tree clean (the spec commit `880e945` is the most recent commit; no untracked or modified files except permitted scratch like `CLAUDE.local.md` if present).
+
+- [ ] **Step 2: Create the feature branch**
+
+Run:
+```bash
+git checkout -b feature/44-jared-start-handoff-pickup
+```
+
+Expected: `Switched to a new branch 'feature/44-jared-start-handoff-pickup'`.
+
+---
+
+### Task 2: Edit `commands/jared-start.md`
+
+**Files:**
+- Modify: `commands/jared-start.md` (full rewrite of the body — the front matter `description:` line stays as-is)
+
+The front-matter `description:` line is preserved unchanged. The flow body is rewritten end-to-end (a single Edit operation against the existing body is cleaner than four surgical edits, since renumbering and the inserted step interleave).
+
+- [ ] **Step 1: Confirm current file state**
+
+Run:
+```bash
+wc -l commands/jared-start.md
+```
+
+Expected: 60 lines (the spec was written against this baseline; if line count differs, re-read the file before editing).
+
+- [ ] **Step 2: Replace the body of `commands/jared-start.md`**
+
+Use the Edit tool to replace the entire body of `commands/jared-start.md` (everything from line 5 onward — `Invoke the Jared skill...` through end of file) with the following exact text:
+
+````markdown
+Invoke the Jared skill to start work on an issue. Takes an optional argument: the issue reference (number or URL).
+
+Argument parsing: `$ARGUMENTS` may contain `#14`, `14`, a URL, a short string like "the excluded employers issue", or be empty. Resolve to a specific issue number, asking to clarify if ambiguous.
+
+Flow:
+
+1. **Look for the most recent handoff prompt.** Glob `tmp/next-session-prompt-*.md`. The filename's `YYYY-MM-DD-HHMM` is monotonic, so lex-sort descending and take the first match. If no match, set `prompt = None` and skip to step 2.
+
+   When a prompt is found, parse the following sections by `##` headers (omit any missing section — never fabricate):
+   - **Frame** — content under `## Frame`. Condense to 2–3 sentences if longer.
+   - **Anti-targets** — bullets under `## What NOT to do`.
+   - **Context pointers** — bullets under `## Context you'll need`.
+   - **Recommended issue** — within the section under `## To start`, find a fenced code block containing a line matching `/jared-start\s+(\d+)` and capture the number.
+   - **Relative time** — parse the filename's `YYYY-MM-DD-HHMM` and render relative to now ("6h ago", "yesterday", "3d ago"). Fall back to the absolute timestamp on parse failure.
+
+   Resolve the target issue:
+   - If `$ARGUMENTS` is non-empty: use it. No drift check on the prompt's recommendation.
+   - If `$ARGUMENTS` is empty AND a recommended issue was parsed: drift-check by running `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared get-item <N>`. If the issue is closed on GitHub or its Status is `Done`, the recommendation is stale — output the **posture block** (see step 6) followed by:
+
+     ```
+     Handoff prompt recommends #<N>, but #<N> is now <closed|Done>.
+     The prompt's posture is still useful context for whatever you pull next.
+
+     Which issue would you like to pull?
+     ```
+
+     Wait for user input, then resume the flow at step 2 with the user-supplied issue. If the recommended issue is pullable, set it as the target and continue.
+
+   - If `$ARGUMENTS` is empty AND no recommended issue was parseable (or no prompt found): ask which issue. When a prompt was found but had no parseable `## To start`, the posture block is still surfaced in step 6.
+
+2. **Check WIP.** Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared summary` and read the `In Progress (N)` header — that `N` is the current count. If it's already at the project's configured cap (default 3), STOP and ask what moves out or pauses. Do NOT silently exceed WIP.
+
+3. **Check pullable state.** Read the target issue's body and verify:
+   - First paragraph is a clear summary
+   - `## Acceptance criteria` is populated (not empty or placeholder)
+   - `## Depends on` — all referenced issues are closed or already done
+   If any is missing, pause and propose reshaping the issue first. Pullable is a discipline, not a formality.
+
+4. **Move to In Progress.** One call:
+
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared move <N> "In Progress"
+   ```
+
+5. **Load context.** Fetch:
+   - Full issue body (including `## Current state`, `## Decisions`, acceptance criteria in `<details>`)
+   - Most recent Session note comment (matches `## Session YYYY-MM-DD` header)
+   - Any plan or spec linked from `## Planning` — read and summarize
+   - Git state: current branch, uncommitted changes, last 5 commits touching related files
+
+6. **Announce the session plan.** When a prompt was found in step 1, prepend a **posture block**:
+
+   ```
+   Handoff posture (tmp/next-session-prompt-<TIMESTAMP>.md, <relative-time>):
+     Frame: <Frame, condensed to 2-3 sentences>
+     Anti-targets:
+       - <bullet from "What NOT to do">
+       - ...
+     Context pointers:
+       - <bullet from "Context you'll need">
+       - ...
+   ```
+
+   Then the per-issue announcement:
+
+   ```
+   Starting #<N>: <title>
+
+   Summary: <first paragraph>
+
+   Last Session note (YYYY-MM-DD):
+     Next action: "<from note>"
+     Gotchas: <if any>
+     State: <if any>
+
+   Plan/spec: <path if any, one-line summary>
+
+   Acceptance criteria:
+     - <criterion 1>
+     - ...
+
+   Proposed plan for this session:
+     1. <first concrete step, based on Next action and context>
+     2. <second>
+     3. <commit / PR boundary>
+
+   Git: branch <name>, <clean | N modified>, last relevant commit <hash> <msg>
+   ```
+
+   The posture block is omitted when no prompt was found in step 1. Two visually-separated blocks when both are present: cross-issue posture above, issue-specific below.
+
+7. **Wait for confirmation** before starting work. User may amend the plan, ask questions, or say "go."
+
+This replaces the pattern of manually reading the issue, the plan, and a handoff prompt before starting. The board + latest Session note + (when present) the most recent handoff prompt is the handoff.
+````
+
+Match `old_string` against the existing body starting from `Invoke the Jared skill to start work...` through the end of the file. Use the Edit tool with the unique anchor `Invoke the Jared skill to start work on an issue. Takes an argument:` to disambiguate (the existing first line says `Takes an argument`; the new text says `Takes an optional argument`).
+
+If the Edit tool reports the `old_string` is not unique or is not found, Read the current file and adjust the anchor — do NOT proceed with a partial edit.
+
+---
+
+### Task 3: Verify the edit
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Read the edited file end-to-end with fresh eyes**
+
+Use Read on `commands/jared-start.md`. Check:
+- Front matter (`description:` line) is unchanged.
+- The flow has 7 numbered steps (1 through 7).
+- Step 1 is the new "Look for the most recent handoff prompt" step.
+- Steps 2–5 are the prior Steps 1–4, unchanged in body.
+- Step 6 is the prior Step 5 ("Announce the session plan"), modified to prepend the posture block.
+- Step 7 is the prior Step 6 ("Wait for confirmation"), unchanged.
+- The closing paragraph mentions "the most recent handoff prompt" alongside board + Session note.
+- No broken references to step numbers (search the body for `step <digit>` mentions and confirm they all point to the new numbering).
+
+- [ ] **Step 2: Run lint and type-check (invariant — should still pass)**
+
+Run:
+```bash
+ruff check . && mypy
+```
+
+Expected: both succeed with zero errors. (Neither tool reads `commands/*.md`, so this is a guard against accidentally modifying Python files alongside the markdown change.)
+
+- [ ] **Step 3: Confirm no Python files were touched**
+
+Run:
+```bash
+git diff --stat main
+```
+
+Expected: a single file (`commands/jared-start.md`) appears in the diffstat. If anything else is listed, investigate before continuing.
+
+- [ ] **Step 4: Confirm the new step references resolve internally**
+
+Run:
+```bash
+grep -nE 'step [0-9]' commands/jared-start.md
+```
+
+Expected output (line numbers approximate):
+- `... output the **posture block** (see step 6) followed by:` (Step 1's drift-case branch references step 6).
+- `Wait for user input, then resume the flow at step 2 with the user-supplied issue.` (Step 1's drift-case branch references step 2).
+- `When a prompt was found in step 1, prepend a **posture block**:` (Step 6 references step 1).
+- `The posture block is omitted when no prompt was found in step 1.` (Step 6 references step 1).
+
+If the references in the rendered file mismatch (e.g., `step 5` instead of `step 6`), fix before committing.
+
+---
+
+### Task 4: Commit and open PR
+
+**Files:**
+- (commit + push + PR — git operations against the modified file)
+
+- [ ] **Step 1: Stage and commit**
+
+Run:
+```bash
+git add commands/jared-start.md
+git commit -m "$(cat <<'EOF'
+feat(commands): /jared-start picks up most recent handoff prompt
+
+Closes #44.
+
+`/jared-start` now globs `tmp/next-session-prompt-*.md`, lex-sorts by
+filename timestamp, and surfaces the most recent prompt's synthesis
+(Frame, anti-targets, context pointers) as a posture block above the
+existing per-issue announcement.
+
+When `$ARGUMENTS` is empty and the prompt has a parseable `## To start`,
+that issue is used as the target — drift-checked first via
+`jared get-item`. Closed/Done recommendations surface the posture block
+plus a drift line and ask which issue to pull, never silently routing
+to a stale recommendation. When `$ARGUMENTS` is non-empty, the user's
+choice wins; the posture block is still surfaced because the synthesis
+is cross-issue.
+
+Spec: docs/superpowers/specs/2026-04-26-jared-start-handoff-pickup-design.md
+Plan: docs/superpowers/plans/2026-04-26-jared-start-handoff-pickup.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds; one file changed.
+
+- [ ] **Step 2: Push the branch**
+
+Run:
+```bash
+git push -u origin feature/44-jared-start-handoff-pickup
+```
+
+Expected: branch published, upstream tracking set.
+
+- [ ] **Step 3: Open the PR**
+
+Run:
+```bash
+gh pr create --base main --title "feat(commands): /jared-start picks up most recent handoff prompt (#44)" --body "$(cat <<'EOF'
+## Summary
+- `/jared-start` now picks up the most recent `tmp/next-session-prompt-*.md` and surfaces its synthesis (Frame, anti-targets, context pointers) as a Handoff posture block above the existing per-issue announcement.
+- When no `$ARGUMENTS` is given and the prompt has a parseable `## To start`, that issue is used — drift-checked via `jared get-item`. Closed/Done recommendations surface the posture and ask which issue to pull instead of silently routing.
+- When `$ARGUMENTS` is given, the user's choice wins; the posture block is still surfaced.
+- No Python changes, no test changes — this is a doc-as-code edit to the slash-command template.
+
+Closes #44.
+
+Spec: `docs/superpowers/specs/2026-04-26-jared-start-handoff-pickup-design.md`
+Plan: `docs/superpowers/plans/2026-04-26-jared-start-handoff-pickup.md`
+
+## Test plan
+- [ ] Read `commands/jared-start.md` end-to-end; confirm 7 numbered steps, internal step references resolve, no broken anchors.
+- [ ] `ruff check . && mypy` — invariant, should pass.
+- [ ] Live (post-merge): in a fresh Claude Code session with `tmp/next-session-prompt-2026-04-26-XXXX.md` present, run `/jared-start` (no args). Confirm the posture block renders, the recommended issue is drift-checked, and either the existing flow continues or the drift fallback fires.
+- [ ] Live (post-merge): `/jared-start <N>` with a prompt present. Confirm posture block renders; drift check is skipped; flow runs on `<N>`.
+- [ ] Live (post-merge): `/jared-start` with no prompt in `tmp/`. Confirm fallback "ask which issue" behavior is unchanged from prior.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR created, URL printed. Capture the URL for the user.
+
+- [ ] **Step 4: Surface the PR URL**
+
+Print the PR URL to the user as the final action of this plan. The user will run live verification scenarios in a fresh Claude Code session before merging.
+
+---
+
+## Self-review notes (already applied)
+
+- **Spec coverage:** All 7 acceptance criteria from the spec map to behavior in the new Step 1 and the modified Step 6. The `## To start`-missing edge case is handled in Step 1's last bullet ("When a prompt was found but had no parseable `## To start`, the posture block is still surfaced in step 6").
+- **Placeholder scan:** Every code block contains the actual target text. No `TBD` / `TODO` / "implement later" markers. The "Live (post-merge)" Test plan items are deliberately deferred to the user, not the implementing agent — the live scenario requires a fresh Claude Code session, which the plan-executing agent cannot manufacture.
+- **Step references:** All `step N` mentions in the target text use the new numbering (1–7). Verified in Task 3 Step 4 with a grep.
+- **Type / signature consistency:** No types or function signatures involved (markdown only). The `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared` invocations match the pattern used elsewhere in the file.

--- a/docs/superpowers/specs/2026-04-26-jared-start-handoff-pickup-design.md
+++ b/docs/superpowers/specs/2026-04-26-jared-start-handoff-pickup-design.md
@@ -1,0 +1,119 @@
+# `/jared-start` — handoff-prompt pickup
+
+**Date:** 2026-04-26
+**Status:** Draft
+**Scope:** Consumer-side change to `commands/jared-start.md`. Producer (`/jared-wrap`) is untouched.
+
+## Problem
+
+`/jared-wrap` produces a rich session-handoff prompt at `tmp/next-session-prompt-<YYYY-MM-DD-HHMM>.md` containing cross-issue synthesis (Frame, anti-targets, context pointers, recommended-issue `## To start`). The producer was designed so the next session ingests this prompt at start. Today the only mechanism to ingest it is for the user to manually pipe the prompt content into the next session's first turn — `/jared-start` itself does not look for it.
+
+This means the synthesis that `/jared-wrap` carefully produces is routinely discarded. Sessions that begin with a bare `/jared-start <N>` lose the cross-issue posture (what's load-bearing, what NOT to do, what shipped) that the producer side spent compute to generate.
+
+## Goal
+
+`/jared-start` should look for the most recent handoff prompt and, if found, surface its synthesis as a "Handoff posture" block above the existing per-issue announcement, and (when no explicit issue argument is given) honor the prompt's `## To start` recommendation — with a drift check so a stale recommendation never silently routes the session to a closed/done issue.
+
+## Non-goals
+
+- **No producer-side changes.** `/jared-wrap` continues to write `tmp/next-session-prompt-*.md` exactly as today.
+- **No CLI subcommand.** This is pure command-prompt template logic. The model executing `/jared-start` already has bash + glob + Read; no new `jared` subcommand is warranted.
+- **No authoritative status promotion.** The prompt remains derived state. Session notes, issues, plans, and memory remain the durable record. The posture block is a synthesis surface, not a decision log.
+- **No replacement of the existing per-issue context load.** Step 4 of the current flow (issue body, latest Session note, linked plan/spec, git state) runs unchanged.
+
+## Behavior
+
+At the top of `/jared-start`, before the existing WIP-cap check (current Step 1):
+
+### Step 0 — look for the most recent handoff prompt
+
+1. Glob `tmp/next-session-prompt-*.md`.
+2. If `tmp/` doesn't exist or no matches: set `prompt = None`, proceed.
+3. Otherwise lex-sort filenames descending, take the first. The filename's `YYYY-MM-DD-HHMM` is monotonic, so lex order matches chronological order. Set `prompt = <path>`.
+
+### Branch table
+
+| Prompt found? | `$ARGUMENTS` given? | Action |
+|---|---|---|
+| No | No | Existing behavior — ask which issue. |
+| No | Yes | Existing flow on `$ARGUMENTS`. |
+| Yes | No | Parse `## To start` for `/jared-start <N>`. **Drift-check** that issue. If pullable, run existing flow on it. If drifted (closed or Status=Done), surface posture + drift message and ask the user which issue to pull. |
+| Yes | Yes | Run existing flow on `$ARGUMENTS`. Surface posture block above the per-issue announcement. No drift check (user picked their own issue). |
+
+### Drift check
+
+Only fires when the prompt's recommendation would be used (no `$ARGUMENTS`, prompt found). Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared get-item <N>` on the prompt's recommended issue. Drift conditions:
+
+- Issue is closed on GitHub.
+- Issue Status is `Done`.
+
+On drift: do **not** silently fall back. Print:
+
+```
+Handoff prompt recommends #<N>, but #<N> is now <closed|Done>.
+The prompt's posture is still useful context for whatever you pull next:
+
+<full posture block — Frame, anti-targets, context pointers>
+
+Which issue would you like to pull?
+```
+
+Then wait for user input. The prompt's body is still rendered because its synthesis (anti-targets, context pointers) is cross-issue and remains relevant even when its `## To start` recommendation is stale.
+
+### Posture-block layout
+
+When prompt is found and being surfaced (any cell with "Yes" in the prompt-found column):
+
+```
+Handoff posture (tmp/next-session-prompt-<TIMESTAMP>.md, <relative-time>):
+  Frame: <Frame paragraph, condensed to 2-3 sentences if needed>
+  Anti-targets:
+    - <bullet from "What NOT to do">
+    - <...>
+  Context pointers:
+    - <bullet from "Context you'll need">
+    - <...>
+
+Starting #<N>: <title>
+  [existing per-issue announcement, unchanged]
+```
+
+Two visually-separated blocks: cross-issue posture above, issue-specific below.
+
+### Parsing rules
+
+- **Most recent prompt:** `glob tmp/next-session-prompt-*.md`, lex-sort descending, take `[0]`. Empty match set → no prompt found.
+- **Recommended issue:** in the prompt body, locate the section `## To start`. Within that section, find a fenced code block containing a line matching `/jared-start\s+(\d+)`. If no match: log "Handoff prompt has no `## To start` recommendation" and treat the prompt-found-no-args case as if no prompt were found (ask which issue), but still surface the posture block.
+- **Frame:** read the section under `## Frame`. Condense to 2–3 sentences if longer; never fabricate.
+- **Anti-targets:** read the section under `## What NOT to do`. Render as bullets. Empty if the section is empty.
+- **Context pointers:** read the section under `## Context you'll need`. Render as bullets. Empty if the section is empty.
+- **Missing sections:** omit the corresponding line from the posture block. Do not fabricate.
+- **Relative time:** parse the filename's `YYYY-MM-DD-HHMM` and render relative to now ("6h ago", "yesterday", "3d ago"). On parse failure, fall back to the raw absolute timestamp.
+
+## Files affected
+
+- `commands/jared-start.md` — primary edit. Insert Step 0 (look for prompt) at the top of the flow. Thread the posture block into Step 5's announcement template. Document the drift-check branch.
+- No CLI changes. The command file is the model's contract; the model executes the lookup with its existing bash + Read tools.
+- No test changes. The command file is documentation for the model; nothing in the Python suite tests prompt content.
+
+## Risks and mitigations
+
+- **Prompt synthesis drift.** The prompt could go stale across multiple sessions if `/jared-wrap` isn't run. Mitigation: the relative-time display ("3d ago") makes staleness visible; the user/agent can decide whether to trust it.
+- **Prompt's `## To start` recommends an issue that's been reshaped/abandoned but not closed.** The drift check only catches Closed/Done. A reshaped issue that's still Open + Up Next will pass the drift check; the existing pullable-check at Step 2 of the original flow will then catch any pullable-criteria failure (missing acceptance criteria, unmet `Depends on`). Mitigation: defer to Step 2's pullable-check; this is the correct layer for that concern.
+- **Multiple prompts in `tmp/` from old sessions.** Lex-sort by filename timestamp picks the newest. Old prompts remain on disk (gitignored, ephemeral) and are harmless.
+- **Parser fragility.** Section-header regex assumes the producer's template structure. Mitigation: when a section is missing, omit that line — never block or fabricate. The producer template is in `assets/next-session-prompt.md.template`; if it changes, the parser tolerates absence gracefully.
+
+## Out of scope (explicitly)
+
+- A `--no-handoff` flag to suppress the posture block. Not warranted yet; if the synthesis is irrelevant the user can ignore it.
+- Cleaning up old prompts in `tmp/`. They're gitignored and ephemeral; no automatic cleanup is needed.
+- Surfacing the posture block on `/jared` (status command). Different command, different surface; out of scope for this change.
+
+## Acceptance criteria
+
+- `/jared-start` with no args and a recent `tmp/next-session-prompt-*.md` containing a parseable `## To start` reads that file, drift-checks the recommended issue, and runs the existing flow on it (or asks on drift).
+- `/jared-start` with no args and no prompt available falls back to the current "ask which issue" behavior.
+- `/jared-start <N>` with a recent prompt available surfaces the posture block above the per-issue announcement, on the user-specified issue, with no drift check.
+- `/jared-start <N>` with no prompt available behaves identically to today.
+- Drift case (prompt recommends a Closed/Done issue) prints the posture block, the drift line, and asks the user which issue to pull. It does NOT silently fall through.
+- Missing prompt sections (no `## Frame`, no anti-targets, no `## To start` line) are tolerated: corresponding lines are omitted, no fabrication, no error.


### PR DESCRIPTION
## Summary
- `/jared-start` now picks up the most recent `tmp/next-session-prompt-*.md` and surfaces its synthesis (Frame, anti-targets, context pointers) as a Handoff posture block above the existing per-issue announcement.
- When no `$ARGUMENTS` is given and the prompt has a parseable `## To start`, that issue is used — drift-checked via `jared get-item`. Closed/Done recommendations surface the posture and ask which issue to pull instead of silently routing.
- When `$ARGUMENTS` is given, the user's choice wins; the posture block is still surfaced.
- No Python changes, no test changes — this is a doc-as-code edit to the slash-command template.

Closes #44.

Spec: `docs/superpowers/specs/2026-04-26-jared-start-handoff-pickup-design.md`
Plan: `docs/superpowers/plans/2026-04-26-jared-start-handoff-pickup.md`

## Test plan
- [x] Read `commands/jared-start.md` end-to-end; confirmed 7 numbered steps, internal step references resolve, no broken anchors.
- [x] `ruff check . && mypy` — invariant, passes.
- [ ] Live (post-merge): in a fresh Claude Code session with `tmp/next-session-prompt-2026-04-26-XXXX.md` present, run `/jared-start` (no args). Confirm the posture block renders, the recommended issue is drift-checked, and either the existing flow continues or the drift fallback fires.
- [ ] Live (post-merge): `/jared-start <N>` with a prompt present. Confirm posture block renders; drift check is skipped; flow runs on `<N>`.
- [ ] Live (post-merge): `/jared-start` with no prompt in `tmp/`. Confirm fallback "ask which issue" behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)