### PR TITLE
chore(release): v0.6.0 — /jared-start handoff-prompt pickup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.5.0"
+version = "0.6.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## v0.6.0

### Highlights
- **`/jared-start` now picks up the most recent handoff prompt** (#44, PR #45). Globs `tmp/next-session-prompt-*.md`, lex-sorts by filename timestamp, and surfaces the most recent prompt's synthesis (Frame, anti-targets, context pointers) as a Handoff posture block above the per-issue announcement.
- When no `\$ARGUMENTS` is given and the prompt has a parseable `## To start`, that issue is used as the target — drift-checked first via `jared get-item`. Closed/Done recommendations surface the posture plus a drift line and ask which issue to pull instead of silently routing to a stale recommendation.
- When `\$ARGUMENTS` is given, the user's choice wins; the posture block is still surfaced because the synthesis is cross-issue.

### Compatibility
- Backward-compatible. Behavior is unchanged when no prompt is present in `tmp/` or when `\$ARGUMENTS` is given without a prompt.
- No CLI subcommand changes, no Python changes, no test suite changes.

## Test plan
- [x] `ruff check . && mypy && pytest` — all green.
- [ ] Live smoke after `/plugin update jared` + `/reload-plugins`: run `/jared-start` in a fresh session with a prompt present in `tmp/` and confirm the posture block renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)