### PR TITLE
perf: cut GraphQL rate-limit pressure (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ tests/testbed.env
 # Per-user Claude Code permissions (not versioned)
 .claude/settings.local.json
 
+# Per-user Claude Code project memory (private, not versioned)
+CLAUDE.local.md
+
+# uv lockfile — venv tooling is pip-based per CLAUDE.md; uv usage is incidental
+uv.lock
+
 # Local venv
 .venv/
 

--- a/skills/jared/scripts/dependency-graph.py
+++ b/skills/jared/scripts/dependency-graph.py
@@ -40,6 +40,9 @@ from lib.board import (
     check_graphql_budget as board_check_graphql_budget,
 )
 from lib.board import (
+    fetch_blocked_by_edges as board_fetch_blocked_by_edges,
+)
+from lib.board import (
     graphql_budget as board_graphql_budget,
 )
 from lib.board import (
@@ -75,48 +78,27 @@ def fetch_issue_state(repo: str, number: int) -> str:
         return "UNKNOWN"
 
 
-def fetch_native_dependencies(repo: str, number: int) -> list[int] | None:
-    """Fetch native blockedBy edges (what this issue is blocked by).
+def fetch_all_native_dependencies(repo: str) -> dict[int, list[int]] | None:
+    """Fetch native blockedBy edges for ALL open issues in one paginated call.
 
-    Returns a list of OPEN dependency numbers on success, or None if the
-    GraphQL call fails (e.g. the repo doesn't have native dependencies
-    enabled). Callers should treat None as "no native data — fall back to
-    body conventions" and an empty list as "native says no dependencies."
+    Returns `{issue_number: [open_blocker_numbers]}` (closed-state blockers
+    are filtered out — the dep-graph only cares about live edges). Returns
+    None if the underlying GraphQL call fails entirely (e.g. the repo
+    doesn't have native dependencies enabled). Callers treat None as
+    "fall back to body-text parsing" and missing-key as "no native data
+    for this issue."
+
+    Replaces the old per-issue call (which made one GraphQL request per
+    open issue — O(N) instead of O(pages)).
     """
-    query = """
-    query($owner: String!, $repo: String!, $number: Int!) {
-      repository(owner: $owner, name: $repo) {
-        issue(number: $number) {
-          blockedBy(first: 50) {
-            nodes { number state }
-          }
-        }
-      }
-    }
-    """
-    owner, name = repo.split("/", 1)
     try:
-        result = board_run_gh(
-            [
-                "api",
-                "graphql",
-                "-f",
-                f"query={query}",
-                "-F",
-                f"owner={owner}",
-                "-F",
-                f"repo={name}",
-                "-F",
-                f"number={number}",
-            ]
-        )
-    except GhInvocationError:
+        edges = board_fetch_blocked_by_edges(repo, cache="60s")
+    except (GhInvocationError, RuntimeError):
         return None
-    issue = result.get("data", {}).get("repository", {}).get("issue")
-    if issue is None:
-        return None
-    deps = (issue.get("blockedBy") or {}).get("nodes", [])
-    return [d["number"] for d in deps if d.get("state") == "OPEN"]
+    return {
+        issue_n: [d["number"] for d in deps if d.get("state") == "OPEN"]
+        for issue_n, deps in edges.items()
+    }
 
 
 # ---------- Body parsing ----------
@@ -353,6 +335,14 @@ def main() -> int:
     issues_by_number = {i["number"]: i for i in issues}
     open_numbers = set(issues_by_number.keys())
 
+    # Pre-fetch ALL native dependency edges for the repo in one paginated
+    # GraphQL call instead of one per issue. None means the GraphQL call
+    # failed entirely; any per-issue lookup miss means no native data for
+    # that issue (treat as fall-back-to-body, same as before).
+    all_native: dict[int, list[int]] | None = None
+    if not args.no_native:
+        all_native = fetch_all_native_dependencies(args.repo)
+
     # Build graph: N → set of issues N depends on
     graph: dict[int, set[int]] = defaultdict(set)
     priorities: dict[int, str] = {}
@@ -363,12 +353,12 @@ def main() -> int:
         # may contain narrative prose ("#10 — shipped, #12 — critical path"),
         # so treat them as a fallback only when native has nothing for this
         # issue — either the API call failed (None) or returned no edges ([]).
-        native = None
-        if not args.no_native:
-            try:
-                native = fetch_native_dependencies(args.repo, n)
-            except Exception:
-                native = None
+        # Missing key in all_native means no native data for this issue
+        # (e.g. milestone-filtered out, or issue isn't in the open-issues
+        # state set). Treat as None — body-text fallback may still find edges.
+        native: list[int] | None = (
+            None if args.no_native or all_native is None else all_native.get(n)
+        )
 
         if native:
             for dep in native:

--- a/skills/jared/scripts/dependency-graph.py
+++ b/skills/jared/scripts/dependency-graph.py
@@ -37,6 +37,12 @@ from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     GhInvocationError,
 )
 from lib.board import (
+    check_graphql_budget as board_check_graphql_budget,
+)
+from lib.board import (
+    graphql_budget as board_graphql_budget,
+)
+from lib.board import (
     run_gh as board_run_gh,
 )
 
@@ -307,7 +313,30 @@ def main() -> int:
         action="store_true",
         help="Skip native issue dependency lookups",
     )
+    parser.add_argument(
+        "--min-budget",
+        type=int,
+        default=200,
+        help="Skip if remaining GraphQL budget is below this (default: 200)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Run even if GraphQL budget is below --min-budget",
+    )
     args = parser.parse_args()
+
+    # Pre-flight GraphQL budget gate. Building the dep-graph fans out
+    # GraphQL calls; bail out early when budget can't cover the work.
+    try:
+        budget = board_graphql_budget()
+    except (RuntimeError, GhInvocationError) as e:
+        print(f"dependency-graph: budget probe failed ({e}); proceeding anyway", file=sys.stderr)
+    else:
+        warning = board_check_graphql_budget(budget, min_required=args.min_budget, force=args.force)
+        if warning:
+            print(f"dependency-graph: {warning}", file=sys.stderr)
+            return 0
 
     print(
         f"Fetching open issues from {args.repo}"

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -148,24 +148,11 @@ def _cmd_get_item(args: argparse.Namespace) -> int:
     board = Board.from_path(Path(args.board))
     item_id = board.find_item_id(args.issue_number)
 
-    data = board.run_gh(
-        [
-            "project",
-            "item-list",
-            str(board.project_number),
-            "--owner",
-            board.owner,
-            "--limit",
-            "500",
-            "--format",
-            "json",
-        ]
-    )
     empty: dict[str, Any] = {}
     match: dict[str, Any] = next(
         (
             item
-            for item in data.get("items", [])
+            for item in board.board_items()
             if (item.get("content") or {}).get("number") == args.issue_number
         ),
         empty,

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import re
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -294,6 +296,9 @@ class Board:
     ) -> Any:
         return run_graphql(query, cache=cache, **variables)
 
+    def graphql_budget(self) -> tuple[int, int, int]:
+        return graphql_budget()
+
 
 def run_gh(args: list[str], *, cache: str | None = None) -> Any:
     """Run a `gh` subcommand and parse its stdout as JSON (empty → {})."""
@@ -359,9 +364,57 @@ def _infer_repo_from_git(repo_root: Path) -> str | None:
     return f"{m.group(1)}/{m.group(2)}"
 
 
-def run_graphql(
-    query: str, *, cache: str | None = None, **variables: str | int | bool
-) -> Any:
+def graphql_budget() -> tuple[int, int, int]:
+    """Return `(remaining, limit, reset_unix)` from `gh api rate_limit`.
+
+    Polls a REST endpoint that does NOT draw from the GraphQL bucket,
+    so it remains usable even when the GraphQL budget is exhausted.
+    Used as a pre-flight probe by heavy GraphQL-bound scripts so they
+    can soft-fail with a useful message instead of crashing mid-run.
+    """
+    data = run_gh(["api", "rate_limit"])
+    gql = data.get("resources", {}).get("graphql", {})
+    return (
+        int(gql.get("remaining", 0)),
+        int(gql.get("limit", 5000)),
+        int(gql.get("reset", 0)),
+    )
+
+
+def check_graphql_budget(
+    budget: tuple[int, int, int],
+    *,
+    min_required: int = 200,
+    force: bool = False,
+) -> str | None:
+    """Return a warning string if budget is too low to proceed; else None.
+
+    `budget` is the `(remaining, limit, reset_unix)` tuple from
+    `graphql_budget()`. Heavy scripts call this before doing real work:
+
+        warning = check_graphql_budget(graphql_budget(), min_required=200)
+        if warning:
+            print(warning, file=sys.stderr)
+            return 0
+
+    `force=True` suppresses the gate (returns None even if budget is low),
+    for users who explicitly want to spend the remaining points. The
+    message includes both the absolute reset clock and minutes-from-now
+    so it reads cleanly in interactive output.
+    """
+    remaining, limit, reset = budget
+    if force or remaining >= min_required:
+        return None
+    reset_dt = dt.datetime.fromtimestamp(reset, tz=dt.UTC)
+    minutes = max(0, int((reset - time.time()) / 60))
+    return (
+        f"GraphQL budget low: {remaining}/{limit} remaining; "
+        f"resets at {reset_dt:%H:%M UTC} (~{minutes} min). "
+        f"Run with --force to override."
+    )
+
+
+def run_graphql(query: str, *, cache: str | None = None, **variables: str | int | bool) -> Any:
     """Run a GraphQL query via `gh api graphql` with named variables.
 
     Uses gh's `-F` for bool/int (so gh casts to the right type) and `-f`

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -41,6 +41,9 @@ class Board:
     _field_options: dict[str, dict[str, str]] = field(default_factory=dict)
     session_handoff_prompt: str = "ask"
     session_start_checks: list[str] = field(default_factory=list)
+    # Cached `gh project item-list` result, populated on first board_items()
+    # call and reused for the lifetime of this instance. None means uncached.
+    _items: list[dict[str, Any]] | None = field(default=None, repr=False)
 
     @classmethod
     def from_path(cls, path: Path) -> Board:
@@ -241,22 +244,43 @@ class Board:
     def run_gh_raw(self, args: list[str]) -> str:
         return run_gh_raw(args)
 
+    def board_items(self) -> list[dict[str, Any]]:
+        """Cached `gh project item-list` result for this Board instance.
+
+        Refreshes on first call; subsequent calls reuse the in-memory copy
+        for the rest of the process. Callers that mutate the board within
+        the same process must call `invalidate_items()` before reading
+        again, or stale entries will leak through.
+
+        `gh project item-list` is GraphQL-billed, so reusing the snapshot
+        is what saves the points — not just the wall-clock time.
+        """
+        if self._items is None:
+            data = self.run_gh(
+                [
+                    "project",
+                    "item-list",
+                    str(self.project_number),
+                    "--owner",
+                    self.owner,
+                    "--limit",
+                    "500",
+                    "--format",
+                    "json",
+                ]
+            )
+            self._items = data.get("items", [])
+        # Narrow Optional after the populate-if-None branch above.
+        assert self._items is not None
+        return self._items
+
+    def invalidate_items(self) -> None:
+        """Drop the cached snapshot. Next `board_items()` call re-fetches."""
+        self._items = None
+
     def find_item_id(self, issue_number: int) -> str:
         """Look up the ProjectV2Item id for a given issue number on this board."""
-        data = self.run_gh(
-            [
-                "project",
-                "item-list",
-                str(self.project_number),
-                "--owner",
-                self.owner,
-                "--limit",
-                "500",
-                "--format",
-                "json",
-            ]
-        )
-        for item in data.get("items", []):
+        for item in self.board_items():
             content = item.get("content") or {}
             if content.get("number") == issue_number:
                 return str(item["id"])

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -364,6 +364,55 @@ def _infer_repo_from_git(repo_root: Path) -> str | None:
     return f"{m.group(1)}/{m.group(2)}"
 
 
+def fetch_blocked_by_edges(
+    repo: str,
+    *,
+    cache: str | None = None,
+) -> dict[int, list[dict[str, Any]]]:
+    """One paginated GraphQL call → `{issue_number: [{number, state}]}` for all
+    open issues in `repo`. Replaces the per-issue N+1 pattern that
+    `dependency-graph.py` used to use.
+
+    Tries the `blockedBy` field first; on a schema error (older repos
+    expose `issueDependencies` under a different name) falls back to
+    `issueDependencies`. Raises if neither is available.
+
+    `cache` is forwarded to gh as `--cache <duration>` — pass "60s" for
+    advisory uses (sweep, dependency-graph) so re-runs within a minute
+    skip the network and the GraphQL points entirely.
+    """
+    owner, name = repo.split("/", 1)
+    for field_name in ("blockedBy", "issueDependencies"):
+        q = (
+            "query($o:String!,$r:String!,$c:String){repository(owner:$o,name:$r){"
+            f"issues(first:100,after:$c,states:OPEN){{pageInfo{{hasNextPage endCursor}}"
+            f"nodes{{number {field_name}(first:20){{nodes{{number state}}}}}}}}}}}}"
+        )
+        result: dict[int, list[dict[str, Any]]] = {}
+        cursor: str | None = None
+        try:
+            while True:
+                kwargs: dict[str, str] = {"o": owner, "r": name}
+                if cursor:
+                    kwargs["c"] = cursor
+                data = run_graphql(q, cache=cache, **kwargs)["data"]["repository"]["issues"]
+                for node in data["nodes"]:
+                    result[node["number"]] = node[field_name]["nodes"]
+                if not data["pageInfo"]["hasNextPage"]:
+                    break
+                cursor = data["pageInfo"]["endCursor"]
+            return result
+        except GhInvocationError as e:
+            # Schema may expose `issueDependencies` instead of `blockedBy`.
+            # Match the gh error verbiage loosely so future GraphQL phrasing
+            # changes don't silently bypass the fallback.
+            msg = str(e)
+            if "Field" in msg and ("doesn" in msg or "isn't" in msg):
+                continue
+            raise
+    raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
+
+
 def graphql_budget() -> tuple[int, int, int]:
     """Return `(remaining, limit, reset_unix)` from `gh api rate_limit`.
 

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -238,11 +238,11 @@ class Board:
             )
         return options[option]
 
-    def run_gh(self, args: list[str]) -> Any:
-        return run_gh(args)
+    def run_gh(self, args: list[str], *, cache: str | None = None) -> Any:
+        return run_gh(args, cache=cache)
 
-    def run_gh_raw(self, args: list[str]) -> str:
-        return run_gh_raw(args)
+    def run_gh_raw(self, args: list[str], *, cache: str | None = None) -> str:
+        return run_gh_raw(args, cache=cache)
 
     def board_items(self) -> list[dict[str, Any]]:
         """Cached `gh project item-list` result for this Board instance.
@@ -289,13 +289,15 @@ class Board:
             f"{self.project_number}. Is the issue added to the board?"
         )
 
-    def run_graphql(self, query: str, **variables: str | int | bool) -> Any:
-        return run_graphql(query, **variables)
+    def run_graphql(
+        self, query: str, *, cache: str | None = None, **variables: str | int | bool
+    ) -> Any:
+        return run_graphql(query, cache=cache, **variables)
 
 
-def run_gh(args: list[str]) -> Any:
+def run_gh(args: list[str], *, cache: str | None = None) -> Any:
     """Run a `gh` subcommand and parse its stdout as JSON (empty → {})."""
-    stdout = run_gh_raw(args)
+    stdout = run_gh_raw(args, cache=cache)
     if not stdout:
         return {}
     try:
@@ -304,14 +306,21 @@ def run_gh(args: list[str]) -> Any:
         raise GhInvocationError(f"gh returned non-JSON output: {stdout[:200]}") from e
 
 
-def run_gh_raw(args: list[str]) -> str:
+def run_gh_raw(args: list[str], *, cache: str | None = None) -> str:
     """Run a `gh` subcommand and return its stdout (stripped) without JSON parsing.
 
     Some gh commands return plain text (e.g. `gh issue create` prints a URL).
     Callers that need the raw string use this; JSON responses use run_gh.
+
+    `cache` is passed to gh as `--cache <duration>`. Only meaningful for
+    `gh api ...` calls (including `gh api graphql`); other subcommands
+    will reject the flag. Caller's responsibility to use it appropriately.
     """
+    full_args = ["gh", *args]
+    if cache is not None:
+        full_args.extend(["--cache", cache])
     result = subprocess.run(
-        ["gh", *args],
+        full_args,
         capture_output=True,
         text=True,
         check=False,
@@ -350,14 +359,19 @@ def _infer_repo_from_git(repo_root: Path) -> str | None:
     return f"{m.group(1)}/{m.group(2)}"
 
 
-def run_graphql(query: str, **variables: str | int | bool) -> Any:
+def run_graphql(
+    query: str, *, cache: str | None = None, **variables: str | int | bool
+) -> Any:
     """Run a GraphQL query via `gh api graphql` with named variables.
 
     Uses gh's `-F` for bool/int (so gh casts to the right type) and `-f`
     for strings. Results come back parsed from JSON.
+
+    `cache` enables gh's HTTP-level response cache (`gh api --cache <dur>`).
+    Use only on read-only queries; mutation callers must leave it None.
     """
     args = ["api", "graphql", "-f", f"query={query}"]
     for name, value in variables.items():
         flag = "-F" if isinstance(value, bool | int) and not isinstance(value, str) else "-f"
         args.extend([flag, f"{name}={value}"])
-    return run_gh(args)
+    return run_gh(args, cache=cache)

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -55,6 +55,12 @@ from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     GhInvocationError,
 )
 from lib.board import (
+    check_graphql_budget as board_check_graphql_budget,
+)
+from lib.board import (
+    graphql_budget as board_graphql_budget,
+)
+from lib.board import (
     run_gh as board_run_gh,
 )
 from lib.board import (
@@ -294,8 +300,7 @@ def format_closed_not_done_line(entry: dict[str, Any]) -> str:
     """
     n = entry["number"]
     return (
-        f"#{n} [{entry['current_status']}]: {entry['title']} — "
-        f"Propose: jared set {n} Status Done"
+        f"#{n} [{entry['current_status']}]: {entry['title']} — Propose: jared set {n} Status Done"
     )
 
 
@@ -545,7 +550,31 @@ def main() -> int:
         default=7,
         help="Flag Blocked-status items with no activity beyond this (default: 7)",
     )
+    parser.add_argument(
+        "--min-budget",
+        type=int,
+        default=200,
+        help="Skip the sweep if remaining GraphQL budget is below this (default: 200)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Run the sweep even if GraphQL budget is below --min-budget",
+    )
     args = parser.parse_args()
+
+    # Pre-flight GraphQL budget gate. The sweep makes many GraphQL-billed
+    # calls; bailing out early with a useful message beats crashing with
+    # `API rate limit exceeded` partway through producing output.
+    try:
+        budget = board_graphql_budget()
+    except (RuntimeError, GhInvocationError) as e:
+        print(f"sweep: budget probe failed ({e}); proceeding anyway", file=sys.stderr)
+    else:
+        warning = board_check_graphql_budget(budget, min_required=args.min_budget, force=args.force)
+        if warning:
+            print(f"sweep: {warning}", file=sys.stderr)
+            return 0
 
     # Resolve owner/project
     if not args.owner or not args.project:

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -58,6 +58,9 @@ from lib.board import (
     check_graphql_budget as board_check_graphql_budget,
 )
 from lib.board import (
+    fetch_blocked_by_edges as board_fetch_blocked_by_edges,
+)
+from lib.board import (
     graphql_budget as board_graphql_budget,
 )
 from lib.board import (
@@ -65,9 +68,6 @@ from lib.board import (
 )
 from lib.board import (
     run_gh_raw as board_run_gh_raw,
-)
-from lib.board import (
-    run_graphql as board_run_graphql,
 )
 
 # ---------- Config discovery ----------
@@ -98,12 +98,12 @@ def find_config() -> Path | None:
 
 # ---------- gh wrappers ----------
 #
-# Uses module-level helpers from lib/board.py (board_run_gh / board_run_gh_raw /
-# board_run_graphql). These handle subprocess invocation, error raising, and
-# JSON parsing uniformly across every jared script — sweep.py doesn't need a
-# full Board instance because it only extracts owner + project-number from the
-# convention doc (see parse_config). It reads field values from the gh JSON
-# response, not field IDs from the convention doc.
+# Uses module-level helpers from lib/board.py (board_run_gh / board_run_gh_raw).
+# Higher-level GraphQL calls (paginated blockedBy lookup) live in lib.board so
+# dependency-graph.py can share them. sweep.py doesn't need a full Board
+# instance — it only extracts owner + project-number from the convention doc
+# (see parse_config) and reads field values from gh JSON, not field IDs from
+# the convention doc.
 
 
 def fetch_items(owner: str, project: str) -> list[dict[str, Any]]:
@@ -143,37 +143,16 @@ def fetch_open_issues_bulk(repo: str) -> list[dict[str, Any]]:
 
 
 def fetch_native_blocked_by(repo: str) -> dict[int, list[dict[str, Any]]]:
-    """One GraphQL call to get blockedBy for all open issues. Returns {number: [{number, state}]}.
+    """Thin wrapper around lib.board.fetch_blocked_by_edges with a 60s cache.
 
-    Tries 'blockedBy' first; falls back to 'issueDependencies' on schema error.
+    Kept as a free function so existing sweep tests / callers don't need to
+    rewire imports — the real implementation lives in lib/board.py and is
+    shared with dependency-graph.py.
     """
-    owner, name = repo.split("/", 1)
-    for field_name in ("blockedBy", "issueDependencies"):
-        q = (
-            "query($o:String!,$r:String!,$c:String){repository(owner:$o,name:$r){"
-            f"issues(first:100,after:$c,states:OPEN){{pageInfo{{hasNextPage endCursor}}"
-            f"nodes{{number {field_name}(first:20){{nodes{{number state}}}}}}}}}}}}"
-        )
-        result: dict[int, list[dict[str, Any]]] = {}
-        cursor: str | None = None
-        try:
-            while True:
-                kwargs: dict[str, str] = {"o": owner, "r": name}
-                if cursor:
-                    kwargs["c"] = cursor
-                data = board_run_graphql(q, **kwargs)["data"]["repository"]["issues"]
-                for node in data["nodes"]:
-                    result[node["number"]] = node[field_name]["nodes"]
-                if not data["pageInfo"]["hasNextPage"]:
-                    break
-                cursor = data["pageInfo"]["endCursor"]
-            return result
-        except GhInvocationError as e:
-            # Schema may expose issueDependencies instead of blockedBy.
-            if "Field" in str(e) and "doesn" in str(e):
-                continue
-            raise
-    raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
+    return cast(
+        dict[int, list[dict[str, Any]]],
+        board_fetch_blocked_by_edges(repo, cache="60s"),
+    )
 
 
 def fetch_recent_comments(repo: str, number: int, limit: int = 5) -> list[dict[str, Any]]:

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -257,6 +257,100 @@ def test_find_item_id_finds_match(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
         b.find_item_id(123456)
 
 
+def test_board_items_caches_within_instance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """board_items() fetches once and reuses; second call must not re-shell out."""
+    from skills.jared.scripts.lib.board import Board
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    call_count = {"n": 0}
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"items": ['
+            '{"id": "PVTI_aaa", "content": {"number": 42}},'
+            '{"id": "PVTI_bbb", "content": {"number": 99}}'
+            "]}"
+        )
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        call_count["n"] += 1
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    first = b.board_items()
+    second = b.board_items()
+
+    assert call_count["n"] == 1, "board_items must cache after first call"
+    assert first is second
+    assert len(first) == 2
+
+
+def test_find_item_id_uses_cached_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Two find_item_id calls on the same Board must share one item-list fetch."""
+    from skills.jared.scripts.lib.board import Board
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    call_count = {"n": 0}
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"items": ['
+            '{"id": "PVTI_aaa", "content": {"number": 42}},'
+            '{"id": "PVTI_bbb", "content": {"number": 99}}'
+            "]}"
+        )
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        call_count["n"] += 1
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    assert b.find_item_id(42) == "PVTI_aaa"
+    assert b.find_item_id(99) == "PVTI_bbb"
+    assert call_count["n"] == 1, (
+        "find_item_id should reuse the snapshot — saw multiple item-list fetches"
+    )
+
+
+def test_invalidate_items_forces_refetch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """invalidate_items() drops the cache so the next read re-fetches."""
+    from skills.jared.scripts.lib.board import Board
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    call_count = {"n": 0}
+
+    class FakeResult:
+        returncode = 0
+        stdout = '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}}]}'
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: (call_count.update(n=call_count["n"] + 1) or FakeResult()),
+    )
+
+    b.board_items()
+    b.invalidate_items()
+    b.board_items()
+
+    assert call_count["n"] == 2
+
+
 def test_run_graphql_passes_query_and_vars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     from skills.jared.scripts.lib.board import Board
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -380,6 +380,69 @@ def test_run_graphql_passes_query_and_vars(monkeypatch: pytest.MonkeyPatch, tmp_
     assert "-F" in args and "number=7" in args
 
 
+def test_run_graphql_cache_flag_appends_when_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """run_graphql(cache='60s') appends `--cache 60s` to gh args; default omits it.
+
+    `gh api --cache <duration>` is GitHub CLI's HTTP-level response cache;
+    a hit avoids the network roundtrip *and* the GraphQL points. Opt-in
+    only (default None) so mutation callers don't accidentally cache.
+    """
+    from skills.jared.scripts.lib.board import Board
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = '{"data": {"ok": true}}'
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    b.run_graphql("query { ok }")
+    assert "--cache" not in captured[0], "default must not enable caching"
+
+    b.run_graphql("query { ok }", cache="60s")
+    last = captured[-1]
+    assert "--cache" in last and "60s" in last
+    cache_idx = last.index("--cache")
+    assert last[cache_idx + 1] == "60s"
+
+
+def test_run_gh_cache_flag_passthrough(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """run_gh(args, cache='5m') appends `--cache 5m` for direct gh api callers
+    (e.g. sweep.py's gh api repos/.../comments path)."""
+    from skills.jared.scripts.lib.board import Board
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = "[]"
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    b.run_gh(["api", "repos/owner/repo/issues/1/comments"], cache="5m")
+    args = captured[-1]
+    assert "--cache" in args and "5m" in args
+
+
 # Legacy board-doc fallbacks: older docs (pre-bootstrap-project.py) lack
 # the machine-readable bullet block, so the parser has to infer the header
 # fields from prose + git remote. These tests pin the fallback behavior

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 from textwrap import dedent
 
@@ -291,9 +292,7 @@ def test_board_items_caches_within_instance(
     assert len(first) == 2
 
 
-def test_find_item_id_uses_cached_snapshot(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_find_item_id_uses_cached_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Two find_item_id calls on the same Board must share one item-list fetch."""
     from skills.jared.scripts.lib.board import Board
 
@@ -324,9 +323,7 @@ def test_find_item_id_uses_cached_snapshot(
     )
 
 
-def test_invalidate_items_forces_refetch(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_invalidate_items_forces_refetch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """invalidate_items() drops the cache so the next read re-fetches."""
     from skills.jared.scripts.lib.board import Board
 
@@ -341,7 +338,7 @@ def test_invalidate_items_forces_refetch(
 
     monkeypatch.setattr(
         "skills.jared.scripts.lib.board.subprocess.run",
-        lambda *a, **kw: (call_count.update(n=call_count["n"] + 1) or FakeResult()),
+        lambda *a, **kw: call_count.update(n=call_count["n"] + 1) or FakeResult(),
     )
 
     b.board_items()
@@ -416,9 +413,62 @@ def test_run_graphql_cache_flag_appends_when_set(
     assert last[cache_idx + 1] == "60s"
 
 
-def test_run_gh_cache_flag_passthrough(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+def test_graphql_budget_parses_rate_limit_response(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """graphql_budget() pulls (remaining, limit, reset) from `gh api rate_limit`.
+
+    The endpoint returns a nested dict — the resource we care about is
+    `resources.graphql`. Numbers come back as ints regardless of how
+    gh's JSON encoded them.
+    """
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"resources": {"core": {"remaining": 4500},'
+            ' "graphql": {"remaining": 142, "limit": 5000, "reset": 1777643200}}}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    remaining, limit, reset = board.graphql_budget()
+    assert remaining == 142
+    assert limit == 5000
+    assert reset == 1777643200
+
+
+def test_check_graphql_budget_warns_when_low() -> None:
+    from skills.jared.scripts.lib.board import check_graphql_budget
+
+    msg = check_graphql_budget((50, 5000, int(time.time()) + 600), min_required=200)
+    assert msg is not None
+    assert "50" in msg and "5000" in msg
+    assert "--force" in msg
+
+
+def test_check_graphql_budget_proceeds_when_above_threshold() -> None:
+    from skills.jared.scripts.lib.board import check_graphql_budget
+
+    assert check_graphql_budget((1000, 5000, int(time.time()) + 600), min_required=200) is None
+
+
+def test_check_graphql_budget_force_overrides_low() -> None:
+    """force=True bypasses the gate even when budget is empty."""
+    from skills.jared.scripts.lib.board import check_graphql_budget
+
+    assert (
+        check_graphql_budget((0, 5000, int(time.time()) + 600), min_required=200, force=True)
+        is None
+    )
+
+
+def test_run_gh_cache_flag_passthrough(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """run_gh(args, cache='5m') appends `--cache 5m` for direct gh api callers
     (e.g. sweep.py's gh api repos/.../comments path)."""
     from skills.jared.scripts.lib.board import Board

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -493,6 +493,140 @@ def test_run_gh_cache_flag_passthrough(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert "--cache" in args and "5m" in args
 
 
+def test_fetch_blocked_by_edges_single_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One paginated GraphQL call → {number: [{number, state}]} for a small repo."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"data": {"repository": {"issues": {'
+            '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+            '"nodes": ['
+            '{"number": 10, "blockedBy": {"nodes": [{"number": 5, "state": "OPEN"}]}},'
+            '{"number": 11, "blockedBy": {"nodes": []}}'
+            "]}}}}"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    edges = board.fetch_blocked_by_edges("brockamer/findajob")
+    assert edges == {
+        10: [{"number": 5, "state": "OPEN"}],
+        11: [],
+    }
+
+
+def test_fetch_blocked_by_edges_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Helper walks `pageInfo.hasNextPage`; each page reuses the schema field name."""
+    from skills.jared.scripts.lib import board
+
+    page_responses = iter(
+        [
+            (
+                '{"data": {"repository": {"issues": {'
+                '"pageInfo": {"hasNextPage": true, "endCursor": "CUR1"},'
+                '"nodes": [{"number": 1, "blockedBy": {"nodes": []}}]'
+                "}}}}"
+            ),
+            (
+                '{"data": {"repository": {"issues": {'
+                '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+                '"nodes": [{"number": 2, "blockedBy": {"nodes": []}}]'
+                "}}}}"
+            ),
+        ]
+    )
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stderr = ""
+
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult(next(page_responses))
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    edges = board.fetch_blocked_by_edges("brockamer/findajob")
+    assert set(edges) == {1, 2}
+    # Two paginated calls, second one carries the cursor.
+    assert len(captured) == 2
+    assert any("c=CUR1" in arg for arg in captured[1])
+
+
+def test_fetch_blocked_by_edges_schema_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If `blockedBy` raises a Field-doesn't-exist error, retry with `issueDependencies`."""
+    from skills.jared.scripts.lib import board
+
+    call_responses = iter(
+        [
+            # First attempt — blockedBy not on this schema.
+            ("", 1, "Field 'blockedBy' doesn't exist on type 'Issue'"),
+            # Second attempt — issueDependencies works.
+            (
+                (
+                    '{"data": {"repository": {"issues": {'
+                    '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+                    '"nodes": [{"number": 7, "issueDependencies": '
+                    '{"nodes": [{"number": 4, "state": "OPEN"}]}}]'
+                    "}}}}"
+                ),
+                0,
+                "",
+            ),
+        ]
+    )
+
+    class FakeResult:
+        def __init__(self, stdout: str, rc: int, stderr: str) -> None:
+            self.stdout = stdout
+            self.returncode = rc
+            self.stderr = stderr
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        return FakeResult(*next(call_responses))
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    edges = board.fetch_blocked_by_edges("brockamer/findajob")
+    assert edges == {7: [{"number": 4, "state": "OPEN"}]}
+
+
+def test_fetch_blocked_by_edges_passes_cache_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cache='60s' threads through to the underlying gh api invocation."""
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"data": {"repository": {"issues": {'
+            '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+            '"nodes": []}}}}'
+        )
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    board.fetch_blocked_by_edges("brockamer/findajob", cache="60s")
+    assert "--cache" in captured[0] and "60s" in captured[0]
+
+
 # Legacy board-doc fallbacks: older docs (pre-bootstrap-project.py) lack
 # the machine-readable bullet block, so the parser has to infer the header
 # fields from prose + git remote. These tests pin the fallback behavior


### PR DESCRIPTION
## Summary

Closes #49.

Heavy single commands (`/jared-groom`, `dependency-graph.py`, `/jared-reshape`) were burning through GitHub's GraphQL rate-limit budget (5000 pts/hr). Evidence: 2026-05-01 ~13:02 UTC findajob session hit `gh project item-list 1 --limit 200 --format json exited 1: GraphQL: API rate limit exceeded` with the budget at 14/5000 — ~4986 points consumed in roughly 30–40 min.

Two findings shaped the work:

1. Almost every `gh` invocation jared makes is GraphQL-billed (`gh project ...`, `gh issue view --json ...`, `gh issue list --json ...`, `gh api graphql` all share the 5000-point bucket).
2. The dominant pattern is N+1 fan-out, not session-accumulation.

## Changes (4 phase-numbered commits)

- **Phase A** — `Board.board_items()` + `invalidate_items()`. `find_item_id` and `_cmd_get_item` now share one `gh project item-list` call per Board instance instead of fetching separately.
- **Phase B** — Optional `cache: str | None` parameter on `run_graphql` / `run_gh` / `run_gh_raw`. Forwards to `gh api --cache <duration>`. Read-only callers pass `cache="60s"`; mutation callers leave it None.
- **Phase C** — `graphql_budget()` (REST `gh api rate_limit`, free of GraphQL bucket) + `check_graphql_budget()` helper. Wired into `sweep.py` and `dependency-graph.py` with `--min-budget` (default 200) and `--force`. Heavy scripts now soft-fail with reset clock instead of crashing mid-run.
- **Phase D** — Lifted `fetch_native_blocked_by` from `sweep.py` into `lib.board.fetch_blocked_by_edges`. `dependency-graph.py` now does ONE paginated GraphQL call upfront instead of one per open issue. O(N) → O(pages).

## Measured on findajob (~70 open issues)

| Workload | Before (est.) | After |
|---|---|---|
| `dependency-graph.py --summary` | 70–140 pts | **2 pts** (1 pt warm) |
| `sweep.py` (full) | ~30–50 pts | 205 pts (sweep does much more — see deferred work below) |
| Budget gate (forced trip) | crash mid-run | clean exit 0 with reset clock |

## Test plan

- [x] `pytest` — 112 passed (was 102; added 10)
- [x] `ruff check .` clean
- [x] `mypy` clean
- [x] Live integration on findajob: `dependency-graph.py --summary` → 2 pts; back-to-back run within 60s → 1 pt (gh `--cache` hit)
- [x] Budget gate trip: `sweep.py --min-budget 9999` exits 0 with `GraphQL budget low: 4465/5000 remaining; resets at 14:31 UTC (~49 min). Run with --force to override.`
- [x] `--force` override: same invocation with `--force` proceeds normally

## Deferred (Phase 2 candidates, enumerated in plan)

1. **Conversational-layer doc tweak** (highest leverage). Edit `commands/*.md` and `skills/jared/references/*.md` to instruct Claude to pass `--cache 60s` on read-only `gh api` calls. Pure documentation change.
2. Cross-process on-disk cache file (would help session-accumulation pain).
3. Batched mutations in `jared file` (3+ `item-edit` mutations per file).
4. ETag/conditional GET on REST endpoints.
5. N+1 in `sweep.py:fetch_recent_comments` and `next-session-prompt:_latest_session_note_oneliner`.

Plan: `~/.claude/plans/the-jared-plugin-is-linked-barto.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)