### PR TITLE
style: ruff format pass on 7 stale files (#56)

### DIFF
--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -689,9 +689,7 @@ def main() -> int:
     # correct either way, but users running on this board with the workflow
     # off will accumulate the drift silently. Warn early.
     workflows = fetch_workflows(owner_type, owner, number)
-    item_closed = next(
-        (w for w in workflows if w.get("name") == "Item closed"), None
-    )
+    item_closed = next((w for w in workflows if w.get("name") == "Item closed"), None)
     if item_closed is not None and not item_closed.get("enabled"):
         print(
             "\nWARNING: the 'Item closed' workflow is DISABLED on this project.\n"
@@ -800,10 +798,7 @@ def main() -> int:
                 repo=args.repo,
             )
             patched = patch_legacy_doc(existing, header)
-            print(
-                f"\n{output} is missing the jared header block "
-                f"({', '.join(missing_bullets)})."
-            )
+            print(f"\n{output} is missing the jared header block ({', '.join(missing_bullets)}).")
             print("Proposed patch — insert five machine-readable bullets near the top:\n")
             for line in difflib.unified_diff(
                 existing.splitlines(keepends=True),

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -68,9 +68,7 @@ def test_parse_referenced_issues_bold_line_plural_with_multiple_refs() -> None:
 
 
 def test_parse_referenced_issues_heading_wins_over_bold_line() -> None:
-    text = (
-        "# Plan\n\n**Issue:** #99\n\n## Issues\n\n- #1\n- #2\n\n## Body\n"
-    )
+    text = "# Plan\n\n**Issue:** #99\n\n## Issues\n\n- #1\n- #2\n\n## Body\n"
     assert ap.parse_referenced_issues(text) == [1, 2]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,9 +71,7 @@ def test_cli_unknown_subcommand_exits_nonzero() -> None:
 def _assert_clean_error(out: str, err: str, expected_in_stderr: str) -> None:
     assert out == "", f"stdout should be empty on error, got: {out!r}"
     assert "Traceback" not in err, f"stderr leaked a traceback:\n{err}"
-    assert expected_in_stderr in err, (
-        f"expected {expected_in_stderr!r} in stderr, got:\n{err}"
-    )
+    assert expected_in_stderr in err, f"expected {expected_in_stderr!r} in stderr, got:\n{err}"
     # Every typed-exception error goes through main()'s uniform prefix.
     assert "jared:" in err, (
         f"expected 'jared:' prefix in stderr (uniform error format), got:\n{err}"

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -28,9 +28,7 @@ def _write_board_with_status(tmp_path: Path) -> Path:
     return board_md
 
 
-def _graphql_item_response(
-    *, project_number: int, status: str, item_id: str = "PVTI_aaa"
-) -> str:
+def _graphql_item_response(*, project_number: int, status: str, item_id: str = "PVTI_aaa") -> str:
     """Build a repository.issue(number).projectItems graphql payload."""
     return json.dumps(
         {
@@ -102,8 +100,7 @@ def test_close_falls_back_to_explicit_move_when_auto_move_lags(
             "issue close": "",
             "api graphql": _graphql_item_response(project_number=7, status="Backlog"),
             "item-list": (
-                '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}, '
-                '"status": "Backlog"}]}'
+                '{"items": [{"id": "PVTI_aaa", "content": {"number": 42}, "status": "Backlog"}]}'
             ),
             "item-edit": "{}",
         },
@@ -179,8 +176,7 @@ def test_close_filters_graphql_to_current_project(
             "issue close": "",
             "api graphql": multi_project_response,
             "item-list": (
-                '{"items": [{"id": "PVTI_ours", "content": {"number": 42}, '
-                '"status": "Backlog"}]}'
+                '{"items": [{"id": "PVTI_ours", "content": {"number": 42}, "status": "Backlog"}]}'
             ),
             "item-edit": "{}",
         },

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -199,9 +199,7 @@ def test_file_makes_no_item_list_calls(
     # Nothing in the call stream should scan the project via `item-list`.
     for c in calls:
         joined = " ".join(c)
-        assert "item-list" not in joined, (
-            f"`jared file` should not call item-list; got: {joined!r}"
-        )
+        assert "item-list" not in joined, f"`jared file` should not call item-list; got: {joined!r}"
     # Expected call ceiling: issue create + item-add + item-edit × 2 (Status,
     # Priority) = 4. Gives AC headroom of 1 for an extra --field if present.
     # Allow the test to flex by asserting an upper bound rather than equality,

--- a/tests/test_link_project_to_repo.py
+++ b/tests/test_link_project_to_repo.py
@@ -35,9 +35,7 @@ def test_link_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = _patch_graphql_responses(
         monkeypatch,
         {
-            "repository(owner:": json.dumps(
-                {"data": {"repository": {"id": "R_kgDOabc"}}}
-            ),
+            "repository(owner:": json.dumps({"data": {"repository": {"id": "R_kgDOabc"}}}),
             "linkProjectV2ToRepository": json.dumps(
                 {"data": {"linkProjectV2ToRepository": {"repository": {"id": "R_kgDOabc"}}}}
             ),

--- a/tests/test_sweep_checks.py
+++ b/tests/test_sweep_checks.py
@@ -49,9 +49,7 @@ def test_check_closed_not_done_handles_no_status() -> None:
     current_status renders as 'no Status' so the downstream format is
     still readable."""
     mod = import_sweep()
-    items = [
-        {"content": {"number": 99, "state": "CLOSED", "title": "No status at all"}}
-    ]
+    items = [{"content": {"number": 99, "state": "CLOSED", "title": "No status at all"}}]
     [entry] = mod.check_closed_not_done(items)
     assert entry["number"] == 99
     assert entry["current_status"] == "no Status"


### PR DESCRIPTION
## Summary

Closes #56.

Pure `ruff format .` pass on 7 files where one-liner asserts were re-wrapped. Picked up during #49 work but kept separate so the rate-limit PR stayed scoped.

## Test plan

- [x] `pytest` — 112 passed
- [x] `ruff check .` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)