### PR TITLE
docs(perf): conversational-layer cache discipline (#51)

### DIFF
--- a/commands/jared-reshape.md
+++ b/commands/jared-reshape.md
@@ -18,7 +18,7 @@ Context to load before starting:
 
 1. `docs/project-board.md` — current conventions
 2. Top-level strategic issues (usually 1–3 long-lived issues describing the roadmap)
-3. Milestone inventory: `gh api repos/<owner>/<repo>/milestones --jq '.[] | {title, state, open_issues, closed_issues, due_on}'`
+3. Milestone inventory: `gh api repos/<owner>/<repo>/milestones --cache 5m --jq '.[] | {title, state, open_issues, closed_issues, due_on}'` (milestones rarely change inside a session — long TTL is safe; see cache-discipline rules in `skills/jared/references/operations.md`)
 4. Current git state (branch, uncommitted work — reshape mid-stream is a red flag)
 
 Produce a review proposal:

--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -54,7 +54,7 @@ See `references/jared-cli.md` for the full subcommand reference.
 
 **Tier 3 — batch / advisory / setup.** Named batch scripts under `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/`: `sweep.py`, `bootstrap-project.py`, `dependency-graph.py`, `capture-context.py`, `archive-plan.py`. Each has its own slash command; invoke by name via those commands, not directly in conversation.
 
-**Escape hatch.** Raw `gh issue`, `gh project`, `gh api graphql` only for cases none of the above cover. See `references/operations.md` for the reference card.
+**Escape hatch.** Raw `gh issue`, `gh project`, `gh api graphql` only for cases none of the above cover. See `references/operations.md` for the reference card — and for the cache-discipline rules (`--cache 60s` on read-only `gh api` calls; prefer `jared get-item` over `gh issue view --json` for state-only checks) that keep conversational sessions inside the GraphQL budget.
 
 Jared never reconstructs a multi-step `gh` flow in conversation when a `jared` subcommand exists for it. Reaching for raw `gh` when `jared file` is the right tool is a drift signal.
 

--- a/skills/jared/references/dependencies.md
+++ b/skills/jared/references/dependencies.md
@@ -23,10 +23,13 @@ ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared blocked-by <B> <A> --remove
 
 ### Reading dependencies
 
-For ad-hoc inspection, `gh api graphql` is the escape hatch:
+For ad-hoc inspection, `gh api graphql` is the escape hatch. Pass
+`--cache 60s` so repeated lookups in one session don't rebill against the
+GraphQL budget (see the cache-discipline rules in
+`references/operations.md`):
 
 ```bash
-gh api graphql -f query='
+gh api graphql --cache 60s -f query='
   query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
       issue(number: $number) {

--- a/skills/jared/references/operations.md
+++ b/skills/jared/references/operations.md
@@ -22,12 +22,43 @@ it.
 - `<item-id>` — project item node ID (different from issue node ID; starts
   with `PVTI_`)
 
+## Cache discipline
+
+Almost every `gh` invocation Jared makes is GraphQL-billed against the same
+5000-point/hour bucket — `gh project ...`, `gh issue view --json ...`, `gh
+issue list --json ...`, and `gh api graphql` all draw from it. Two rules
+keep conversational sessions inside that budget:
+
+1. **Pass `--cache 60s` on every read-only `gh api ...` call.** This
+   includes `gh api graphql ...` (the cache key covers the POST body, so
+   identical queries hit it). Use a longer TTL — `5m`, `1h` — for things
+   that genuinely don't change inside a session (e.g., milestone inventory,
+   schema introspection). The cache is a transparent HTTP response cache
+   keyed by request shape, with no smart invalidation: after mutating
+   something, a cached read of that data returns stale until TTL expires.
+   Pass `--cache 0` to force a refresh after a mutation when you need the
+   updated state. Worked example: `gh api graphql -f query='…' --cache 60s`.
+
+2. **Prefer the `jared` CLI for board-shaped queries.** `jared summary` and
+   `jared get-item <N>` share a per-process snapshot of `gh project
+   item-list`, so a session that asks "what's on the board?" then "what's
+   the state of #51?" pays for one `item-list` fetch, not two. Reach for
+   `gh issue view --json …` only when you actually need body / title /
+   labels / milestone — the fields the CLI doesn't expose. For Status /
+   Priority / item-id / field values, `jared get-item` is cheaper and
+   bounded.
+
+The escape-hatch examples below are written with these rules applied.
+
 ## Raw `gh` fallback — the minimum escape-hatch set
 
 ### Inspect the board
 
 ```bash
-# Full item list — item-ids, field values, content snippets for every row
+# Full item list — item-ids, field values, content snippets for every row.
+# Prefer `jared summary` / `jared get-item` in conversational flows; those
+# share one fetch per process. Use this raw form only for ad-hoc inspection
+# of fields the CLI doesn't expose.
 gh project item-list <project-number> --owner <owner> --limit 500 --format json
 
 # Project metadata (title, id, field counts)
@@ -40,12 +71,16 @@ gh project field-list <project-number> --owner <owner> --format json
 ### Inspect an issue
 
 ```bash
-# Body + state + labels + milestone
+# Body + state + labels + milestone.
+# For state-only checks (Status / Priority / item-id), use `jared get-item
+# <N>` instead — it hits the per-process snapshot cache. Use this raw form
+# only when you need the body / labels / milestone fields.
 gh issue view <issue-number> --repo <repo> --json \
   body,state,labels,milestone,closedAt
 
-# Native blocked-by edges (GraphQL — not exposed via `gh issue view`)
-gh api graphql -f query='
+# Native blocked-by edges (GraphQL — not exposed via `gh issue view`).
+# `--cache 60s` deduplicates repeats inside a single session.
+gh api graphql --cache 60s -f query='
 query($o:String!,$r:String!,$n:Int!) {
   repository(owner:$o, name:$r) {
     issue(number:$n) {
@@ -58,8 +93,9 @@ query($o:String!,$r:String!,$n:Int!) {
 ### Introspect the GraphQL schema
 
 ```bash
-# When "is this field available on this GitHub version?" comes up
-gh api graphql -f query='
+# When "is this field available on this GitHub version?" comes up.
+# Schema doesn't change inside a session — long TTL is safe.
+gh api graphql --cache 1h -f query='
 { __type(name: "Issue") { fields { name type { name } } } }'
 ```
 


### PR DESCRIPTION
## Summary

Phase 2 follow-up to #49. Closes #51.

The 2026-05-01 findajob rate-limit incident showed Claude making many `gh issue view --json` and ad-hoc `gh api graphql` calls during slash-command flows — bypassing the per-process snapshot cache the jared CLI gained in #49 and not using gh's `--cache` flag. This PR codifies two rules in the conversational-layer docs so future Jared sessions stay inside the GraphQL budget.

**Two rules** (now documented in `skills/jared/references/operations.md`):

1. Pass `--cache 60s` on every read-only `gh api ...` call (including `gh api graphql` — cache key covers the POST body). Longer TTLs for stable data: 5m for milestones, 1h for schema. The doc explicitly notes that `gh --cache` is transparent HTTP response caching with no smart invalidation, and tells the reader to pass `--cache 0` to force-refresh after a mutation.

2. Prefer `jared get-item` and `jared summary` over `gh issue view --json` for board-shaped state-only checks. Those share the per-process snapshot cache from #49.

**Files touched:**
- `skills/jared/references/operations.md` — new "Cache discipline" section near the top + `--cache` added to GraphQL examples + inline redirects on the raw-gh examples
- `skills/jared/SKILL.md` — escape-hatch paragraph now references the cache-discipline rules
- `skills/jared/references/dependencies.md` — `--cache 60s` on the ad-hoc `blockedBy` example
- `commands/jared-reshape.md` — `--cache 5m` on the milestone-inventory call

**Files audited and intentionally left alone** (mutations, prose mentions, or already CLI-routed): the rest of `commands/*.md`, plus references for session-continuity, board-sweep, milestones-and-roadmap, migration, new-board, jared-cli, human-readable-board.

## Out of scope (filed separately at wrap)

The Acceptance criterion on #51 (≤50% GraphQL budget on a typical findajob session) requires **live measurement**. Per the `feedback_deferred_verification_drift` memory, that won't ship as a "user runs findajob later" hint in a handoff prompt — it'll be a tracked follow-up issue with its own Acceptance, filed at `/jared-wrap` time. #51 closes on the static-checkable rule encoding; the live measurement gets its own issue.

Per the handoff anti-target, this PR explicitly does NOT widen scope to slash-command refactors. The audit surfaced that the doc tweak needs to land in three files outside the issue's original named list (`SKILL.md`, `dependencies.md`, `jared-reshape.md`) — that's still doc work, not refactor work.

## Test plan

- [x] `git diff` reviewed — 49 insertions, 10 deletions, all docs
- [x] No code touched, no test/lint impact
- [ ] Static read-back of all four changed sections — guidance is actionable (each rule names the specific subcommand or flag, no handwaving)
- [ ] Live verification: ≤50% GraphQL budget on a typical findajob session — tracked as a separate follow-up issue (filed at wrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)