### PR TITLE
perf(comments): batch session-note fetches into a single GraphQL call (#55)

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -26,6 +26,7 @@ from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     GhInvocationError,
     ItemNotFound,
     OptionNotFound,
+    fetch_recent_comments_batch,
 )
 
 ALL_SUBCOMMANDS = [
@@ -640,31 +641,23 @@ def _fetch_recently_closed(board: Board, *, days: int) -> list[dict[str, Any]]:
     return items
 
 
-def _latest_session_note_oneliner(board: Board, issue_number: int) -> str | None:
-    """Pull the most recent comment whose body starts with `## Session ` and
-    extract the **Next action:** sentence. Returns None if no Session note
-    exists or no Next action line is found.
+def _latest_session_note_oneliner(comments: list[dict[str, Any]]) -> str | None:
+    """From a pre-fetched list of comments (chronological order, oldest →
+    newest), pull the most recent one whose body starts with `## Session `
+    and extract the **Next action:** sentence. Returns None if no Session
+    note exists or no Next action line is found.
 
     The `## Session ` prefix is the discipline laid out in
     `references/session-continuity.md` — comments that don't match are
     ordinary discussion and are skipped.
+
+    Comments are passed in pre-fetched (rather than fetched here per
+    issue) so the caller can batch all in-flight issues into one
+    GraphQL round-trip via `fetch_recent_comments_batch`.
     """
-    data = board.run_gh(
-        [
-            "issue",
-            "view",
-            str(issue_number),
-            "--repo",
-            board.repo,
-            "--json",
-            "comments",
-        ]
-    )
-    comments = data.get("comments", []) if isinstance(data, dict) else []
     session_notes = [c for c in comments if (c.get("body") or "").startswith("## Session ")]
     if not session_notes:
         return None
-    # gh returns comments in chronological order; the latest is the last one.
     latest = session_notes[-1]
     body = latest.get("body", "")
     return _extract_next_action(body)
@@ -704,10 +697,22 @@ def _cmd_next_session_prompt(args: argparse.Namespace) -> int:
     print("## In flight")
     print()
     if in_progress:
+        # One aliased GraphQL call covers every in-flight issue's comments,
+        # replacing the per-issue `gh issue view --json comments` fan-out.
+        in_flight_numbers = [
+            n
+            for item in in_progress
+            if isinstance((n := (item.get("content") or {}).get("number")), int)
+        ]
+        comments_by_number = fetch_recent_comments_batch(
+            board.repo, in_flight_numbers, limit=10, cache="60s"
+        )
         for item in in_progress:
             num = (item.get("content") or {}).get("number")
             note_one_liner = (
-                _latest_session_note_oneliner(board, num) if isinstance(num, int) else None
+                _latest_session_note_oneliner(comments_by_number.get(num, []))
+                if isinstance(num, int)
+                else None
             )
             _render_in_flight(item, note_one_liner)
     else:

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -413,6 +413,49 @@ def fetch_blocked_by_edges(
     raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
 
 
+def fetch_recent_comments_batch(
+    repo: str,
+    issue_numbers: list[int],
+    *,
+    limit: int = 10,
+    cache: str | None = None,
+) -> dict[int, list[dict[str, Any]]]:
+    """One aliased GraphQL call → `{issue_number: [{body, createdAt}, ...]}`
+    for the given numbers. Returns the most recent `limit` comments per
+    issue, in chronological order (oldest → newest), matching what gh's
+    REST `/comments` endpoint and `gh issue view --json comments` both
+    return.
+
+    Replaces the per-issue N+1 in `sweep.py:fetch_recent_comments` and
+    the per-issue `gh issue view --json comments` in
+    `jared:_latest_session_note_oneliner`. Aliased query — one alias per
+    requested number — keeps it a single round trip; cap callers at a
+    reasonable N (≤10 typical, the WIP cap is the natural ceiling).
+
+    Empty input → empty dict, no gh call.
+    """
+    if not issue_numbers:
+        return {}
+    owner, name = repo.split("/", 1)
+    aliases = "\n".join(
+        f"  i{n}: issue(number: {n}) {{ comments(last: {limit}) {{ nodes {{ body createdAt }} }} }}"
+        for n in issue_numbers
+    )
+    query = (
+        f"query($o:String!,$r:String!) {{\n  repository(owner:$o, name:$r) {{\n{aliases}\n  }}\n}}"
+    )
+    data = run_graphql(query, cache=cache, o=owner, r=name)["data"]["repository"]
+    result: dict[int, list[dict[str, Any]]] = {}
+    for n in issue_numbers:
+        issue_data = data.get(f"i{n}")
+        if not issue_data:
+            result[n] = []
+            continue
+        nodes = issue_data.get("comments", {}).get("nodes", []) or []
+        result[n] = nodes
+    return result
+
+
 def graphql_budget() -> tuple[int, int, int]:
     """Return `(remaining, limit, reset_unix)` from `gh api rate_limit`.
 

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -61,6 +61,9 @@ from lib.board import (
     fetch_blocked_by_edges as board_fetch_blocked_by_edges,
 )
 from lib.board import (
+    fetch_recent_comments_batch as board_fetch_recent_comments_batch,
+)
+from lib.board import (
     graphql_budget as board_graphql_budget,
 )
 from lib.board import (
@@ -153,31 +156,6 @@ def fetch_native_blocked_by(repo: str) -> dict[int, list[dict[str, Any]]]:
         dict[int, list[dict[str, Any]]],
         board_fetch_blocked_by_edges(repo, cache="60s"),
     )
-
-
-def fetch_recent_comments(repo: str, number: int, limit: int = 5) -> list[dict[str, Any]]:
-    """Get recent comments on an issue (for session-note freshness)."""
-    try:
-        stdout = board_run_gh_raw(
-            [
-                "api",
-                f"repos/{repo}/issues/{number}/comments",
-                "--jq",
-                f".[-{limit}:] | .[] | {{body, created_at}}",
-            ]
-        )
-    except GhInvocationError:
-        return []
-    # jq emits one object per line
-    comments = []
-    for line in stdout.splitlines():
-        line = line.strip()
-        if line:
-            try:
-                comments.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-    return comments
 
 
 # ---------- Item helpers ----------
@@ -478,7 +456,7 @@ def check_session_note_freshness(
     if not repo:
         return ["(skipping session-note check — repo not determined)"]
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=days)
-    findings = []
+    in_progress_numbers: list[int] = []
     for i in items:
         content = i.get("content") or {}
         if content.get("state") == "CLOSED":
@@ -486,9 +464,16 @@ def check_session_note_freshness(
         if i.get("status") != "In Progress":
             continue
         n = content.get("number")
-        if not n:
-            continue
-        comments = fetch_recent_comments(repo, n, limit=10)
+        if isinstance(n, int):
+            in_progress_numbers.append(n)
+    # Single GraphQL round-trip for all in-progress issues, replacing the
+    # per-issue REST fan-out that used to live here.
+    comments_by_number = board_fetch_recent_comments_batch(
+        repo, in_progress_numbers, limit=10, cache="60s"
+    )
+    findings = []
+    for n in in_progress_numbers:
+        comments = comments_by_number.get(n, [])
         # A Session note starts with "## Session YYYY-MM-DD"
         session_notes = [
             c
@@ -499,7 +484,7 @@ def check_session_note_freshness(
             findings.append(f"#{n}: In Progress with no Session note comment ever")
             continue
         latest = max(
-            dt.datetime.fromisoformat(c["created_at"].replace("Z", "+00:00")) for c in session_notes
+            dt.datetime.fromisoformat(c["createdAt"].replace("Z", "+00:00")) for c in session_notes
         )
         if latest < cutoff:
             age = (dt.datetime.now(dt.UTC) - latest).days

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -627,6 +627,99 @@ def test_fetch_blocked_by_edges_passes_cache_flag(monkeypatch: pytest.MonkeyPatc
     assert "--cache" in captured[0] and "60s" in captured[0]
 
 
+def test_fetch_recent_comments_batch_single_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One aliased GraphQL call covers many issues; returns {number: [comments]}."""
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = (
+            '{"data": {"repository": {'
+            '"i10": {"comments": {"nodes": ['
+            '  {"body": "## Session 2026-04-30", "createdAt": "2026-04-30T12:00:00Z"},'
+            '  {"body": "regular reply", "createdAt": "2026-04-30T13:00:00Z"}'
+            "]}},"
+            '"i11": {"comments": {"nodes": ['
+            '  {"body": "## Session 2026-05-01", "createdAt": "2026-05-01T09:00:00Z"}'
+            "]}},"
+            '"i12": {"comments": {"nodes": []}}'
+            "}}}"
+        )
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    result = board.fetch_recent_comments_batch("brockamer/findajob", [10, 11, 12])
+    assert len(captured) == 1, "should make exactly one gh call for any number of issues"
+    assert result == {
+        10: [
+            {"body": "## Session 2026-04-30", "createdAt": "2026-04-30T12:00:00Z"},
+            {"body": "regular reply", "createdAt": "2026-04-30T13:00:00Z"},
+        ],
+        11: [{"body": "## Session 2026-05-01", "createdAt": "2026-05-01T09:00:00Z"}],
+        12: [],
+    }
+    # Aliases for each requested number land in the query.
+    joined = " ".join(captured[0])
+    assert "i10:" in joined and "i11:" in joined and "i12:" in joined
+
+
+def test_fetch_recent_comments_batch_empty_input_skips_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty issue list short-circuits — no gh invocation, no GraphQL points."""
+    from skills.jared.scripts.lib import board
+
+    def fake_run(args: list[str], **kw: object) -> object:
+        raise AssertionError("gh should not be called for empty input")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    assert board.fetch_recent_comments_batch("brockamer/findajob", []) == {}
+
+
+def test_fetch_recent_comments_batch_passes_cache_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cache='60s' threads through to the underlying gh api invocation."""
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = '{"data": {"repository": {"i7": {"comments": {"nodes": []}}}}}'
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    board.fetch_recent_comments_batch("brockamer/findajob", [7], cache="60s")
+    assert "--cache" in captured[0] and "60s" in captured[0]
+
+
+def test_fetch_recent_comments_batch_handles_null_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If GraphQL returns a null alias (e.g., issue not found), we get [] for it."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stderr = ""
+        stdout = '{"data": {"repository": {"i99": null}}}'
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    assert board.fetch_recent_comments_batch("brockamer/findajob", [99]) == {99: []}
+
+
 # Legacy board-doc fallbacks: older docs (pre-bootstrap-project.py) lack
 # the machine-readable bullet block, so the parser has to infer the header
 # fields from prose + git remote. These tests pin the fallback behavior

--- a/tests/test_cmd_next_session_prompt.py
+++ b/tests/test_cmd_next_session_prompt.py
@@ -31,14 +31,14 @@ def test_next_session_prompt_renders_basic_sections(
         '"status": "Up Next", "priority": "Medium"}'
         "]}"
     )
-    # gh issue view <N> --json comments returns the latest Session note
+    # gh api graphql aliased batch returns comments for every in-flight number
     issue_comments = (
-        '{"comments": ['
+        '{"data": {"repository": {"i65": {"comments": {"nodes": ['
         '{"createdAt": "2026-04-24T10:00:00Z", "body": "## Session 2026-04-24\\n\\n'
         "**Progress:** wired prefilter\\n\\n"
         "**Next action:** decide YAML ordering question and unblock the third test."
         '"}'
-        "]}"
+        "]}}}}}"
     )
     # gh issue list for recently closed (state=closed, closed within 7d)
     closed_list = '[{"number": 251, "title": "v0.4 release", "closedAt": "2026-04-23T15:00:00Z"}]'
@@ -47,7 +47,7 @@ def test_next_session_prompt_renders_basic_sections(
         monkeypatch,
         responses={
             "item-list": item_list,
-            "issue view 65": issue_comments,
+            "graphql": issue_comments,
             "issue list": closed_list,
         },
     )
@@ -138,12 +138,12 @@ def test_in_progress_without_session_notes_skips_one_liner(
         '"status": "In Progress", "priority": "Medium"}'
         "]}"
     )
-    # No comments at all
+    # No comments at all — graphql returns an empty nodes list under the alias
     patch_gh_by_arg(
         monkeypatch,
         responses={
             "item-list": item_list,
-            "issue view 7": '{"comments": []}',
+            "graphql": '{"data": {"repository": {"i7": {"comments": {"nodes": []}}}}}',
             "issue list": "[]",
         },
     )
@@ -171,13 +171,16 @@ def test_session_note_without_next_action_field_skips_one_liner(
     )
     # Comment matches Session prefix but lacks **Next action:**
     issue_comments = (
-        '{"comments": [{"body": "## Session 2026-04-24\\n\\n**Progress:** stuff happened.\\n"}]}'
+        '{"data": {"repository": {"i9": {"comments": {"nodes": [{'
+        '"createdAt": "2026-04-24T10:00:00Z",'
+        '"body": "## Session 2026-04-24\\n\\n**Progress:** stuff happened.\\n"'
+        "}]}}}}}"
     )
     patch_gh_by_arg(
         monkeypatch,
         responses={
             "item-list": item_list,
-            "issue view 9": issue_comments,
+            "graphql": issue_comments,
             "issue list": "[]",
         },
     )


### PR DESCRIPTION
## Summary

Phase 2 follow-up to #49. Closes #55.

Two N+1 patterns that survived #49: `sweep.py:fetch_recent_comments` (per-issue REST call, fan-out across in-progress items) and `jared:_latest_session_note_oneliner` (per-issue `gh issue view --json comments`, GraphQL-billed). Both replaced by a single aliased GraphQL query.

**New helper** (`lib/board.py`):
- `fetch_recent_comments_batch(repo, issue_numbers, *, limit=10, cache=None)` — one aliased GraphQL call, returns `{number: [{body, createdAt}, ...]}`. Same pattern as `fetch_blocked_by_edges` from #49 (module-level, optional cache kwarg).
- Empty input short-circuits without calling gh.

**Call sites refactored:**
- `sweep.py:check_session_note_freshness` — pre-collects in-progress numbers, makes one batch call, then iterates the dict. The orphaned per-issue helper is removed. Field name on the freshness comparison switches from REST's `created_at` to GraphQL's `createdAt`.
- `jared:_cmd_next_session_prompt` — pre-fetches comments for all in-flight items, passes each list into a slimmed `_latest_session_note_oneliner(comments)` (which no longer fetches anything itself).

Both callers pass `cache=\"60s\"` so a sweep + a summary in the same shell reuse the same response.

## Test plan

- [x] 4 new unit tests for the helper: single call for many issues, empty input skips gh, cache flag threads through, null-alias yields empty list
- [x] Updated mocks in `test_cmd_next_session_prompt` route on \`graphql\` and return aliased response
- [x] Full suite: 116 passed
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] \`mypy --strict\` clean (25 source files)
- [x] Live integration: \`jared next-session-prompt\` against the jared board (with #51 and #55 In Progress) — aliased query roundtripped against real GitHub, In Flight section rendered correctly
- [ ] Live measurement of \"sweep on findajob shows 1 GraphQL call for comments instead of 3\" — filed as separate tracked follow-up at wrap, per the deferred-verification-drift discipline

## Notes

- The strict reading of #55's Acceptance refers to Site B (the GraphQL-billed `gh issue view --json` calls). Site A in sweep was a true REST endpoint (separate 5000/hr bucket) so the GraphQL-budget impact is Site B only — but folding both sites into the same helper still wins on round-trip count and gives a single test target.
- Out of scope per the parent plan ordering: #54 (ETag) and #52 (on-disk cache) — both should wait for post-#51-and-#55 measurement before being pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)