### PR TITLE
fix(summary): exclude stuck-closed items from In Progress count (#43)

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -26,6 +26,7 @@ from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     GhInvocationError,
     ItemNotFound,
     OptionNotFound,
+    check_closed_not_done,
     fetch_recent_comments_batch,
 )
 
@@ -528,7 +529,20 @@ def _cmd_summary(args: argparse.Namespace) -> int:
             return f"  #{num} [{prio}] {title}"
         return f"  #{num} {title}"
 
-    in_progress = by_status("In Progress")
+    # Stuck-closed items: closed issues whose Status never auto-moved to
+    # Done (typical drift path: PR-merge auto-close on a project where
+    # the built-in "Item closed → Done" workflow is off). They look like
+    # In Progress to a naive `status == "In Progress"` filter and would
+    # silently inflate the WIP count that /jared-start uses to enforce
+    # the cap. Detect them here, list separately, and exclude from the
+    # In Progress total. Detector lives in lib.board so sweep and summary
+    # share one source of truth.
+    stuck_closed = check_closed_not_done(items)
+    stuck_numbers = {entry["number"] for entry in stuck_closed}
+    in_progress_raw = by_status("In Progress")
+    in_progress = [
+        i for i in in_progress_raw if (i.get("content") or {}).get("number") not in stuck_numbers
+    ]
     up_next_all = by_status("Up Next")
     up_next = up_next_all[:3]
     blocked = by_status("Blocked")
@@ -538,6 +552,16 @@ def _cmd_summary(args: argparse.Namespace) -> int:
     print(f"In Progress ({len(in_progress)}):")
     for it in in_progress:
         print(render_item(it))
+    if stuck_closed:
+        print()
+        print(f"Stuck closed ({len(stuck_closed)}) — closed issues not on Done:")
+        for entry in stuck_closed:
+            cur = entry.get("current_status") or "no Status"
+            print(f"  #{entry['number']} [{cur}] {entry['title']}")
+        print(
+            "  Fix: jared set <N> Status Done   "
+            "(or enable the project's auto-archive workflow)"
+        )
     print()
     print(f"Up Next (top 3 of {len(up_next_all)}):")
     for it in up_next:

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -413,6 +413,39 @@ def fetch_blocked_by_edges(
     raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
 
 
+def check_closed_not_done(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Closed issues should auto-move to Done. If they don't, return them.
+
+    Detection-only. Each entry is `{number, title, current_status}` —
+    callers decide the rendering (sweep adds a `Propose: jared set <N>
+    Status Done` remediation suffix; the CLI's `summary` command renders
+    them under a separate `Stuck closed (N):` heading and excludes them
+    from the `In Progress` count). Keeping format out of the detector
+    means each call site can pick its own affordance.
+
+    The drift usually comes from projects whose built-in "Item closed →
+    Done" workflow is disabled — paths like `gh issue close` and PR-merge
+    auto-close rely on it entirely (only `jared close` has its own
+    explicit-Status fallback).
+    """
+    stuck = []
+    for i in items:
+        content = i.get("content") or {}
+        if content.get("state") != "CLOSED":
+            continue
+        status = i.get("status") or ""
+        if status == "Done":
+            continue
+        stuck.append(
+            {
+                "number": content.get("number"),
+                "title": (content.get("title") or i.get("title") or "")[:60],
+                "current_status": status or "no Status",
+            }
+        )
+    return stuck
+
+
 def fetch_recent_comments_batch(
     repo: str,
     issue_numbers: list[int],

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -53,6 +53,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     GhInvocationError,
+    check_closed_not_done,
 )
 from lib.board import (
     check_graphql_budget as board_check_graphql_budget,
@@ -213,39 +214,6 @@ def check_metadata(items: list[dict[str, Any]]) -> list[str]:
         if issues:
             missing.append(f"#{n}: {', '.join(issues)}")
     return missing
-
-
-def check_closed_not_done(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Closed issues should auto-move to Done. If they don't, return them.
-
-    Detection-only. Each entry is {number, title, current_status} — callers
-    decide the rendering (e.g. sweep's main() adds the `Propose: jared set
-    <N> Status Done` remediation suffix in its render loop). Keeping
-    format out of the detector means the next sweep-check that needs a
-    Propose-style remediation can follow the same pattern at its own
-    render site without reinventing the formatter here.
-
-    The drift usually comes from projects whose built-in "Item closed →
-    Done" workflow is disabled — paths like `gh issue close` and PR-merge
-    auto-close rely on it entirely (only `jared close` has its own
-    explicit-Status fallback).
-    """
-    stuck = []
-    for i in items:
-        content = i.get("content") or {}
-        if content.get("state") != "CLOSED":
-            continue
-        status = i.get("status") or ""
-        if status == "Done":
-            continue
-        stuck.append(
-            {
-                "number": content.get("number"),
-                "title": (content.get("title") or i.get("title") or "")[:60],
-                "current_status": status or "no Status",
-            }
-        )
-    return stuck
 
 
 def format_closed_not_done_line(entry: dict[str, Any]) -> str:

--- a/tests/test_cmd_summary.py
+++ b/tests/test_cmd_summary.py
@@ -60,6 +60,85 @@ def test_summary_shows_blocked_section(
     assert "#6" in out
 
 
+def test_summary_excludes_stuck_closed_from_in_progress_count(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Closed items still sitting at Status=In Progress (PR-merge auto-close
+    drift) must not inflate the In Progress (N) count that /jared-start
+    parses for its WIP-cap check. They surface separately under
+    'Stuck closed' so the operator can see the truth without breaking flow.
+    Regression test for #43.
+    """
+    board_md = write_minimal_board(tmp_path)
+    patch_gh(
+        monkeypatch,
+        stdout=(
+            '{"items": ['
+            # One legitimately In Progress (open + Status=In Progress)
+            '{"id": "a", "content": {"number": 100, "title": "Real in-progress",'
+            ' "state": "OPEN"}, "status": "In Progress", "priority": "High"},'
+            # Two stuck-closed: state=CLOSED, Status still In Progress
+            '{"id": "b", "content": {"number": 101, "title": "Closed stuck one",'
+            ' "state": "CLOSED"}, "status": "In Progress", "priority": "Medium"},'
+            '{"id": "c", "content": {"number": 102, "title": "Closed stuck two",'
+            ' "state": "CLOSED"}, "status": "In Progress", "priority": "Low"}'
+            "]}"
+        ),
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "summary"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    # The In Progress count must reflect ONLY the truly-open item.
+    assert "In Progress (1):" in out, (
+        "stuck-closed items must not count toward In Progress, "
+        "or /jared-start's WIP check will silently miscount"
+    )
+    # The stuck-closed section appears with the right total + members.
+    assert "Stuck closed (2)" in out
+    assert "#101" in out and "#102" in out
+    assert "Closed stuck one" in out and "Closed stuck two" in out
+    # Only the truly-open item appears in the In Progress block — verify
+    # by checking the legitimate item is rendered and the stuck ones are
+    # NOT in the In Progress portion (they are in Stuck closed instead).
+    assert "Real in-progress" in out
+    in_progress_at = out.find("In Progress (1):")
+    stuck_at = out.find("Stuck closed")
+    assert in_progress_at < stuck_at
+    # In Progress section spans from `In Progress (1):` to `Stuck closed`.
+    in_progress_section = out[in_progress_at:stuck_at]
+    assert "#101" not in in_progress_section
+    assert "#102" not in in_progress_section
+    # Remediation hint is shown.
+    assert "jared set" in out and "Status Done" in out
+
+
+def test_summary_no_stuck_closed_section_when_clean(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When nothing is stuck-closed, the section is omitted entirely so
+    the common case stays terse."""
+    board_md = write_minimal_board(tmp_path)
+    patch_gh(
+        monkeypatch,
+        stdout=(
+            '{"items": ['
+            '{"id": "a", "content": {"number": 1, "title": "Open thing", "state": "OPEN"}, '
+            '"status": "In Progress", "priority": "High"}'
+            "]}"
+        ),
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "summary"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Stuck closed" not in out
+
+
 def test_summary_up_next_truncates_to_three(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #43. Follow-up to #18.

The detection-only approach #18 added to /jared-groom's sweep was right for batch hygiene but underpowered for in-session ergonomics: closed issues whose Status never auto-moved to Done (PR-merge auto-close drift) silently inflate the \`In Progress (N)\` count that /jared-start parses for its WIP-cap check. Three issues hit this on 2026-04-25 (#33, #37, #38) — a fourth pull would have been wrongly blocked.

Fix is at the read site, not in \`jared close\`:
- Lift \`check_closed_not_done\` from sweep.py into \`lib/board.py\` so summary and sweep share one detector
- \`_cmd_summary\` now filters stuck items out of the In Progress count and lists them under \`Stuck closed (N)\` with a one-line remediation hint
- Section omitted entirely when nothing is stuck — common case stays terse
- /jared-start's WIP check parses the same \`In Progress (N):\` header, so the corrected count flows through transparently

Per the issue's Decisions section, this PR explicitly does NOT change \`jared close\` or re-litigate the auto-fix-in-close debate (#18/PR #20 settled that).

## Test plan

- [x] All 5 existing detector tests in \`test_sweep_checks.py\` pass unchanged (sweep re-imports the lifted helper)
- [x] New \`test_summary_excludes_stuck_closed_from_in_progress_count\` — three items at Status=In Progress (1 OPEN + 2 CLOSED); asserts In Progress (1), Stuck closed (2), no overlap, remediation hint
- [x] New \`test_summary_no_stuck_closed_section_when_clean\` — section omitted when clean
- [x] Full suite: 118 passed
- [x] \`ruff check\` + \`ruff format --check\` + \`mypy --strict\` clean
- [x] Live: \`jared summary\` against the jared board renders cleanly (no stuck-closed items present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)