### PR TITLE
chore(release): bump version 0.6.0 → 0.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.6.0"
+version = "0.7.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Bump plugin version 0.6.0 → 0.7.0. Sixteen commits since the last tag.

## Highlights

**Perf rebuild (#49 → PR #50, four phases):**
- Per-Board snapshot cache for \`gh project item-list\`
- \`--cache <duration>\` plumbed through \`run_gh\` / \`run_graphql\` / \`run_gh_raw\`
- Pre-flight GraphQL budget gate in sweep + dependency-graph
- N+1 elimination in \`dependency-graph.py\` via shared Board helper

**Phase 2 follow-ups landed:**
- Cache-discipline doctrine in \`operations.md\`, \`SKILL.md\`, \`dependencies.md\`, \`jared-reshape.md\` (#51 → PR #58)
- Session-note batch fetch via aliased GraphQL — \`fetch_recent_comments_batch\` (#55 → PR #59)

**Fixes:**
- \`jared summary\` excludes stuck-closed items from the In Progress count and surfaces them under a \`Stuck closed\` section, so \`/jared-start\`'s WIP-cap check stops silently miscounting (#43 → PR #61)
- Plan-spec drift regex tightened to require heading shape (#48 → PR #62)
- Ruff format pass on stale files (#56 → PR #57)

## Verification

Live measurement of the perf delta on findajob is tracked under #60. Per the deferred-verification-drift discipline, that lives as its own tracked issue rather than a release-note hint.

## Test plan

- [x] Full suite: 120 passed
- [x] \`ruff check\` + \`ruff format --check\` + \`mypy --strict\` clean (25 source files)
- [x] Live: \`jared summary\`, \`jared next-session-prompt\`, and \`sweep.py\` all run end-to-end against the jared board
- [ ] Tag v0.7.0 + push tag (after merge)
- [ ] \`/plugin update jared\` + \`/reload-plugins\` on consumer projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)