### PR TITLE
fix(file): atomicity recovery via jared add-to-board (#64)

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -422,9 +422,16 @@ def _build_add_to_board_command(
     status: str,
     fields: list[tuple[str, str]],
 ) -> str:
-    """Render the literal `jared add-to-board <N> ...` recovery line."""
+    """Render the literal `<jared-path> add-to-board <N> ...` recovery line.
+
+    Uses `__file__` so the line invokes the same binary that emitted it —
+    important because `jared` typically isn't on PATH (it's installed via
+    Claude Code's plugin cache or run from a checkout). Bare `jared` would
+    `command-not-found` on most setups, defeating the paste-and-run UX.
+    """
+    binary = str(Path(__file__).resolve())
     parts = [
-        "jared",
+        binary,
         "add-to-board",
         str(issue_number),
         "--priority",

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -38,6 +38,7 @@ ALL_SUBCOMMANDS = [
     "close",
     "comment",
     "file",
+    "add-to-board",
     "blocked-by",
     "next-session-prompt",
 ]
@@ -115,6 +116,29 @@ def build_parser() -> argparse.ArgumentParser:
         '(e.g. "Work Stream=Planning"). Repeatable.',
     )
     file_p.set_defaults(func=_cmd_file)
+
+    add_p = sub.add_parser(
+        "add-to-board",
+        help=(
+            "Add an existing issue to the board, set Priority + Status + fields. "
+            "Idempotent — safe to re-run. Used as the recovery path when "
+            "`jared file` fails after issue create, and standalone for issues "
+            "created outside `jared file`."
+        ),
+    )
+    add_p.add_argument("issue_number", type=int)
+    add_p.add_argument(
+        "--priority", required=True, choices=["High", "Medium", "Low"]
+    )
+    add_p.add_argument("--status", help="Status column (default: Backlog)")
+    add_p.add_argument("--label", action="append", help="Issue label (repeatable)")
+    add_p.add_argument(
+        "--field",
+        action="append",
+        help="NAME=VALUE for additional single-select fields "
+        '(e.g. "Work Stream=Planning"). Repeatable.',
+    )
+    add_p.set_defaults(func=_cmd_add_to_board)
 
     dep = sub.add_parser(
         "blocked-by",
@@ -296,24 +320,26 @@ def _cmd_close(args: argparse.Namespace) -> int:
 
 
 def _cmd_file(args: argparse.Namespace) -> int:
-    """Atomic: create issue, add to project, set Priority + Status + extras, verify.
+    """Atomic: create issue, add to project, set Priority + Status + extras.
 
     Implements the 'new issue must land on board with Status set' invariant
-    (see memory: jared file must guarantee project membership + status).
-    Any failure halts before the user's workflow moves on.
+    (see memory: jared file must guarantee project membership + status). On
+    any post-create failure (board-add, field-set), prints a literal
+    `jared add-to-board <N> ...` recovery command to stderr so the user can
+    finish the filing without retyping the body — see #64.
     """
     board = Board.from_path(Path(args.board))
     status = args.status or "Backlog"
 
-    # Pre-resolve all field/option IDs before we touch GitHub. Fails fast on
-    # misconfigured board without creating an orphan issue. FieldNotFound /
-    # OptionNotFound propagate to main()'s top-level catch for uniform
-    # `jared:`-prefixed output.
-    prio_field = board.field_id("Priority")
-    prio_option = board.option_id("Priority", args.priority)
-    status_field = board.field_id("Status")
-    status_option = board.option_id("Status", status)
-    extra_edits: list[tuple[str, str, str]] = []
+    # Pre-resolve before we touch GitHub: a misconfigured board fails fast
+    # without creating an orphan issue. add_existing_to_board re-resolves
+    # the same names — the duplication is intentional, since this catches
+    # bad config *before* `gh issue create` is called.
+    board.field_id("Priority")
+    board.option_id("Priority", args.priority)
+    board.field_id("Status")
+    board.option_id("Status", status)
+    extra_specs: list[tuple[str, str]] = []
     for spec in args.field or []:
         if "=" not in spec:
             print(
@@ -322,9 +348,11 @@ def _cmd_file(args: argparse.Namespace) -> int:
             )
             return 1
         name, value = spec.split("=", 1)
-        extra_edits.append((name, board.field_id(name), board.option_id(name, value)))
+        board.field_id(name)
+        board.option_id(name, value)
+        extra_specs.append((name, value))
 
-    # 1. Create the issue. gh prints the URL on stdout.
+    # Create the issue. gh prints the URL on stdout.
     create_args = [
         "issue",
         "create",
@@ -347,60 +375,101 @@ def _cmd_file(args: argparse.Namespace) -> int:
         return 2
     issue_number = int(issue_url.rsplit("/", 1)[-1])
 
-    # 2. Add to the project board.
+    # assume_new=True skips the find_item_id membership scan that #4's perf
+    # fix removed from the filing hot path. On failure the issue exists on
+    # the repo but isn't fully configured on the board; the recovery line
+    # below tells the user the exact command to finish the job.
     try:
-        add_data = board.run_gh(
-            [
-                "project",
-                "item-add",
-                str(board.project_number),
-                "--owner",
-                board.owner,
-                "--url",
-                issue_url,
-                "--format",
-                "json",
-            ]
+        board.add_existing_to_board(
+            issue_number,
+            priority=args.priority,
+            status=status,
+            fields=extra_specs,
+            assume_new=True,
         )
-    except GhInvocationError as e:
+    except (
+        GhInvocationError,
+        FieldNotFound,
+        OptionNotFound,
+        ItemNotFound,
+    ) as e:
+        recovery = _build_add_to_board_command(
+            issue_number, args.priority, status, extra_specs
+        )
         print(
-            f"error: filed issue #{issue_number} but failed to add to project: {e}",
+            f"error: filed issue #{issue_number} ({issue_url}) but failed to "
+            f"finish board setup: {e}",
             file=sys.stderr,
         )
+        print(f"  recover with: {recovery}", file=sys.stderr)
         return 2
-    item_id = add_data["id"]
 
-    # 3. Set Priority + Status + extras in order.
-    for field_id, option_id in [
-        (prio_field, prio_option),
-        (status_field, status_option),
-        *[(f, o) for _, f, o in extra_edits],
-    ]:
-        board.run_gh(
-            [
-                "project",
-                "item-edit",
-                "--project-id",
-                board.project_id,
-                "--id",
-                item_id,
-                "--field-id",
-                field_id,
-                "--single-select-option-id",
-                option_id,
-            ]
-        )
-
-    # No post-create verification: `gh project item-add` returned the item-id
-    # without error (caught above as GhInvocationError), and each item-edit
-    # mutation either returned exit 0 (write landed server-side) or raised.
-    # Re-reading via `item-list --limit 500` to confirm was the hot path that
-    # drained the GraphQL budget and rate-limited ~11 issues into any batch
-    # filing (#4). If a real write-path regression ever surfaces, a single
-    # `node(id: <item-id>)` GraphQL query would be the cheap verify shape —
-    # one call, not a list-all scan.
     print(f"OK: filed #{issue_number} → {status}, Priority={args.priority}")
     print(f"URL: {issue_url}")
+    return 0
+
+
+def _shell_quote(s: str) -> str:
+    """Quote a string for safe shell pasting (POSIX single-quote form)."""
+    if s and not any(c in s for c in " \t\n\"'\\$`"):
+        return s
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _build_add_to_board_command(
+    issue_number: int,
+    priority: str,
+    status: str,
+    fields: list[tuple[str, str]],
+) -> str:
+    """Render the literal `jared add-to-board <N> ...` recovery line."""
+    parts = [
+        "jared",
+        "add-to-board",
+        str(issue_number),
+        "--priority",
+        priority,
+        "--status",
+        _shell_quote(status),
+    ]
+    for name, value in fields:
+        parts.extend(["--field", _shell_quote(f"{name}={value}")])
+    return " ".join(parts)
+
+
+def _cmd_add_to_board(args: argparse.Namespace) -> int:
+    """Add an existing issue to the board, apply labels and fields.
+
+    Idempotent — safe to re-run. Two intended uses:
+      1. Recovery from `jared file` failing partway through post-create.
+         The error message in `_cmd_file` prints the exact invocation.
+      2. Putting an issue on the board that was created outside `jared file`
+         (GitHub UI, raw `gh issue create`, etc.).
+    """
+    board = Board.from_path(Path(args.board))
+    status = args.status or "Backlog"
+
+    fields: list[tuple[str, str]] = []
+    for spec in args.field or []:
+        if "=" not in spec:
+            print(
+                f"error: --field expects NAME=VALUE, got {spec!r}",
+                file=sys.stderr,
+            )
+            return 1
+        name, value = spec.split("=", 1)
+        fields.append((name, value))
+
+    board.add_existing_to_board(
+        args.issue_number,
+        priority=args.priority,
+        status=status,
+        labels=args.label or None,
+        fields=fields,
+    )
+    print(
+        f"OK: #{args.issue_number} on board → {status}, Priority={args.priority}"
+    )
     return 0
 
 

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -291,6 +291,108 @@ class Board:
             f"{self.project_number}. Is the issue added to the board?"
         )
 
+    def _add_to_board(self, issue_number: int) -> str:
+        """Call `gh project item-add` for `issue_number` and return the new item-id.
+
+        Invalidates the cached item-list snapshot so subsequent `find_item_id`
+        calls in the same process see the addition.
+        """
+        url = f"https://github.com/{self.repo}/issues/{issue_number}"
+        data = self.run_gh(
+            [
+                "project",
+                "item-add",
+                str(self.project_number),
+                "--owner",
+                self.owner,
+                "--url",
+                url,
+                "--format",
+                "json",
+            ]
+        )
+        self.invalidate_items()
+        return str(data["id"])
+
+    def add_existing_to_board(
+        self,
+        issue_number: int,
+        *,
+        priority: str,
+        status: str,
+        labels: list[str] | None = None,
+        fields: list[tuple[str, str]] | None = None,
+        assume_new: bool = False,
+    ) -> str:
+        """Add an issue to the board (if needed), apply labels, set Priority/Status/extras.
+
+        Idempotent: re-running on a fully-configured item is a no-op at the
+        GitHub API level — `gh project item-edit` exits 0 when the field
+        already holds the requested option, and `gh issue edit --add-label`
+        is a no-op for labels already present.
+
+        `assume_new=True` skips the `find_item_id` membership check and goes
+        straight to `gh project item-add`. Used by `_cmd_file` after a fresh
+        `gh issue create` to preserve the perf fix from #4 (no `item-list`
+        scan in the filing hot path). Recovery callers leave it False so a
+        re-run on an already-added item finds the existing item-id.
+
+        Returns the item_id. Pre-resolves all field/option IDs before any
+        GitHub call so misconfiguration raises before side effects. On any
+        gh failure raises GhInvocationError; the caller may catch and
+        synthesize a paste-and-run recovery command.
+        """
+        # Pre-resolve everything up front. FieldNotFound / OptionNotFound
+        # raise here, before we touch GitHub.
+        prio_field_id = self.field_id("Priority")
+        prio_option_id = self.option_id("Priority", priority)
+        status_field_id = self.field_id("Status")
+        status_option_id = self.option_id("Status", status)
+        extras: list[tuple[str, str]] = []
+        for name, value in fields or []:
+            extras.append((self.field_id(name), self.option_id(name, value)))
+
+        # Resolve item-id. assume_new short-circuits the membership scan.
+        item_id: str
+        if assume_new:
+            item_id = self._add_to_board(issue_number)
+        else:
+            try:
+                item_id = self.find_item_id(issue_number)
+            except ItemNotFound:
+                item_id = self._add_to_board(issue_number)
+
+        # Labels are issue-scoped, not item-scoped; gh issue edit handles it.
+        if labels:
+            label_args = ["issue", "edit", str(issue_number), "--repo", self.repo]
+            for label in labels:
+                label_args.extend(["--add-label", label])
+            self.run_gh(label_args)
+
+        # Priority → Status → extras, in that order. Failures here leave the
+        # item partially configured; recovery is `jared add-to-board <N> ...`.
+        for field_id_, option_id_ in [
+            (prio_field_id, prio_option_id),
+            (status_field_id, status_option_id),
+            *extras,
+        ]:
+            self.run_gh(
+                [
+                    "project",
+                    "item-edit",
+                    "--project-id",
+                    self.project_id,
+                    "--id",
+                    item_id,
+                    "--field-id",
+                    field_id_,
+                    "--single-select-option-id",
+                    option_id_,
+                ]
+            )
+
+        return item_id
+
     def run_graphql(
         self, query: str, *, cache: str | None = None, **variables: str | int | bool
     ) -> Any:

--- a/tests/test_cmd_add_to_board.py
+++ b/tests/test_cmd_add_to_board.py
@@ -1,0 +1,239 @@
+"""Tests for `jared add-to-board <N>` — the recovery path / standalone-add subcommand.
+
+The subcommand was added alongside #64 to make `jared file` failures
+recoverable: when the post-create chain breaks, `_cmd_file` prints a
+literal `jared add-to-board <N> ...` line, and the user pastes it back.
+The same subcommand also serves the legitimate "I created the issue
+manually, now put it on the board" flow.
+
+Idempotency invariant tested below: calling the subcommand on an issue
+already on the board should *not* call `gh project item-add` again — it
+should reuse the existing item-id discovered by `find_item_id`.
+"""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from tests.conftest import FakeGhResult, import_cli
+
+
+def _write_full_board(tmp_path: Path) -> Path:
+    board_md = tmp_path / "docs" / "project-board.md"
+    board_md.parent.mkdir(parents=True)
+    board_md.write_text(
+        dedent("""\
+        - Project URL: https://github.com/users/brockamer/projects/7
+        - Project number: 7
+        - Project ID: PVT_kwHO_xyz
+        - Owner: brockamer
+        - Repo: brockamer/findajob
+
+        ### Status
+        - Field ID: PVTSSF_status
+        - Backlog: OPTION_backlog
+        - Up Next: OPTION_up_next
+        - In Progress: OPTION_in_progress
+        - Done: OPTION_done
+        - Blocked: OPTION_blocked
+
+        ### Priority
+        - Field ID: PVTSSF_prio
+        - High: OPTION_high
+        - Medium: OPTION_med
+        - Low: OPTION_low
+
+        ### Work Stream
+        - Field ID: PVTSSF_ws
+        - Perception: OPTION_perc
+        - Planning: OPTION_plan
+        - Fleet Ops: OPTION_fleet
+    """)
+    )
+    return board_md
+
+
+def test_add_to_board_when_issue_not_on_board(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Issue absent from board → item-list (membership check) → item-add → field edits."""
+    board_md = _write_full_board(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        if "item-list" in joined:
+            # Membership check: no item for this issue number.
+            return FakeGhResult(stdout='{"items": []}')
+        if "item-add" in joined:
+            return FakeGhResult(stdout='{"id": "PVTI_new"}')
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "add-to-board",
+            "142",
+            "--priority",
+            "High",
+            "--status",
+            "Up Next",
+            "--field",
+            "Work Stream=Planning",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+
+    # find_item_id triggers item-list; issue isn't on board, so we item-add.
+    assert any("item-add" in " ".join(c) for c in calls)
+
+    # All three edits land: Priority + Status + Work Stream.
+    edits = [c for c in calls if "item-edit" in c]
+    assert len(edits) >= 3, calls
+    joined_edits = " ".join(" ".join(c) for c in edits)
+    assert "PVTSSF_prio" in joined_edits and "OPTION_high" in joined_edits
+    assert "PVTSSF_status" in joined_edits and "OPTION_up_next" in joined_edits
+    assert "PVTSSF_ws" in joined_edits and "OPTION_plan" in joined_edits
+
+
+def test_add_to_board_idempotent_when_issue_already_on_board(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Issue already on board → item-list finds it → NO item-add → field edits.
+
+    Confirms the helper re-uses an existing item-id rather than calling
+    `gh project item-add` (which would either error or duplicate). This is
+    the safety property that makes the recovery flow re-runnable without
+    surprises if the user re-pastes the recovery command after a partial
+    re-success.
+    """
+    board_md = _write_full_board(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        if "item-list" in joined:
+            return FakeGhResult(
+                stdout=('{"items": [{"id": "PVTI_existing", "content": {"number": 142}}]}')
+            )
+        # If the helper ever calls item-add here, the test should still
+        # complete — but the assertion below catches the regression.
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "add-to-board",
+            "142",
+            "--priority",
+            "Medium",
+            "--status",
+            "Backlog",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+
+    # The whole point of the idempotency property: no item-add.
+    assert not any("item-add" in " ".join(c) for c in calls), (
+        f"add-to-board should re-use the existing item-id, not call item-add. Calls: {calls}"
+    )
+
+    # Edits still apply against the discovered item-id.
+    edits = [c for c in calls if "item-edit" in c]
+    joined_edits = " ".join(" ".join(c) for c in edits)
+    assert "PVTI_existing" in joined_edits, joined_edits
+    assert "PVTSSF_prio" in joined_edits and "OPTION_med" in joined_edits
+    assert "PVTSSF_status" in joined_edits and "OPTION_backlog" in joined_edits
+
+
+def test_add_to_board_applies_labels_when_provided(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--label` translates to `gh issue edit --add-label` (not item-edit)."""
+    board_md = _write_full_board(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        if "item-list" in joined:
+            return FakeGhResult(stdout='{"items": []}')
+        if "item-add" in joined:
+            return FakeGhResult(stdout='{"id": "PVTI_new"}')
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "add-to-board",
+            "142",
+            "--priority",
+            "Low",
+            "--label",
+            "bug",
+            "--label",
+            "documentation",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+
+    issue_edits = [c for c in calls if "issue" in c and "edit" in c]
+    assert len(issue_edits) == 1, issue_edits
+    label_call = " ".join(issue_edits[0])
+    assert "--add-label bug" in label_call
+    assert "--add-label documentation" in label_call
+
+
+def test_add_to_board_rejects_malformed_field_spec(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--field` without `=` → exit 1, matches `_cmd_file` behavior."""
+    board_md = _write_full_board(tmp_path)
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "add-to-board",
+            "142",
+            "--priority",
+            "Low",
+            "--field",
+            "no-equals-sign",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "NAME=VALUE" in captured.err

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -211,14 +211,74 @@ def test_file_emits_recovery_command_on_post_create_failure(
     assert rc != 0, captured.err
 
     # Recovery command must be in stderr, with the right issue number,
-    # priority, status, and any extra --field values the user passed.
-    assert "jared add-to-board" in captured.err, captured.err
+    # priority, status, and any extra --field values the user passed. The
+    # binary path is `Path(__file__).resolve()` of the running CLI so the
+    # paste-and-run line points at *this* jared, not bare `jared` (which
+    # is typically not on PATH).
+    assert "/jared add-to-board" in captured.err, captured.err
     assert str(issue_number) in captured.err, captured.err
     assert "--priority High" in captured.err, captured.err
     assert "'Up Next'" in captured.err, captured.err
     assert "'Work Stream=Planning'" in captured.err, captured.err
     # Underlying gh error context is surfaced too.
     assert "Resource not accessible" in captured.err, captured.err
+
+
+def test_file_emits_recovery_command_on_item_edit_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same recovery contract when failure is *after* item-add succeeds.
+
+    Covers the "network blip mid-loop" failure mode advisor flagged: the
+    issue is on the board with an item-id, but a later `gh project item-edit`
+    fails (Priority set, Status not yet, etc.). Recovery line still works
+    because `jared add-to-board` is idempotent — it'll find the existing
+    item, skip item-add, and finish setting fields.
+    """
+    board_md = _write_full_board(tmp_path)
+    body_file = tmp_path / "body.md"
+    body_file.write_text("Body content.")
+
+    issue_number = 142
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        joined = " ".join(args)
+        if "issue create" in joined:
+            return FakeGhResult(
+                stdout=f"https://github.com/brockamer/findajob/issues/{issue_number}\n"
+            )
+        if "item-add" in joined:
+            return FakeGhResult(stdout='{"id": "PVTI_new"}')
+        if "item-edit" in joined:
+            return FakeGhResult(
+                stdout="",
+                returncode=1,
+                stderr="GraphQL: rate limit exceeded (updateProjectV2ItemFieldValue)",
+            )
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body-file",
+            str(body_file),
+            "--priority",
+            "Medium",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc != 0, captured.err
+    assert "/jared add-to-board" in captured.err, captured.err
+    assert str(issue_number) in captured.err, captured.err
+    assert "--priority Medium" in captured.err, captured.err
+    assert "rate limit exceeded" in captured.err, captured.err
 
 
 def test_file_makes_no_item_list_calls(

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -151,6 +151,76 @@ def test_file_with_custom_status_and_extra_field(
     assert "PVTSSF_ws" in joined_edits and "OPTION_plan" in joined_edits
 
 
+def test_file_emits_recovery_command_on_post_create_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Regression test for #64: when post-create fails, `jared file` must
+    print the literal `jared add-to-board <N> ...` recovery command to
+    stderr instead of leaving the user to reverse-engineer gh project calls.
+
+    Simulates `gh project item-add` failing (the real-world trigger was a
+    GH_TOKEN-without-project-scope env override, but any failure in the
+    post-create chain should surface the same recovery path).
+    """
+    board_md = _write_full_board(tmp_path)
+    body_file = tmp_path / "body.md"
+    body_file.write_text("Body content.")
+
+    issue_number = 142
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        joined = " ".join(args)
+        if "issue create" in joined:
+            return FakeGhResult(
+                stdout=f"https://github.com/brockamer/findajob/issues/{issue_number}\n"
+            )
+        if "item-add" in joined:
+            return FakeGhResult(
+                stdout="",
+                returncode=1,
+                stderr=(
+                    "GraphQL: Resource not accessible by personal "
+                    "access token (addProjectV2ItemById)"
+                ),
+            )
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body-file",
+            str(body_file),
+            "--priority",
+            "High",
+            "--status",
+            "Up Next",
+            "--field",
+            "Work Stream=Planning",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    # Non-zero exit so the calling shell knows the filing did not complete.
+    assert rc != 0, captured.err
+
+    # Recovery command must be in stderr, with the right issue number,
+    # priority, status, and any extra --field values the user passed.
+    assert "jared add-to-board" in captured.err, captured.err
+    assert str(issue_number) in captured.err, captured.err
+    assert "--priority High" in captured.err, captured.err
+    assert "'Up Next'" in captured.err, captured.err
+    assert "'Work Stream=Planning'" in captured.err, captured.err
+    # Underlying gh error context is surfaced too.
+    assert "Resource not accessible" in captured.err, captured.err
+
+
 def test_file_makes_no_item_list_calls(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

- Add `jared add-to-board <N> --priority X --status Y [--field NAME=VALUE]` subcommand. Idempotent — safe to re-run.
- When `jared file` fails after `gh issue create` (e.g., `addProjectV2ItemById` rejected, transient error, rate limit), print the literal `jared add-to-board <N> ...` recovery command to stderr instead of leaving the user to reverse-engineer raw `gh project` calls with field/option UUIDs.
- Extract the post-create chain into `Board.add_existing_to_board(...)`. `_cmd_file` calls it with `assume_new=True` to preserve the #4 perf fix (no `item-list` scan in the filing hot path).
- Bonus: the new subcommand also serves the legitimate "I created an issue manually, now put it on the board with fields" workflow.

Closes #64. Decision rationale (why (b) over (a) atomic-delete or (c) self-healing scan) is recorded in the issue body's `## Decisions` section.

## Test plan

- [x] `pytest -q` — 125 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy` — clean
- [x] Regression test for the failure path: stderr includes literal `jared add-to-board <N>` with correct priority/status/--field; exit ≠ 0
- [x] Idempotency test: helper does NOT call `gh project item-add` when the issue is already on the board
- [x] Label-application test: `--label X --label Y` translates to a single `gh issue edit --add-label X --add-label Y`
- [x] Existing `_cmd_file` happy-path tests still pass after the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)