### PR TITLE
fix(file): scrub GH_TOKEN/GITHUB_TOKEN from gh subprocess env (#65)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
 import re
 import subprocess
 import time
@@ -413,6 +414,21 @@ def run_gh(args: list[str], *, cache: str | None = None) -> Any:
         raise GhInvocationError(f"gh returned non-JSON output: {stdout[:200]}") from e
 
 
+def _child_env() -> dict[str, str]:
+    """Env for `gh` subprocess calls, with GH_TOKEN/GITHUB_TOKEN removed.
+
+    When either var is set, gh prefers it over the OAuth session from
+    `gh auth login`, so a fine-grained PAT without `project` scope shadows
+    an OAuth token that has it — and `gh auth status` doesn't surface the
+    override. Scrubbing here forces project mutations (and every other gh
+    call) onto the OAuth session jared expects to be authoritative.
+    """
+    env = os.environ.copy()
+    env.pop("GH_TOKEN", None)
+    env.pop("GITHUB_TOKEN", None)
+    return env
+
+
 def run_gh_raw(args: list[str], *, cache: str | None = None) -> str:
     """Run a `gh` subcommand and return its stdout (stripped) without JSON parsing.
 
@@ -431,6 +447,7 @@ def run_gh_raw(args: list[str], *, cache: str | None = None) -> str:
         capture_output=True,
         text=True,
         check=False,
+        env=_child_env(),
     )
     if result.returncode != 0:
         raise GhInvocationError(

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -468,6 +468,42 @@ def test_check_graphql_budget_force_overrides_low() -> None:
     )
 
 
+def test_run_gh_strips_github_token_envs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """gh prefers GH_TOKEN/GITHUB_TOKEN over `gh auth login`'s OAuth session, so a
+    fine-grained PAT without `project` scope shadows an OAuth token that has it.
+    run_gh_raw must scrub both vars from the child env (jared#65)."""
+    from skills.jared.scripts.lib.board import Board
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    monkeypatch.setenv("GH_TOKEN", "bogus-pat")
+    monkeypatch.setenv("GITHUB_TOKEN", "bogus-pat")
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    captured: dict[str, object] = {}
+
+    class FakeResult:
+        returncode = 0
+        stdout = "{}"
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured["env"] = kw.get("env")
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    b.run_gh(["api", "graphql", "-f", "query=mutation{}"])
+
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "GH_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert env.get("PATH") == "/usr/bin"
+
+
 def test_run_gh_cache_flag_passthrough(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """run_gh(args, cache='5m') appends `--cache 5m` for direct gh api callers
     (e.g. sweep.py's gh api repos/.../comments path)."""

--- a/tests/testbed-setup.md
+++ b/tests/testbed-setup.md
@@ -8,6 +8,17 @@ testbed from scratch.
 - `gh` authenticated (`gh auth status` green) with `project` scope.
 - Write access to `brockamer/jared-testbed` (or equivalent — adjust names below).
 
+> **`GH_TOKEN` gotcha.** When `GH_TOKEN` (or `GITHUB_TOKEN`) is exported, `gh`
+> uses it for every API call regardless of `gh auth login`'s OAuth session, and
+> `gh auth status` still reports the OAuth scopes ✓ — misleading, since it's
+> reporting scopes from a source `gh` won't actually use. If a fine-grained PAT
+> without `project` scope is in `GH_TOKEN`, project mutations fail with
+> `Resource not accessible by personal access token`. Jared's `lib/board.py`
+> wrapper scrubs both vars from the child env before invoking `gh`, so the
+> OAuth session is what takes effect — but `gh` invoked directly from the
+> shell still picks up the env. If you hit a token-scope error from a raw
+> `gh` command in this doc, run `unset GH_TOKEN GITHUB_TOKEN` first.
+
 ## One-time setup
 
 1. Create repo:


### PR DESCRIPTION
## Summary
- Scrubs `GH_TOKEN` and `GITHUB_TOKEN` from the env passed to every `gh` subprocess in `lib/board.py`, so project mutations use `gh auth login`'s OAuth session (which jared expects to have `project` scope) instead of whatever fine-grained PAT the operator has set for adjacent purposes.
- Centralized in a new `_child_env()` helper invoked from `run_gh_raw`. `run_gh` and `run_graphql` flow through `run_gh_raw`, so the one chokepoint covers all three layers — no per-callsite changes.
- Decision: **uniform** scrub (issue body invited the call between selective and uniform — uniform is simpler and the OAuth session is the auth jared expects to be authoritative everywhere).

Closes #65.

## Why this matters
When a fine-grained PAT lacking `project` scope is in `GH_TOKEN`, project mutations fail with `Resource not accessible by personal access token` while `gh auth status` still reports the OAuth scopes ✓ — confusing because it's reporting scopes from a source `gh` won't actually use for the call. This is one trigger of the trailscribe#161 incident, and a permanent gotcha for any operator with `GH_TOKEN` set in their environment for any reason.

#66 (token-scope diagnostic) is the companion fix: even after this, future scope failures (e.g., OAuth session lacking `project`) still need an intelligible error message.

## Test plan
- [x] New unit test: set `GH_TOKEN=bogus` + `GITHUB_TOKEN=bogus`, capture `subprocess.run`'s `env` kwarg, assert neither var is present and `PATH` is preserved (proves we pass a full env, not `env={}` which would break `gh` discovery).
- [x] Full test suite: 127 passed.
- [x] `ruff check .` clean.
- [x] `mypy` clean.
- [ ] Manual smoke: with `GH_TOKEN=<scope-less PAT>` exported, run `jared file --title "smoke" --body-file - --priority Low --status Backlog --label "big ideas" <<< "smoke"` — expect success (vs. prior `Resource not accessible` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)