### PR TITLE
fix(file): token-scope diagnostic on project-mutation 403s (#66)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -429,6 +429,83 @@ def _child_env() -> dict[str, str]:
     return env
 
 
+_TOKEN_SCOPE_ERROR_SIGNATURE = "Resource not accessible by personal access token"
+
+
+def _looks_like_project_mutation(args: list[str]) -> bool:
+    """True when args correspond to a project v2 mutation that needs `project` scope.
+
+    Two shapes hit this codepath: `gh project item-add/item-edit/item-archive ...`
+    and `gh api graphql -f query=mutation { ... addProjectV2... | updateProjectV2... }`.
+    """
+    if not args:
+        return False
+    if args[0] == "project" and len(args) > 1 and args[1] in {
+        "item-add",
+        "item-edit",
+        "item-archive",
+        "item-delete",
+        "create",
+        "field-create",
+    }:
+        return True
+    if args[:2] == ["api", "graphql"]:
+        for chunk in args:
+            if "addProjectV2" in chunk or "updateProjectV2" in chunk or "deleteProjectV2" in chunk:
+                return True
+    return False
+
+
+def _format_token_scope_diagnostic() -> str:
+    """Four-part diagnostic block for `Resource not accessible by personal access token`
+    failures from project mutations. Best-effort — silently skips parts that can't be
+    determined.
+
+    Post-#65, jared scrubs GH_TOKEN/GITHUB_TOKEN before invoking gh, so the call
+    that just failed ran on `gh auth login`'s OAuth session. The realistic remaining
+    trigger for this error class is OAuth without `project` scope. Mention the #65
+    scrub explicitly so an operator with GH_TOKEN set isn't misled.
+    """
+    lines: list[str] = ["", "Token-scope diagnostic:"]
+
+    has_gh_token = bool(os.environ.get("GH_TOKEN"))
+    has_gh_token_var = "GITHUB_TOKEN" if os.environ.get("GITHUB_TOKEN") else None
+    if has_gh_token or has_gh_token_var:
+        lines.append(
+            "  Token source used: gh auth login OAuth session "
+            "(jared scrubs GH_TOKEN/GITHUB_TOKEN before invoking gh — see #65)."
+        )
+    else:
+        lines.append("  Token source used: gh auth login OAuth session.")
+
+    scopes = _probe_oauth_scopes()
+    if scopes is not None:
+        lines.append(f"  Scopes present: {scopes or '(none reported)'}")
+
+    lines.append("  Scopes needed: project (write) for project v2 mutations.")
+    lines.append("  Suggested fix: gh auth refresh -s project")
+    return "\n".join(lines)
+
+
+def _probe_oauth_scopes() -> str | None:
+    """Best-effort scopes lookup via `gh auth status`. Returns the scopes line,
+    or None if the probe fails."""
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_child_env(),
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    blob = (result.stdout or "") + (result.stderr or "")
+    m = re.search(r"Token scopes:\s*(.+)", blob)
+    return m.group(1).strip() if m else None
+
+
 def run_gh_raw(args: list[str], *, cache: str | None = None) -> str:
     """Run a `gh` subcommand and return its stdout (stripped) without JSON parsing.
 
@@ -450,9 +527,15 @@ def run_gh_raw(args: list[str], *, cache: str | None = None) -> str:
         env=_child_env(),
     )
     if result.returncode != 0:
-        raise GhInvocationError(
+        message = (
             f"gh {' '.join(args)} exited {result.returncode}: {result.stderr.strip()}"
         )
+        if (
+            _TOKEN_SCOPE_ERROR_SIGNATURE in result.stderr
+            and _looks_like_project_mutation(args)
+        ):
+            message += "\n" + _format_token_scope_diagnostic()
+        raise GhInvocationError(message)
     return result.stdout.strip()
 
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -229,6 +229,130 @@ def test_run_gh_non_zero_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     with pytest.raises(GhInvocationError) as exc:
         b.run_gh(["api", "user"])
     assert "401" in str(exc.value)
+    # Non-token-scope failures should NOT carry the diagnostic block (jared#66).
+    assert "Token-scope diagnostic" not in str(exc.value)
+
+
+def test_token_scope_error_on_project_mutation_includes_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A `Resource not accessible by personal access token` failure on a project-v2
+    mutation should append the four-part diagnostic (token source, scopes-needed,
+    suggested fix). Non-mutation failures with the same stderr should not (jared#66)."""
+    from skills.jared.scripts.lib.board import Board, GhInvocationError
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = (
+            "GraphQL: Resource not accessible by personal access token "
+            "(addProjectV2ItemById)"
+        )
+
+    # Sequenced fake: first call (the failing mutation) returns the 403; any
+    # subsequent call (the auth-status probe inside the diagnostic) returns no
+    # parseable scopes line so the test doesn't depend on the host's gh state.
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        calls.append(args)
+        if args[:2] == ["gh", "auth"]:
+
+            class AuthResult:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return AuthResult()  # type: ignore[return-value]
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    project_mutation_args = [
+        "api",
+        "graphql",
+        "-f",
+        'query=mutation { addProjectV2ItemById(input: {projectId: "x", contentId: "y"}) '
+        "{ item { id } } }",
+    ]
+    with pytest.raises(GhInvocationError) as exc:
+        b.run_gh(project_mutation_args)
+    msg = str(exc.value)
+    assert "Token-scope diagnostic" in msg
+    assert "Token source used:" in msg
+    assert "Scopes needed: project" in msg
+    assert "gh auth refresh -s project" in msg
+
+
+def test_token_scope_error_on_repo_call_skips_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same error string on a non-project-mutation call (e.g. `gh api user`) should
+    not append the diagnostic — only project-mutation paths get the four-part block,
+    per the AC bullet about not noising up other failures."""
+    from skills.jared.scripts.lib.board import Board, GhInvocationError
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "Resource not accessible by personal access token"
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    with pytest.raises(GhInvocationError) as exc:
+        b.run_gh(["api", "user"])
+    assert "Token-scope diagnostic" not in str(exc.value)
+
+
+def test_token_scope_diagnostic_mentions_gh_token_scrub_when_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When operator has GH_TOKEN exported, the diagnostic should mention that jared
+    scrubs it (#65) so the operator isn't misled into thinking GH_TOKEN is the cause."""
+    from skills.jared.scripts.lib.board import Board, GhInvocationError
+
+    b = Board.from_path(_minimal_board(tmp_path))
+    monkeypatch.setenv("GH_TOKEN", "scopeless-pat")
+
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "Resource not accessible by personal access token"
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        if args[:2] == ["gh", "auth"]:
+
+            class AuthResult:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return AuthResult()  # type: ignore[return-value]
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    with pytest.raises(GhInvocationError) as exc:
+        b.run_gh(
+            [
+                "project",
+                "item-add",
+                "1",
+                "--owner",
+                "x",
+                "--url",
+                "https://github.com/x/y/issues/1",
+            ]
+        )
+    assert "scrubs GH_TOKEN/GITHUB_TOKEN" in str(exc.value)
+    assert "#65" in str(exc.value)
 
 
 def test_find_item_id_finds_match(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- When a project v2 mutation fails with `Resource not accessible by personal access token`, append a four-part diagnostic before raising: token source used, scopes present (best-effort), scopes needed, suggested fix.
- Sniff is narrow: only fires when stderr contains the signature **and** the args look like a project-v2 mutation (`gh project item-*/create/field-create` or `gh api graphql` whose query mentions `addProjectV2|updateProjectV2|deleteProjectV2`). Other failures pass through unchanged, per the AC bullet about not noising up unrelated errors.
- When operator has `GH_TOKEN` or `GITHUB_TOKEN` exported, the diagnostic explicitly mentions that jared scrubs them (#65) — pre-empts the "but I have a PAT set!" misdirection.

Closes #66.

## AC drift note
The issue body was written before #65 shipped and listed `unset GH_TOKEN && retry` as one of the suggested fixes. Post-#65 that case never reaches the user — jared scrubs both vars unconditionally. The diagnostic reflects the post-#65 reality (OAuth-without-`project` is the realistic remaining trigger; `gh auth refresh -s project` is the fix). The scrub-mention keeps it honest about *why* the operator's GH_TOKEN isn't the answer.

## Test plan
- [x] New tests in `tests/test_board.py`:
  - project-mutation 403 → diagnostic appended (covers GraphQL mutation argv shape)
  - non-mutation 403 (e.g. `gh api user`) → no diagnostic
  - `GH_TOKEN` exported in parent env → diagnostic mentions the scrub + #65
  - existing `test_run_gh_non_zero_raises` extended to assert diagnostic absence on non-token-scope failures
- [x] Full suite: 130 passed.
- [x] `ruff check .` clean.
- [x] `mypy` clean.
- [ ] Manual smoke: revoke `project` scope on `gh auth login`'s OAuth session, run `jared file ...`, observe diagnostic block in stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)