### PR TITLE
verify(file): gh project item-add is idempotent on already-added issues (#71)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -297,6 +297,11 @@ class Board:
 
         Invalidates the cached item-list snapshot so subsequent `find_item_id`
         calls in the same process see the addition.
+
+        Empirically idempotent (jared#71, 2026-05-01): calling item-add on an
+        already-on-board issue exits 0 and returns the existing item-id, so
+        the `assume_new=True` short-circuit in `add_existing_to_board` and
+        the recovery flow from #64 are safe to re-run.
         """
         url = f"https://github.com/{self.repo}/issues/{issue_number}"
         data = self.run_gh(

--- a/tests/test_integration_item_add_idempotency.py
+++ b/tests/test_integration_item_add_idempotency.py
@@ -1,0 +1,87 @@
+"""Integration test for #71 — empirically verify `gh project item-add` is idempotent
+on an already-on-board issue.
+
+Gated by `pytest -m integration`. Requires tests/testbed.env (see tests/testbed-setup.md).
+The default test run skips this (pyproject sets `addopts = "-m 'not integration'"`).
+
+Empirical probe on 2026-05-01 against project #4 (jared itself, real account) confirmed
+behavior (a) from the issue body: a duplicate item-add returns exit 0 with stdout JSON
+containing the existing item-id. This test pins that behavior so a future gh release
+that regresses to a duplicate-add error is caught at the testbed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _load_testbed_env() -> dict[str, str]:
+    """Parse tests/testbed.env into a dict. Skips the test if missing."""
+    env_path = Path(__file__).parent / "testbed.env"
+    if not env_path.exists():
+        pytest.skip("tests/testbed.env not present — see tests/testbed-setup.md")
+    out: dict[str, str] = {}
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+@pytest.mark.integration
+def test_gh_project_item_add_is_idempotent_on_already_added_issue() -> None:
+    """Calling `gh project item-add` twice on the same issue against the testbed
+    should return exit 0 both times with the same item-id in stdout."""
+    env_vars = _load_testbed_env()
+    project_number = env_vars.get("TESTBED_PROJECT_NUMBER")
+    owner = env_vars.get("TESTBED_OWNER")
+    repo = env_vars.get("TESTBED_REPO")
+    if not (project_number and owner and repo):
+        pytest.skip("TESTBED_PROJECT_NUMBER / TESTBED_OWNER / TESTBED_REPO unset")
+
+    # Use seed issue #1 — should always exist on the testbed (see seed-issues.yaml).
+    issue_url = f"https://github.com/{repo}/issues/1"
+
+    # Match jared's child-env discipline (#65) — scrub GH_TOKEN/GITHUB_TOKEN so the
+    # call uses the OAuth session jared expects to be authoritative.
+    child_env = os.environ.copy()
+    child_env.pop("GH_TOKEN", None)
+    child_env.pop("GITHUB_TOKEN", None)
+
+    args = [
+        "gh",
+        "project",
+        "item-add",
+        project_number,
+        "--owner",
+        owner,
+        "--url",
+        issue_url,
+        "--format",
+        "json",
+    ]
+
+    first = subprocess.run(args, capture_output=True, text=True, check=False, env=child_env)
+    assert first.returncode == 0, f"first item-add failed: {first.stderr}"
+    first_id = json.loads(first.stdout)["id"]
+
+    second = subprocess.run(args, capture_output=True, text=True, check=False, env=child_env)
+    assert second.returncode == 0, (
+        "second item-add on already-added issue failed — gh idempotency assumption "
+        f"broken (#71). stderr: {second.stderr}"
+    )
+    second_id = json.loads(second.stdout)["id"]
+
+    assert first_id == second_id, (
+        f"second item-add returned a different item-id ({second_id} vs {first_id}) — "
+        "this would also break the assume_new=True short-circuit assumption (#71)."
+    )


### PR DESCRIPTION
## Summary
- Empirically verified the assumption baked into `_cmd_file`'s `assume_new=True` and the #64 recovery flow: `gh project item-add` on an already-on-board issue returns exit 0 with stdout JSON containing the existing item-id (behavior **(a)** from the issue body).
- One-line empirical-finding comment on `Board._add_to_board` so a future reader sees the answer + the date.
- Integration-gated test (`pytest -m integration`) pins the behavior on the testbed so a future gh regression is caught.

Closes #71.

## Empirical probe
```
$ gh project item-add 4 --owner brockamer --url https://github.com/brockamer/jared/issues/71 --format json
{"id":"PVTI_lAHOAgGulc4BVgT5zgrk6dc", ... "title":"verify gh project item-add idempotency on already-added issue", ...}
exit code: 0
```
The returned `id` matches the existing item-id from `jared get-item 71`, confirming idempotency. Probe was run against project #4 (jared itself) on 2026-05-01 because `tests/testbed.env` isn't present in this environment — an already-Done item was the lowest-risk live target available.

## Test plan
- [x] Default suite: `pytest` — 130 passed, 1 deselected (the integration test).
- [x] `pytest -m integration --collect-only` — collects the new test correctly.
- [x] `ruff check .` — clean.
- [x] `mypy` — clean.
- [ ] Run `pytest -m integration` against the bootstrapped testbed (deferred — testbed.env absent locally; CI or operator with testbed.env will exercise the test).

## Notes
- Pulls one foot of the `feedback_deferred_verification_drift` discipline: empirical verification was the *content* of this issue, not a deferred sidecar. The unit-test scaffold lives in the producing PR.
- After this merges the trailscribe-incident triad (#64, #65, #66) plus the empirical follow-up (#71) is fully resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)