### PR TITLE
chore(release): bump version 0.7.0 → 0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.7.0"
+version = "0.8.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
Bumps `.claude-plugin/plugin.json` and `pyproject.toml` from 0.7.0 → 0.8.0.

## Release theme
Reliability — trailscribe-incident triad and adjacent fixes around project-mutation atomicity, gh token handling, and session continuity.

### Changes since v0.7.0
- **#64** `fix(file): atomicity recovery via \`jared add-to-board <N>\`` — partially-failed `jared file` runs surface a paste-and-run recovery line on stderr; new `Board.add_existing_to_board` is also reusable for "manually-created issue, now put it on the board" workflows.
- **#65** `fix(file): scrub GH_TOKEN/GITHUB_TOKEN from gh subprocess env` — project mutations use `gh auth login`'s OAuth session unconditionally; fine-grained PATs no longer shadow it.
- **#66** `fix(file): token-scope diagnostic on project-mutation 403s` — `Resource not accessible by personal access token` failures now print a four-part block (token source, scopes present, scopes needed, suggested fix).
- **#69** `fix(wrap): archive older handoff prompts after writing new one` — `/jared-wrap` sweeps prior `tmp/next-session-prompt-*.md` into `tmp/handoff-archive/`.
- **#71** `verify(file): gh project item-add is idempotent on already-added issues` — empirically confirmed; integration test pins the behavior on the testbed.

## Test plan
- [x] Default suite green at `40d85ad` (130 passed).
- [x] Tag `v0.8.0` will be cut from main after this merges.
- [ ] Reload plugin locally (`/plugin update jared` + `/reload-plugins`) and smoke `jared` from a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)