### PR TITLE
perf(file): batch field mutations into one GraphQL call (#53)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -375,27 +375,24 @@ class Board:
                 label_args.extend(["--add-label", label])
             self.run_gh(label_args)
 
-        # Priority → Status → extras, in that order. Failures here leave the
-        # item partially configured; recovery is `jared add-to-board <N> ...`.
-        for field_id_, option_id_ in [
-            (prio_field_id, prio_option_id),
-            (status_field_id, status_option_id),
-            *extras,
-        ]:
-            self.run_gh(
-                [
-                    "project",
-                    "item-edit",
-                    "--project-id",
-                    self.project_id,
-                    "--id",
-                    item_id,
-                    "--field-id",
-                    field_id_,
-                    "--single-select-option-id",
-                    option_id_,
-                ]
-            )
+        # Build a single aliased mutation that sets Priority, Status, and any
+        # extras in one GraphQL round-trip. IDs are opaque internal values
+        # resolved above from project-board.md — interpolating them directly
+        # is safe. cache=None is required (mutations must never be cached).
+        all_fields = [
+            ("setPriority", prio_field_id, prio_option_id),
+            ("setStatus", status_field_id, status_option_id),
+            *[(f"setExtra{i}", fid, oid) for i, (fid, oid) in enumerate(extras)],
+        ]
+        mutation_parts = "\n  ".join(
+            f"{alias}: updateProjectV2ItemFieldValue("
+            f'input: {{projectId: "{self.project_id}", itemId: "{item_id}", '
+            f'fieldId: "{fid}", value: {{singleSelectOptionId: "{oid}"}}}}'
+            f") {{ projectV2Item {{ id }} }}"
+            for alias, fid, oid in all_fields
+        )
+        mutation = f"mutation {{\n  {mutation_parts}\n}}"
+        self.run_graphql(mutation, cache=None)
 
         return item_id
 
@@ -445,14 +442,19 @@ def _looks_like_project_mutation(args: list[str]) -> bool:
     """
     if not args:
         return False
-    if args[0] == "project" and len(args) > 1 and args[1] in {
-        "item-add",
-        "item-edit",
-        "item-archive",
-        "item-delete",
-        "create",
-        "field-create",
-    }:
+    if (
+        args[0] == "project"
+        and len(args) > 1
+        and args[1]
+        in {
+            "item-add",
+            "item-edit",
+            "item-archive",
+            "item-delete",
+            "create",
+            "field-create",
+        }
+    ):
         return True
     if args[:2] == ["api", "graphql"]:
         for chunk in args:
@@ -532,13 +534,8 @@ def run_gh_raw(args: list[str], *, cache: str | None = None) -> str:
         env=_child_env(),
     )
     if result.returncode != 0:
-        message = (
-            f"gh {' '.join(args)} exited {result.returncode}: {result.stderr.strip()}"
-        )
-        if (
-            _TOKEN_SCOPE_ERROR_SIGNATURE in result.stderr
-            and _looks_like_project_mutation(args)
-        ):
+        message = f"gh {' '.join(args)} exited {result.returncode}: {result.stderr.strip()}"
+        if _TOKEN_SCOPE_ERROR_SIGNATURE in result.stderr and _looks_like_project_mutation(args):
             message += "\n" + _format_token_scope_diagnostic()
         raise GhInvocationError(message)
     return result.stdout.strip()

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -246,10 +246,7 @@ def test_token_scope_error_on_project_mutation_includes_diagnostic(
     class FakeResult:
         returncode = 1
         stdout = ""
-        stderr = (
-            "GraphQL: Resource not accessible by personal access token "
-            "(addProjectV2ItemById)"
-        )
+        stderr = "GraphQL: Resource not accessible by personal access token (addProjectV2ItemById)"
 
     # Sequenced fake: first call (the failing mutation) returns the 403; any
     # subsequent call (the auth-status probe inside the diagnostic) returns no
@@ -592,9 +589,7 @@ def test_check_graphql_budget_force_overrides_low() -> None:
     )
 
 
-def test_run_gh_strips_github_token_envs(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_run_gh_strips_github_token_envs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """gh prefers GH_TOKEN/GITHUB_TOKEN over `gh auth login`'s OAuth session, so a
     fine-grained PAT without `project` scope shadows an OAuth token that has it.
     run_gh_raw must scrub both vars from the child env (jared#65)."""
@@ -1110,6 +1105,112 @@ def test_board_defaults_when_jared_config_absent(tmp_path: Path) -> None:
     board = Board.from_path(board_md)
     assert board.session_handoff_prompt == "ask"
     assert board.session_start_checks == []
+
+
+def _write_full_board_for_add(tmp_path: Path) -> "Path":
+    """Write a full board with Status, Priority, and Work Stream fields."""
+    from textwrap import dedent
+
+    board_md = tmp_path / "docs" / "project-board.md"
+    board_md.parent.mkdir(parents=True, exist_ok=True)
+    board_md.write_text(
+        dedent("""\
+        - Project URL: https://github.com/users/brockamer/projects/7
+        - Project number: 7
+        - Project ID: PVT_kwHO_xyz
+        - Owner: brockamer
+        - Repo: brockamer/findajob
+
+        ### Status
+        - Field ID: PVTSSF_status
+        - Backlog: OPTION_backlog
+        - Up Next: OPTION_up_next
+        - In Progress: OPTION_in_progress
+        - Done: OPTION_done
+        - Blocked: OPTION_blocked
+
+        ### Priority
+        - Field ID: PVTSSF_prio
+        - High: OPTION_high
+        - Medium: OPTION_med
+        - Low: OPTION_low
+
+        ### Work Stream
+        - Field ID: PVTSSF_ws
+        - Perception: OPTION_perc
+        - Planning: OPTION_plan
+        - Fleet Ops: OPTION_fleet
+    """)
+    )
+    return board_md
+
+
+def test_add_existing_to_board_batches_field_mutations_into_one_graphql_call(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Priority + Status + 1 extra field must issue ONE gh api graphql call, not
+    three gh project item-edit calls. This is the perf regression guard for #53.
+
+    The mutation must embed all three field IDs and option IDs in a single
+    aliased document so GitHub bills one GraphQL point instead of three.
+    """
+    from skills.jared.scripts.lib.board import Board
+    from tests.conftest import FakeGhResult
+
+    board_md = _write_full_board_for_add(tmp_path)
+    board = Board.from_path(board_md)
+
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        if "item-list" in joined:
+            # Issue already on board — find_item_id returns existing item-id.
+            return FakeGhResult(
+                stdout='{"items": [{"id": "PVTI_abc123", "content": {"number": 99}}]}'
+            )
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    item_id = board.add_existing_to_board(
+        99,
+        priority="High",
+        status="Up Next",
+        fields=[("Work Stream", "Planning")],
+    )
+
+    assert item_id == "PVTI_abc123"
+
+    # Regression guard: zero item-edit calls.
+    item_edit_calls = [c for c in calls if "item-edit" in " ".join(c)]
+    assert item_edit_calls == [], (
+        f"add_existing_to_board should not call item-edit; got {len(item_edit_calls)} call(s):\n"
+        + "\n".join(" ".join(c) for c in item_edit_calls)
+    )
+
+    # Exactly one gh api graphql call for all three field mutations.
+    graphql_calls = [c for c in calls if "api" in c and "graphql" in c]
+    assert len(graphql_calls) == 1, (
+        f"expected exactly 1 gh api graphql call, got {len(graphql_calls)}:\n"
+        + "\n".join(" ".join(c) for c in graphql_calls)
+    )
+
+    # The single mutation carries all three field IDs and their option IDs.
+    joined_mutation = " ".join(graphql_calls[0])
+    assert "PVTSSF_prio" in joined_mutation and "OPTION_high" in joined_mutation, joined_mutation
+    assert "PVTSSF_status" in joined_mutation and "OPTION_up_next" in joined_mutation, (
+        joined_mutation
+    )
+    assert "PVTSSF_ws" in joined_mutation and "OPTION_plan" in joined_mutation, joined_mutation
+
+    # The item-id is embedded in the mutation document.
+    assert "PVTI_abc123" in joined_mutation, joined_mutation
+
+    # Aliased mutation structure: each field has its own alias.
+    assert "setPriority" in joined_mutation, joined_mutation
+    assert "setStatus" in joined_mutation, joined_mutation
 
 
 def test_board_jared_config_does_not_leak_field_block_bullets(tmp_path: Path) -> None:

--- a/tests/test_cmd_add_to_board.py
+++ b/tests/test_cmd_add_to_board.py
@@ -59,7 +59,7 @@ def test_add_to_board_when_issue_not_on_board(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Issue absent from board → item-list (membership check) → item-add → field edits."""
+    """Issue absent from board → item-list (membership check) → item-add → graphql mutation."""
     board_md = _write_full_board(tmp_path)
     calls: list[list[str]] = []
 
@@ -96,13 +96,18 @@ def test_add_to_board_when_issue_not_on_board(
     # find_item_id triggers item-list; issue isn't on board, so we item-add.
     assert any("item-add" in " ".join(c) for c in calls)
 
-    # All three edits land: Priority + Status + Work Stream.
-    edits = [c for c in calls if "item-edit" in c]
-    assert len(edits) >= 3, calls
-    joined_edits = " ".join(" ".join(c) for c in edits)
-    assert "PVTSSF_prio" in joined_edits and "OPTION_high" in joined_edits
-    assert "PVTSSF_status" in joined_edits and "OPTION_up_next" in joined_edits
-    assert "PVTSSF_ws" in joined_edits and "OPTION_plan" in joined_edits
+    # All three fields land in a single graphql mutation — no item-edit calls.
+    graphql_calls = [c for c in calls if "api" in c and "graphql" in c]
+    assert len(graphql_calls) == 1, (
+        f"expected exactly 1 graphql call, got {len(graphql_calls)}: {calls}"
+    )
+    joined_graphql = " ".join(" ".join(c) for c in graphql_calls)
+    assert "PVTSSF_prio" in joined_graphql and "OPTION_high" in joined_graphql
+    assert "PVTSSF_status" in joined_graphql and "OPTION_up_next" in joined_graphql
+    assert "PVTSSF_ws" in joined_graphql and "OPTION_plan" in joined_graphql
+    assert not any("item-edit" in " ".join(c) for c in calls), (
+        "item-edit should be replaced by graphql mutation"
+    )
 
 
 def test_add_to_board_idempotent_when_issue_already_on_board(
@@ -110,7 +115,7 @@ def test_add_to_board_idempotent_when_issue_already_on_board(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Issue already on board → item-list finds it → NO item-add → field edits.
+    """Issue already on board → item-list finds it → NO item-add → single graphql mutation.
 
     Confirms the helper re-uses an existing item-id rather than calling
     `gh project item-add` (which would either error or duplicate). This is
@@ -155,12 +160,18 @@ def test_add_to_board_idempotent_when_issue_already_on_board(
         f"add-to-board should re-use the existing item-id, not call item-add. Calls: {calls}"
     )
 
-    # Edits still apply against the discovered item-id.
-    edits = [c for c in calls if "item-edit" in c]
-    joined_edits = " ".join(" ".join(c) for c in edits)
-    assert "PVTI_existing" in joined_edits, joined_edits
-    assert "PVTSSF_prio" in joined_edits and "OPTION_med" in joined_edits
-    assert "PVTSSF_status" in joined_edits and "OPTION_backlog" in joined_edits
+    # Fields are set via a single graphql mutation using the discovered item-id.
+    graphql_calls = [c for c in calls if "api" in c and "graphql" in c]
+    assert len(graphql_calls) == 1, (
+        f"expected exactly 1 graphql call, got {len(graphql_calls)}: {calls}"
+    )
+    joined_graphql = " ".join(" ".join(c) for c in graphql_calls)
+    assert "PVTI_existing" in joined_graphql, joined_graphql
+    assert "PVTSSF_prio" in joined_graphql and "OPTION_med" in joined_graphql
+    assert "PVTSSF_status" in joined_graphql and "OPTION_backlog" in joined_graphql
+    assert not any("item-edit" in " ".join(c) for c in calls), (
+        "item-edit should be replaced by graphql mutation"
+    )
 
 
 def test_add_to_board_applies_labels_when_provided(

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -103,15 +103,19 @@ def test_file_sequences_create_add_status_priority(
     captured = capsys.readouterr()
     assert rc == 0, captured.err
 
-    # Must invoke the three essentials: issue create, item-add, field edits.
+    # Must invoke the three essentials: issue create, item-add, single graphql mutation.
     assert any("issue" in c and "create" in c for c in calls)
     assert any("item-add" in c for c in calls)
 
-    edits = [c for c in calls if "item-edit" in c]
-    assert len(edits) >= 2, "expected at least Priority + Status item-edit calls"
-    joined_edits = " ".join(" ".join(c) for c in edits)
-    assert "PVTSSF_prio" in joined_edits and "OPTION_high" in joined_edits
-    assert "PVTSSF_status" in joined_edits and "OPTION_backlog" in joined_edits
+    # Field mutations go through a single `gh api graphql` call now — no item-edit.
+    graphql_calls = [c for c in calls if "api" in c and "graphql" in c]
+    assert len(graphql_calls) >= 1, "expected at least one gh api graphql call for field mutations"
+    joined_graphql = " ".join(" ".join(c) for c in graphql_calls)
+    assert "PVTSSF_prio" in joined_graphql and "OPTION_high" in joined_graphql
+    assert "PVTSSF_status" in joined_graphql and "OPTION_backlog" in joined_graphql
+    assert not any("item-edit" in " ".join(c) for c in calls), (
+        "item-edit should be replaced by graphql mutation"
+    )
 
     # No item-list in the filing path — that's the #4 regression we guard
     # against. See test_file_makes_no_item_list_calls for the explicit pin.
@@ -146,9 +150,13 @@ def test_file_with_custom_status_and_extra_field(
     )
     captured = capsys.readouterr()
     assert rc == 0, captured.err
-    joined_edits = " ".join(" ".join(c) for c in calls if "item-edit" in c)
-    assert "OPTION_up_next" in joined_edits
-    assert "PVTSSF_ws" in joined_edits and "OPTION_plan" in joined_edits
+    # All three fields land in the single graphql mutation; no item-edit calls.
+    joined_graphql = " ".join(" ".join(c) for c in calls if "api" in c and "graphql" in c)
+    assert "OPTION_up_next" in joined_graphql
+    assert "PVTSSF_ws" in joined_graphql and "OPTION_plan" in joined_graphql
+    assert not any("item-edit" in " ".join(c) for c in calls), (
+        "item-edit should be replaced by graphql mutation"
+    )
 
 
 def test_file_emits_recovery_command_on_post_create_failure(
@@ -224,16 +232,16 @@ def test_file_emits_recovery_command_on_post_create_failure(
     assert "Resource not accessible" in captured.err, captured.err
 
 
-def test_file_emits_recovery_command_on_item_edit_failure(
+def test_file_emits_recovery_command_on_field_mutation_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Same recovery contract when failure is *after* item-add succeeds.
 
-    Covers the "network blip mid-loop" failure mode advisor flagged: the
-    issue is on the board with an item-id, but a later `gh project item-edit`
-    fails (Priority set, Status not yet, etc.). Recovery line still works
-    because `jared add-to-board` is idempotent — it'll find the existing
-    item, skip item-add, and finish setting fields.
+    Covers the "network blip on field mutation" failure mode: the issue is on
+    the board with an item-id, but the single `gh api graphql` mutation for
+    setting fields fails. Recovery line still works because `jared add-to-board`
+    is idempotent — it'll find the existing item, skip item-add, and retry
+    setting fields.
     """
     board_md = _write_full_board(tmp_path)
     body_file = tmp_path / "body.md"
@@ -249,7 +257,7 @@ def test_file_emits_recovery_command_on_item_edit_failure(
             )
         if "item-add" in joined:
             return FakeGhResult(stdout='{"id": "PVTI_new"}')
-        if "item-edit" in joined:
+        if "api" in joined and "graphql" in joined and "updateProjectV2" in joined:
             return FakeGhResult(
                 stdout="",
                 returncode=1,
@@ -330,12 +338,10 @@ def test_file_makes_no_item_list_calls(
     for c in calls:
         joined = " ".join(c)
         assert "item-list" not in joined, f"`jared file` should not call item-list; got: {joined!r}"
-    # Expected call ceiling: issue create + item-add + item-edit × 2 (Status,
-    # Priority) = 4. Gives AC headroom of 1 for an extra --field if present.
-    # Allow the test to flex by asserting an upper bound rather than equality,
-    # since argparse or gh version changes could introduce an extra query we
-    # haven't noticed.
-    assert len(calls) <= 5, (
-        f"`jared file` made {len(calls)} gh calls; expected ≤5. Calls:\n"
+    # Expected call ceiling: issue create + item-add + 1 graphql mutation = 3.
+    # All field-setting (Priority + Status + extras) is batched into one call.
+    # Allow the test to flex by asserting an upper bound rather than equality.
+    assert len(calls) <= 4, (
+        f"`jared file` made {len(calls)} gh calls; expected ≤4. Calls:\n"
         + "\n".join(" ".join(c) for c in calls)
     )


### PR DESCRIPTION
## Summary

- Replace the per-field `gh project item-edit` loop in `Board.add_existing_to_board()` with a single aliased `updateProjectV2ItemFieldValue` mutation document
- Cuts 2–3 GraphQL-billed calls per filed issue down to 1 (Priority + Status + any extras all in one round-trip)
- Applies to both the `assume_new=True` path (fresh `jared file`) and the `assume_new=False` recovery path (`jared add-to-board`)

## Test plan

- [x] New acceptance test `test_add_existing_to_board_batches_field_mutations_into_one_graphql_call` in `tests/test_board.py` — directly calls `Board.add_existing_to_board(...)` with Priority + Status + 1 extra field, asserts exactly 1 `gh api graphql` call with zero `item-edit` calls, and verifies all three field/option IDs appear in the mutation document
- [x] Updated `test_cmd_file.py` and `test_cmd_add_to_board.py` to assert on the new graphql call shape instead of `item-edit` argv — same coverage (all IDs verified), new location
- [x] Renamed `test_file_emits_recovery_command_on_item_edit_failure` → `test_file_emits_recovery_command_on_field_mutation_failure`; fake now fails on `api graphql` + `updateProjectV2` instead of `item-edit`
- [x] Tightened `test_file_makes_no_item_list_calls` call ceiling from ≤5 to ≤4 (create + item-add + 1 graphql = 3 expected)
- [x] `pytest` 131/131 passed, `ruff check`, `ruff format --check`, and `mypy --strict` all clean

Phase 2 follow-up to #49. Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)