### PR TITLE
perf(ties): single batched fetch in _cmd_ties (#81)

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -894,16 +894,9 @@ def _cmd_ties(args: argparse.Namespace) -> int:
     )
 
     board = Board.from_path(Path(args.board))
-    target = board.get_issue(args.issue_number)
-    if target is None:
-        # fetch_open_issues_for_ties already excludes Done; if get_issue returned
-        # None, the target is either closed, archived, or doesn't exist.
-        print(
-            f"jared: target #{args.issue_number} not found or closed",
-            file=sys.stderr,
-        )
-        return 1
 
+    # Budget pre-flight before any fetch — partial mode is meant to skip
+    # body bytes, so we must decide full vs partial *before* fetching.
     remaining, _, _ = board.graphql_budget()
     if remaining < 50:
         print("(GraphQL budget exhausted — ties analysis skipped)")
@@ -919,7 +912,22 @@ def _cmd_ties(args: argparse.Namespace) -> int:
         )
     )
 
+    # Single batched fetch, then resolve target by walking the result.
+    # Replaces the older Board.get_issue + fetch_open_issues_for_ties pair
+    # which paid for body bytes even in partial mode (#81).
     open_issues = board.fetch_open_issues_for_ties(include_bodies=full_mode)
+    target = next(
+        (i for i in open_issues if i.number == args.issue_number), None
+    )
+    if target is None:
+        # fetch_open_issues_for_ties excludes Done; missing → closed,
+        # archived, or doesn't exist on this repo.
+        print(
+            f"jared: target #{args.issue_number} not found or closed",
+            file=sys.stderr,
+        )
+        return 1
+
     stop_words = board.tie_stop_words()
 
     hits = []

--- a/tests/test_cmd_ties.py
+++ b/tests/test_cmd_ties.py
@@ -69,9 +69,8 @@ def test_ties_smoke_renders_block(tmp_path: Path, capsys: pytest.CaptureFixture[
         patch.object(
             cli.Board,
             "fetch_open_issues_for_ties",
-            lambda self, **kw: _stub_open_issues(),
+            lambda self, **kw: [_stub_target(), *_stub_open_issues()],
         ),
-        patch.object(cli.Board, "get_issue", lambda self, n: _stub_target()),
         patch.object(cli.Board, "tie_stop_words", lambda self: frozenset()),
     ):
         rc = cli.main(["--board", str(doc), "ties", "1"])
@@ -87,14 +86,34 @@ def test_ties_budget_exhausted_emits_skip_line(
 ) -> None:
     cli = import_cli()
     doc = _board_doc(tmp_path)
-    with (
-        patch.object(cli.Board, "graphql_budget", lambda self: (25, 5000, 0)),
-        patch.object(cli.Board, "get_issue", lambda self, n: _stub_target()),
-    ):
+    with patch.object(cli.Board, "graphql_budget", lambda self: (25, 5000, 0)):
         rc = cli.main(["--board", str(doc), "ties", "1"])
     assert rc == 0
     out = capsys.readouterr().out.strip()
     assert out == "(GraphQL budget exhausted — ties analysis skipped)"
+
+
+def test_ties_full_mode_single_fetch_with_bodies(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Regression for #81: full mode does ONE body-bearing fetch, not two."""
+    cli = import_cli()
+    doc = _board_doc(tmp_path)
+    captured_calls: list[dict[str, Any]] = []
+
+    def fake_fetch(self: Any, **kw: Any) -> list[Any]:
+        captured_calls.append(dict(kw))
+        return [_stub_target(), *_stub_open_issues()]
+
+    with (
+        patch.object(cli.Board, "graphql_budget", lambda self: (5000, 5000, 0)),
+        patch.object(cli.Board, "fetch_open_issues_for_ties", fake_fetch),
+        patch.object(cli.Board, "tie_stop_words", lambda self: frozenset()),
+    ):
+        rc = cli.main(["--board", str(doc), "ties", "1"])
+
+    assert rc == 0
+    assert captured_calls == [{"include_bodies": True}]
 
 
 def test_ties_partial_mode_emits_diagnostic(
@@ -106,12 +125,11 @@ def test_ties_partial_mode_emits_diagnostic(
 
     def fake_fetch(self: Any, **kw: Any) -> list[Any]:
         captured_calls.append(dict(kw))
-        return _stub_open_issues()
+        return [_stub_target(), *_stub_open_issues()]
 
     with (
         patch.object(cli.Board, "graphql_budget", lambda self: (100, 5000, 0)),
         patch.object(cli.Board, "fetch_open_issues_for_ties", fake_fetch),
-        patch.object(cli.Board, "get_issue", lambda self, n: _stub_target()),
         patch.object(cli.Board, "tie_stop_words", lambda self: frozenset()),
     ):
         rc = cli.main(["--board", str(doc), "ties", "1"])
@@ -119,17 +137,24 @@ def test_ties_partial_mode_emits_diagnostic(
     assert rc == 0
     out = capsys.readouterr().out
     assert "low GraphQL budget" in out
-    # _cmd_ties calls fetch_open_issues_for_ties twice in partial mode:
-    # once via get_issue (always include_bodies=True) and once for the
-    # actual partial-mode analysis (include_bodies=False). Verify the
-    # second call is the partial-mode one.
-    assert captured_calls[-1] == {"include_bodies": False}
+    # Regression for #81: partial mode now does ONE body-skipped fetch.
+    # Previously it called fetch_open_issues_for_ties twice — once via
+    # Board.get_issue with bodies, once for analysis without — which
+    # defeated the budget protection.
+    assert captured_calls == [{"include_bodies": False}]
 
 
 def test_ties_target_closed_returns_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     cli = import_cli()
     doc = _board_doc(tmp_path)
-    with patch.object(cli.Board, "get_issue", lambda self, n: None):
+    with (
+        patch.object(cli.Board, "graphql_budget", lambda self: (5000, 5000, 0)),
+        patch.object(
+            cli.Board,
+            "fetch_open_issues_for_ties",
+            lambda self, **kw: _stub_open_issues(),  # no record with number=1
+        ),
+    ):
         rc = cli.main(["--board", str(doc), "ties", "1"])
     assert rc == 1
 
@@ -142,9 +167,8 @@ def test_ties_json_format(tmp_path: Path, capsys: pytest.CaptureFixture[str]) ->
         patch.object(
             cli.Board,
             "fetch_open_issues_for_ties",
-            lambda self, **kw: _stub_open_issues(),
+            lambda self, **kw: [_stub_target(), *_stub_open_issues()],
         ),
-        patch.object(cli.Board, "get_issue", lambda self, n: _stub_target()),
         patch.object(cli.Board, "tie_stop_words", lambda self: frozenset()),
     ):
         rc = cli.main(["--board", str(doc), "ties", "1", "--format", "json"])


### PR DESCRIPTION
## Summary

- Refactor `_cmd_ties` to do **one** `fetch_open_issues_for_ties` call instead of two
- Budget check now runs before any fetch; full vs partial mode is decided once and the single fetch picks up the right `include_bodies` flag
- Target is resolved by walking the fetched list (`next(...)`) instead of a separate `Board.get_issue` lookup
- `Board.get_issue` is left intact — public helper for non-`_cmd_ties` callers (per spec acceptance)

## Why

Partial mode was supposed to skip body bytes when the GraphQL budget is low, but `Board.get_issue` always called `fetch_open_issues_for_ties(include_bodies=True)` *first* — paying the body cost regardless of mode. The two fetches keyed differently in the 5-min cache (queries differ in whether `body` is in the field set), so the body-skipped follow-up didn't reuse the heavier first one. Net effect: in partial mode we paid the cost partial mode was meant to avoid.

This was Task 12's reviewer flag during #77; the plan accepted it as v1 simplicity. #81 is the follow-up.

## Test plan

- [x] Two new regression tests assert exactly one fetch with the expected `include_bodies` flag (full + partial)
- [x] `test_ties_partial_mode_emits_diagnostic` updated to assert one body-skipped call (was: "second of two calls")
- [x] `test_ties_target_closed_returns_1` updated to patch `fetch_open_issues_for_ties` returning a list without the target, instead of patching the now-unused `get_issue` path
- [x] Smoke + JSON tests updated to include the target in the fetch result so `next(...)` resolves
- [x] `pytest`: 203 passed, 1 deselected
- [x] `ruff check .`, `ruff format --check .`: clean
- [x] `mypy`: clean across 34 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)