### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.8.0"
+version = "0.8.1"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Patch release v0.8.1. Since v0.8.0:

- **#81 (PR #83) perf(ties): single batched fetch in `_cmd_ties`** — partial mode now respects the GraphQL budget. Previously `Board.get_issue` always called `fetch_open_issues_for_ties(include_bodies=True)` first, paying for body bytes even when partial mode was meant to skip them. Refactor: budget pre-flight first, then ONE fetch with the right `include_bodies` flag, then target resolution by walking the result. `Board.get_issue` retained as a public helper.

No new features, no API breakage. Internal refactor + regression tests asserting exactly one fetch with the expected mode flag.

## Test plan

- [x] `pytest`: 203 passed (#83's tests covering full + partial mode call counts)
- [x] `ruff check .` + `ruff format --check .`: clean
- [x] `mypy --strict`: clean across 34 source files
- [x] After merge: tag `v0.8.1` on main and push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)