### PR TITLE
fix(sweep): whitelist-validate Status against kanban columns (#85)

### DIFF
--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -183,6 +183,15 @@ def guess_repo_from_items(items: list[dict[str, Any]]) -> str | None:
 # ---------- Checks ----------
 
 
+# Items can land on the board with no column assignment (auto-add-to-project
+# workflow, manual API call without a Status set). `gh project item-list
+# --format json` surfaces those as missing-key, None, "", or — depending on
+# gh version and field configuration — as a display string like "No Status".
+# Whitelist-validate against the known kanban column names so all four
+# shapes get flagged uniformly. (#85)
+VALID_STATUSES = frozenset({"Backlog", "Up Next", "In Progress", "Blocked", "Done"})
+
+
 def check_metadata(items: list[dict[str, Any]]) -> list[str]:
     # Detect whether Work Stream is in use on this board. If no open item
     # has Work Stream set, assume the project doesn't define the field and
@@ -203,9 +212,9 @@ def check_metadata(items: list[dict[str, Any]]) -> list[str]:
         n = content.get("number")
         prio = field(i, "priority")
         ws = field(i, "work Stream", "workStream", "workstream")
-        status = i.get("status") or ""
+        status = i.get("status")
         issues = []
-        if not status:
+        if status not in VALID_STATUSES:
             issues.append("no Status")
         if not prio:
             issues.append("no Priority")

--- a/tests/test_sweep_checks.py
+++ b/tests/test_sweep_checks.py
@@ -72,6 +72,71 @@ def test_check_closed_not_done_ignores_missing_content() -> None:
     assert stuck[0]["number"] == 5
 
 
+def test_check_metadata_flags_missing_status_key() -> None:
+    mod = import_sweep()
+    items = [{"content": {"number": 999, "title": "x"}, "priority": "Low"}]
+    assert mod.check_metadata(items) == ["#999: no Status"]
+
+
+def test_check_metadata_flags_null_status() -> None:
+    mod = import_sweep()
+    items = [{"content": {"number": 999, "title": "x"}, "priority": "Low", "status": None}]
+    assert mod.check_metadata(items) == ["#999: no Status"]
+
+
+def test_check_metadata_flags_empty_status() -> None:
+    mod = import_sweep()
+    items = [{"content": {"number": 999, "title": "x"}, "priority": "Low", "status": ""}]
+    assert mod.check_metadata(items) == ["#999: no Status"]
+
+
+def test_check_metadata_flags_no_status_sentinel_string() -> None:
+    """Regression for #85 — `gh project item-list --format json` can surface
+    items without a column assignment as the literal display string
+    `"No Status"` (or other non-column values). The check must whitelist
+    against the known kanban columns, not just test truthiness.
+    """
+    mod = import_sweep()
+    items = [
+        {
+            "content": {"number": 999, "title": "x"},
+            "priority": "Low",
+            "status": "No Status",
+        }
+    ]
+    assert mod.check_metadata(items) == ["#999: no Status"]
+
+
+def test_check_metadata_flags_arbitrary_unknown_status_string() -> None:
+    """Any value that isn't one of {Backlog, Up Next, In Progress, Blocked, Done}
+    is treated as not-on-the-kanban — including future typos like a status
+    accidentally set to a Priority value."""
+    mod = import_sweep()
+    items = [
+        {
+            "content": {"number": 999, "title": "x"},
+            "priority": "Low",
+            "status": "High",  # bogus
+        }
+    ]
+    assert mod.check_metadata(items) == ["#999: no Status"]
+
+
+def test_check_metadata_passes_known_kanban_columns() -> None:
+    mod = import_sweep()
+    items = [
+        {"content": {"number": 1, "title": "x"}, "priority": "Low", "status": "Backlog"},
+        {"content": {"number": 2, "title": "x"}, "priority": "Low", "status": "Up Next"},
+        {
+            "content": {"number": 3, "title": "x"},
+            "priority": "Low",
+            "status": "In Progress",
+        },
+        {"content": {"number": 4, "title": "x"}, "priority": "Low", "status": "Blocked"},
+    ]
+    assert mod.check_metadata(items) == []
+
+
 def test_check_plan_spec_drift_recognizes_bare_hash_issue_refs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- `check_metadata` previously tested falsiness on the status field — catches `None` / `""` / missing-key but let through any non-empty string, including the literal `"No Status"` display fallback that `gh project item-list --format json` returns for items with no column assignment. Two findajob issues with Priority set and no kanban column slipped through the recent groom run.
- Whitelist against `{Backlog, Up Next, In Progress, Blocked, Done}` so all unset shapes get flagged uniformly. Closes #85.

## Test plan

- [x] New regression tests in `tests/test_sweep_checks.py` covering all four shapes: missing key, `None`, `""`, literal `"No Status"`, and an arbitrary unknown string.
- [x] `pytest` — 209 passed (1 deselected — integration only)
- [x] `ruff check .` clean
- [x] `mypy` strict clean
- [ ] Re-run sweep on `findajob` once branch is in cache; expect any no-Status items to be flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)