### PR TITLE
fix(plans): unify issue-ref parsing; ignore prose refs (#86 #87 #88)

### DIFF
--- a/skills/jared/scripts/archive-plan.py
+++ b/skills/jared/scripts/archive-plan.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
-import re
 import sys
 import tempfile
 from pathlib import Path
@@ -33,6 +32,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     GhInvocationError,
+)
+from lib.board import (
+    parse_referenced_issues as board_parse_referenced_issues,
 )
 from lib.board import (
     run_gh as board_run_gh,
@@ -76,44 +78,10 @@ def write_issue_body(repo: str, number: int, body: str) -> None:
         Path(path).unlink(missing_ok=True)
 
 
-# ---------- Plan parsing ----------
-
-
-_BOLD_ISSUE_LINE_LOOKAHEAD = 15
-_BOLD_ISSUE_LINE_RE = re.compile(
-    r"^\*\*(?:Tracking\s+)?Issues?:\*\*\s+(.+?)\s*$",
-    re.IGNORECASE | re.MULTILINE,
-)
-_ISSUE_REF_RE = re.compile(
-    r"(?:https?://github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d+)"
-    r"|(?:[\w.-]+/[\w.-]+)?#(\d+))"
-)
-
-
-def parse_referenced_issues(plan_text: str) -> list[int]:
-    """Extract issue numbers from a plan/spec.
-
-    Primary: a `## Issue` / `## Issues` / `## Issue(s)` section heading.
-    Fallback: a `**Issue:**` / `**Issues:**` / `**Tracking issue:**` bold
-    line near the top of the file (scanned across the first
-    `_BOLD_ISSUE_LINE_LOOKAHEAD` non-empty lines).
-
-    Refs are recognized in `#N`, `owner/repo#N`, and full GitHub URL forms.
-    Heading wins when both forms are present.
-    """
-    m = re.search(
-        r"^#{1,3}\s+Issue[s()]*\s*$([\s\S]+?)(?=^#{1,3}\s|\Z)",
-        plan_text,
-        re.MULTILINE,
-    )
-    if m:
-        return [int(n) for n in re.findall(r"#(\d+)", m.group(1))]
-
-    head = "\n".join(plan_text.splitlines()[:_BOLD_ISSUE_LINE_LOOKAHEAD])
-    bold = _BOLD_ISSUE_LINE_RE.search(head)
-    if not bold:
-        return []
-    return [int(n) for ref in _ISSUE_REF_RE.findall(bold.group(1)) for n in ref if n]
+# Re-export the shared helper so archive_plan.parse_referenced_issues stays
+# the public test surface — the actual logic lives in lib/board.py and is
+# shared with sweep.py (#86, #87, #88).
+parse_referenced_issues = board_parse_referenced_issues
 
 
 def already_archived(path: Path) -> bool:

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -746,6 +746,76 @@ def fetch_blocked_by_edges(
     raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
 
 
+# ---------- Plan/spec issue-ref parsing ----------
+#
+# Shared between archive-plan.py and sweep.py so the two scripts can't
+# disagree on what counts as a referenced issue (#86, #87, #88).
+
+_PLAN_BOLD_ISSUE_LOOKAHEAD = 15
+_PLAN_BOLD_ISSUE_LINE_RE = re.compile(
+    r"^\*\*(?:Tracking\s+)?Issues?:\*\*\s+(.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_PLAN_ISSUE_REF_RE = re.compile(
+    r"(?:https?://github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d+)"
+    r"|(?:[\w.-]+/[\w.-]+)?#(\d+))"
+)
+# A line in the ## Issue section "counts" as a ref-bearing line only if its
+# meaningful content (after an optional list marker) STARTS with a ref —
+# either a bare/qualified `#N`, a GitHub issues/pull URL, or a markdown link
+# to one. Mid-line refs in narrative prose (`Adapter #2 ...`, `**Issue:**
+# [#408](...)`, `> closes #310 ...`) are deliberately ignored — they are
+# the source of #86/#87 false positives.
+_PLAN_LINE_REF_RE = re.compile(
+    r"^[\s]*[-*]?\s*"
+    r"(?:\[)?"  # optional opening of a markdown link `[#N](...)`
+    r"(?:https?://github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d+)"
+    r"|(?:[\w.-]+/[\w.-]+)?#(\d+))"
+)
+
+
+def parse_referenced_issues(plan_text: str) -> list[int]:
+    """Extract issue numbers from a plan/spec.
+
+    Primary source: a `## Issue` / `## Issues` / `## Issue(s)` section. Inside
+    that section, only lines whose meaningful content STARTS with a ref count
+    — list-item form (`- #42`, `* https://github.com/.../issues/42`) and
+    bare line-start form (`#229 — Metric Layer C.0`) both qualify.
+    Mid-line refs in prose, blockquotes, or bold lines are skipped.
+
+    Fallback (when no `## Issue` heading is present): a `**Issue:**` /
+    `**Issues:**` / `**Tracking issue:**` bold line near the top of the file
+    (within the first `_PLAN_BOLD_ISSUE_LOOKAHEAD` lines). The fallback path
+    accepts inline ref lists since the bold line itself is the ref carrier
+    — there's no risk of swallowing prose paragraphs.
+
+    Refs in `#N`, `owner/repo#N`, and full GitHub issue/pull URL forms.
+    Heading wins when both forms are present.
+    """
+    section_match = re.search(
+        r"^#{1,3}\s+Issue[s()]*\s*$([\s\S]+?)(?=^#{1,3}\s|\Z)",
+        plan_text,
+        re.MULTILINE,
+    )
+    if section_match:
+        refs: list[int] = []
+        for line in section_match.group(1).splitlines():
+            m = _PLAN_LINE_REF_RE.match(line)
+            if not m:
+                continue
+            for g in m.groups():
+                if g:
+                    refs.append(int(g))
+                    break
+        return refs
+
+    head = "\n".join(plan_text.splitlines()[:_PLAN_BOLD_ISSUE_LOOKAHEAD])
+    bold = _PLAN_BOLD_ISSUE_LINE_RE.search(head)
+    if not bold:
+        return []
+    return [int(n) for ref in _PLAN_ISSUE_REF_RE.findall(bold.group(1)) for n in ref if n]
+
+
 def check_closed_not_done(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Closed issues should auto-move to Done. If they don't, return them.
 

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -68,6 +68,9 @@ from lib.board import (
     graphql_budget as board_graphql_budget,
 )
 from lib.board import (
+    parse_referenced_issues as board_parse_referenced_issues,
+)
+from lib.board import (
     run_gh as board_run_gh,
 )
 from lib.board import (
@@ -362,13 +365,15 @@ def check_legacy_priority_labels(issues_by_number: dict[int, dict[str, Any]]) ->
     return findings
 
 
-def parse_issue_refs(text: str) -> set[int]:
-    """Find #N references in a block of text."""
-    return {int(m) for m in re.findall(r"#(\d+)", text or "")}
-
-
 def check_plan_spec_drift(plan_dirs: list[Path], repo: str) -> list[str]:
-    """Scan plan/spec directories for orphans and shippable archivals."""
+    """Scan plan/spec directories for orphans and shippable archivals.
+
+    Issue refs are extracted via the shared `parse_referenced_issues` helper
+    in `lib.board`, so sweep and archive-plan can't disagree on what counts
+    as a referenced issue (#88). The helper accepts both the canonical
+    `## Issue` heading form (with list-item refs) and the legacy
+    `**Issue:** #N` bold-line fallback.
+    """
     if not repo:
         return ["(skipping plan/spec check — repo not determined)"]
 
@@ -383,23 +388,9 @@ def check_plan_spec_drift(plan_dirs: list[Path], repo: str) -> list[str]:
                 continue
             text = p.read_text(errors="replace")
 
-            # Look for ## Issue section — support ## Issue, ## Issue(s), ## Issues.
-            # The body terminator is `^#{1,3}\s` (a real heading) rather than
-            # `^#`: a bare `#229` issue reference at column zero is a valid
-            # plan-body line, not the start of the next section, so the
-            # terminator must require whitespace after the hashes. (#48)
-            issue_section_match = re.search(
-                r"^#{1,3}\s+Issue[s()]*\s*$([\s\S]+?)(?=^#{1,3}\s|\Z)",
-                text,
-                re.MULTILINE,
-            )
-            if not issue_section_match:
-                findings.append(f"  {p}: no ## Issue section — orphaned plan/spec")
-                continue
-
-            refs = parse_issue_refs(issue_section_match.group(1))
+            refs = set(board_parse_referenced_issues(text))
             if not refs:
-                findings.append(f"  {p}: ## Issue section but no #N references")
+                findings.append(f"  {p}: no ## Issue section — orphaned plan/spec")
                 continue
 
             # Check state of each referenced issue

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -83,6 +83,59 @@ def test_parse_referenced_issues_bold_line_only_scanned_near_top() -> None:
     assert ap.parse_referenced_issues(text) == []
 
 
+def test_parse_referenced_issues_ignores_inline_refs_in_section_prose() -> None:
+    """Regression for #86 — the ## Issue section parser previously captured
+    everything between the heading and the next heading, then ran a broad
+    `re.findall(r'#(\\d+)', section)` over the whole thing. That harvested
+    refs from prose paragraphs (bold lines, blockquotes, narrative) the user
+    happened to put after the bullet list but before the next heading. Only
+    list-item form (or refs at the start of a line) inside the section
+    should count.
+    """
+    text = (
+        "# Plan\n\n"
+        "## Issue\n\n"
+        "- #408\n"
+        "- #310 (closed by this plan)\n\n"
+        "> agentic-workers note...\n\n"
+        "**Goal:** ...closes #310...\n\n"
+        "**Issue:** [#408](...); spawns [#410](...), [#411](...), [#412](...).\n\n"
+        "## Pre-flight: branch setup\n"
+    )
+    assert ap.parse_referenced_issues(text) == [408, 310]
+
+
+def test_parse_referenced_issues_ignores_inline_prose_hash() -> None:
+    """Regression for #87 — bare `#NNN` inside flowing prose (e.g.
+    "Adapter #2 validating the framework") must not be matched as an issue
+    reference. Refs only count when they appear at the start of a line,
+    after an optional list marker."""
+    text = (
+        "# Plan\n\n"
+        "## Issue\n\n"
+        "- #408\n"
+        "- #310\n\n"
+        "Adapter #2 validating the framework — see #88 for follow-up.\n\n"
+        "## Body\n"
+    )
+    assert ap.parse_referenced_issues(text) == [408, 310]
+
+
+def test_parse_referenced_issues_accepts_url_form_in_list_items() -> None:
+    """URLs and `owner/repo#N` forms remain valid inside list items — they're
+    unambiguous, no prose-interpretation risk."""
+    text = "# Plan\n\n## Issue\n\n- https://github.com/o/r/issues/42\n- owner/repo#15\n\n## Body\n"
+    assert ap.parse_referenced_issues(text) == [42, 15]
+
+
+def test_parse_referenced_issues_accepts_bare_line_at_column_zero() -> None:
+    """The pre-existing #48-style bare-line form (no list marker — the ref
+    sits at column zero) must still be accepted. A line whose meaningful
+    content starts with `#NNN` counts."""
+    text = "# Plan\n\n## Issue(s)\n\n#229 — Metric Layer C.0\n#230 — follow-up\n\n## Approach\n"
+    assert ap.parse_referenced_issues(text) == [229, 230]
+
+
 def test_archive_one_accepts_merged_pr_as_shipped(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_sweep_checks.py
+++ b/tests/test_sweep_checks.py
@@ -140,6 +140,102 @@ def test_check_plan_spec_drift_recognizes_bare_hash_issue_refs(
     )
 
 
+def test_check_plan_spec_drift_accepts_bold_line_issue_form(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression for #88 — sweep used a stricter parser than archive-plan,
+    so plans using the legacy `**Issue:** #N` bold-line form (no `## Issue`
+    heading) were reported as orphaned. The shared parser in lib/board.py
+    accepts the bold-line fallback; sweep now inherits that behavior.
+    """
+    mod = import_sweep()
+
+    plan_dir = tmp_path / "plans"
+    plan_dir.mkdir()
+    (plan_dir / "legacy-bold-line.md").write_text(
+        dedent("""\
+        # An older plan
+
+        **Spec:** path/to/spec.md
+        **Issue:** brockamer/jared#339
+
+        ## Approach
+
+        Words.
+        """)
+    )
+
+    class FakeResult:
+        returncode = 0
+        stdout = '{"state": "OPEN"}'
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    findings = mod.check_plan_spec_drift([plan_dir], "brockamer/jared")
+    bug_messages = [f for f in findings if "no ## Issue section" in f or "no #N references" in f]
+    assert bug_messages == [], (
+        "Plans using **Issue:** bold-line fallback should NOT be reported as "
+        f"orphaned — got {bug_messages}"
+    )
+
+
+def test_check_plan_spec_drift_ignores_inline_prose_refs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Sweep must not query issue state for stray prose `#NNN` mentions
+    inside the `## Issue` section — only list-item / line-start refs count.
+    """
+    mod = import_sweep()
+    plan_dir = tmp_path / "plans"
+    plan_dir.mkdir()
+    (plan_dir / "with-prose.md").write_text(
+        dedent("""\
+        # Plan
+
+        ## Issue
+
+        - #408
+        - #310
+
+        > agentic-workers note...
+
+        **Goal:** ...closes #310...
+
+        **Issue:** [#408](...); spawns [#410](...), [#411](...).
+
+        ## Approach
+
+        Words.
+        """)
+    )
+
+    seen_numbers: list[str] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = '{"state": "OPEN"}'
+        stderr = ""
+
+    def fake_run(*args: Any, **kwargs: Any) -> FakeResult:
+        cmd = args[0] if args else kwargs.get("args", [])
+        for tok in cmd or []:
+            if isinstance(tok, str) and tok.isdigit():
+                seen_numbers.append(tok)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod.check_plan_spec_drift([plan_dir], "brockamer/jared")
+    assert sorted(set(seen_numbers)) == ["310", "408"], (
+        f"sweep should only query refs from list-item lines, not inline prose; "
+        f"got {sorted(set(seen_numbers))}"
+    )
+
+
 def test_check_plan_spec_drift_still_flags_genuinely_orphaned_plans(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

`archive-plan.py` and `sweep.py` each had their own `## Issue` section parser, both broken in subtly different ways:

- `archive-plan.py` captured everything between the heading and the next heading, then ran `re.findall(r'#(\d+)', section)` — so any bare `#NNN` inside narrative prose (bold lines, blockquotes, "Adapter #2 validating...") was harvested as a referenced issue. (#86, #87)
- `sweep.py` only recognized the `## Issue` heading form, missing the legacy `**Issue:** #N` bold-line fallback that `archive-plan.py` already accepted. (#88)

Move `parse_referenced_issues` into `lib/board.py` and have both scripts import the same helper. Inside the `## Issue` section, only refs whose meaningful content **starts at the line** count — list-item form (`- #42`, `* https://github.com/.../issues/42`) and the pre-existing bare-line form (`#229 — Metric Layer C.0`). Mid-line refs in prose are ignored. The `**Issue:**` bold-line fallback is preserved unchanged.

Closes #86, #87, #88.

## Test plan

- [x] New regression tests cover the three bug repros: greedy parser harvesting prose refs (#86), stray `Adapter #2` in prose (#87), and sweep parity on `**Issue:**` plans (#88).
- [x] Existing 8 `parse_referenced_issues` tests + the #48 bare-line regression still pass.
- [x] Sweep test confirms `gh issue view` is only called for list-item refs (`310`, `408`), not for prose refs (`310`, `410`, `411`, `412`).
- [x] `pytest` — 209 passed
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy` strict clean
- [ ] Re-run sweep + archive on `findajob` once branch is in cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)