### PR TITLE
feat(archive-plan): support recycled-issue plans via ## Shipped section (#89)

### DIFF
--- a/skills/jared/scripts/archive-plan.py
+++ b/skills/jared/scripts/archive-plan.py
@@ -37,6 +37,9 @@ from lib.board import (
     parse_referenced_issues as board_parse_referenced_issues,
 )
 from lib.board import (
+    parse_shipped_section as board_parse_shipped_section,
+)
+from lib.board import (
     run_gh as board_run_gh,
 )
 from lib.board import (
@@ -78,10 +81,11 @@ def write_issue_body(repo: str, number: int, body: str) -> None:
         Path(path).unlink(missing_ok=True)
 
 
-# Re-export the shared helper so archive_plan.parse_referenced_issues stays
-# the public test surface — the actual logic lives in lib/board.py and is
-# shared with sweep.py (#86, #87, #88).
+# Re-export the shared helpers so archive_plan.parse_referenced_issues and
+# .parse_shipped_section stay the public test surface — the actual logic
+# lives in lib/board.py and is shared with sweep.py (#86, #87, #88, #89).
 parse_referenced_issues = board_parse_referenced_issues
+parse_shipped_section = board_parse_shipped_section
 
 
 def already_archived(path: Path) -> bool:
@@ -107,20 +111,37 @@ def archive_one(
     yes: bool = False,
     update_issues: bool = True,
 ) -> str | None:
-    """Archive a single plan file. Returns the archived path or None."""
-    text = plan_path.read_text()
-    refs = parse_referenced_issues(text)
-    if not refs:
-        return f"{plan_path}: no ## Issue section; skipping"
+    """Archive a single plan file. Returns the archived path or None.
 
-    # Check all referenced issue states. A plan's ## Issues section may
-    # cite an issue (CLOSED when shipped) or a PR (MERGED when shipped);
-    # both count as "shipped" for archival purposes.
-    SHIPPED = ("CLOSED", "MERGED")
-    states = {n: issue_state(repo, n) for n in refs}
-    if not all(s[0] in SHIPPED for s in states.values()):
-        open_ones = [n for n, (s, _) in states.items() if s not in SHIPPED]
-        return f"{plan_path}: not all issues closed (open: {open_ones}); skipping"
+    Two evidence paths for "this plan has shipped":
+
+    1. ## Shipped section listing one or more PR refs — checked first, since
+       it's an explicit declaration that survives issue recycling. PRs must
+       be MERGED. Archive on the latest merge date. (#89)
+    2. ## Issue section (or **Issue:** bold-line fallback) — referenced
+       issues/PRs must all be CLOSED/MERGED.
+    """
+    text = plan_path.read_text()
+
+    shipped_prs = parse_shipped_section(text)
+    if shipped_prs:
+        states = {n: issue_state(repo, n) for n in shipped_prs}
+        not_merged = [n for n, (s, _) in states.items() if s != "MERGED"]
+        if not_merged:
+            return f"{plan_path}: ## Shipped PRs not all merged (open: {not_merged}); skipping"
+        refs = shipped_prs
+    else:
+        refs = parse_referenced_issues(text)
+        if not refs:
+            return f"{plan_path}: no ## Issue section; skipping"
+
+        # ## Issue may cite an issue (CLOSED when shipped) or a PR (MERGED
+        # when shipped); both count as "shipped" for archival purposes.
+        SHIPPED = ("CLOSED", "MERGED")
+        states = {n: issue_state(repo, n) for n in refs}
+        if not all(s[0] in SHIPPED for s in states.values()):
+            open_ones = [n for n, (s, _) in states.items() if s not in SHIPPED]
+            return f"{plan_path}: not all issues closed (open: {open_ones}); skipping"
 
     # Determine ship date from latest closedAt
     closed_dates = [s[1] for s in states.values() if s[1]]

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -760,18 +760,49 @@ _PLAN_ISSUE_REF_RE = re.compile(
     r"(?:https?://github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d+)"
     r"|(?:[\w.-]+/[\w.-]+)?#(\d+))"
 )
-# A line in the ## Issue section "counts" as a ref-bearing line only if its
-# meaningful content (after an optional list marker) STARTS with a ref —
-# either a bare/qualified `#N`, a GitHub issues/pull URL, or a markdown link
-# to one. Mid-line refs in narrative prose (`Adapter #2 ...`, `**Issue:**
-# [#408](...)`, `> closes #310 ...`) are deliberately ignored — they are
-# the source of #86/#87 false positives.
+# A line in the ## Issue / ## Shipped section "counts" as a ref-bearing line
+# only if it's either:
+#   1. a bare line-start ref (`#229 — Metric Layer C.0`, no list marker), or
+#   2. a list item (`- ...`/`* ...`) whose first content is a ref, optionally
+#      preceded by a `PR ` / `Issue ` label (e.g. `- PR #415`).
+#
+# Mid-line refs in narrative prose are deliberately ignored — they are the
+# source of #86/#87 false positives. The label is gated behind a list marker
+# so a bare prose line like `Issue #99 supersedes this work.` cannot match.
 _PLAN_LINE_REF_RE = re.compile(
-    r"^[\s]*[-*]?\s*"
+    r"^[\s]*"
+    r"(?:[-*]\s+(?:(?:PR|Issue)\s+)?)?"  # optional list marker + optional PR/Issue label
     r"(?:\[)?"  # optional opening of a markdown link `[#N](...)`
     r"(?:https?://github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d+)"
-    r"|(?:[\w.-]+/[\w.-]+)?#(\d+))"
+    r"|(?:[\w.-]+/[\w.-]+)?#(\d+))",
+    re.IGNORECASE,
 )
+
+
+def _parse_plan_section(plan_text: str, heading_pattern: str) -> list[int] | None:
+    """Find a heading-bounded section and return line-start refs from its body.
+
+    Returns None if the heading is absent — distinguishes "section missing"
+    from "section present but empty" so callers can fall back to alternate
+    parsers (e.g. the `**Issue:**` bold-line fallback).
+    """
+    section_match = re.search(
+        rf"^{heading_pattern}\s*$([\s\S]+?)(?=^#{{1,3}}\s|\Z)",
+        plan_text,
+        re.MULTILINE,
+    )
+    if not section_match:
+        return None
+    refs: list[int] = []
+    for line in section_match.group(1).splitlines():
+        m = _PLAN_LINE_REF_RE.match(line)
+        if not m:
+            continue
+        for g in m.groups():
+            if g:
+                refs.append(int(g))
+                break
+    return refs
 
 
 def parse_referenced_issues(plan_text: str) -> list[int]:
@@ -792,21 +823,8 @@ def parse_referenced_issues(plan_text: str) -> list[int]:
     Refs in `#N`, `owner/repo#N`, and full GitHub issue/pull URL forms.
     Heading wins when both forms are present.
     """
-    section_match = re.search(
-        r"^#{1,3}\s+Issue[s()]*\s*$([\s\S]+?)(?=^#{1,3}\s|\Z)",
-        plan_text,
-        re.MULTILINE,
-    )
-    if section_match:
-        refs: list[int] = []
-        for line in section_match.group(1).splitlines():
-            m = _PLAN_LINE_REF_RE.match(line)
-            if not m:
-                continue
-            for g in m.groups():
-                if g:
-                    refs.append(int(g))
-                    break
+    refs = _parse_plan_section(plan_text, r"#{1,3}\s+Issue[s()]*")
+    if refs is not None:
         return refs
 
     head = "\n".join(plan_text.splitlines()[:_PLAN_BOLD_ISSUE_LOOKAHEAD])
@@ -814,6 +832,20 @@ def parse_referenced_issues(plan_text: str) -> list[int]:
     if not bold:
         return []
     return [int(n) for ref in _PLAN_ISSUE_REF_RE.findall(bold.group(1)) for n in ref if n]
+
+
+def parse_shipped_section(plan_text: str) -> list[int]:
+    """Extract PR numbers from a `## Shipped` section.
+
+    Same line-start rules as `parse_referenced_issues`. Used by archive-plan
+    to support recycled-issue plans (#89): a plan that shipped via a merged
+    PR but whose originally-tracked issue was rewritten to track follow-on
+    work can still be archived by declaring shipping evidence explicitly.
+
+    Returns an empty list if no `## Shipped` section is present.
+    """
+    refs = _parse_plan_section(plan_text, r"#{1,3}\s+Shipped")
+    return refs if refs is not None else []
 
 
 def check_closed_not_done(items: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -128,12 +128,121 @@ def test_parse_referenced_issues_accepts_url_form_in_list_items() -> None:
     assert ap.parse_referenced_issues(text) == [42, 15]
 
 
+def test_parse_referenced_issues_ignores_prose_line_starting_with_issue_label() -> None:
+    """The PR/Issue label is gated behind a list marker — a bare prose line
+    like `Issue #99 supersedes this work.` (no `- ` or `* ` prefix) must not
+    match. Otherwise PR 3's relaxation re-opens the #87 false-positive class.
+    """
+    text = (
+        "# Plan\n\n## Issue\n\n- #408\n\n"
+        "Issue #99 supersedes this work; see also PR #100 for context.\n\n"
+        "## Body\n"
+    )
+    assert ap.parse_referenced_issues(text) == [408]
+
+
 def test_parse_referenced_issues_accepts_bare_line_at_column_zero() -> None:
     """The pre-existing #48-style bare-line form (no list marker — the ref
     sits at column zero) must still be accepted. A line whose meaningful
     content starts with `#NNN` counts."""
     text = "# Plan\n\n## Issue(s)\n\n#229 — Metric Layer C.0\n#230 — follow-up\n\n## Approach\n"
     assert ap.parse_referenced_issues(text) == [229, 230]
+
+
+def test_parse_shipped_section_returns_pr_numbers() -> None:
+    """The `## Shipped` section is the same shape as `## Issue` — list-item
+    refs whose meaningful content starts with `#NNN` or a URL.
+    """
+    text = "# Plan\n\n## Shipped\n\n- PR #415 (merged 2026-05-02)\n- PR #416\n\n## Body\n"
+    assert ap.parse_shipped_section(text) == [415, 416]
+
+
+def test_parse_shipped_section_empty_when_absent() -> None:
+    text = "# Plan\n\n## Issue\n\n- #408\n\n## Body\n"
+    assert ap.parse_shipped_section(text) == []
+
+
+def test_parse_shipped_section_ignores_inline_prose_refs() -> None:
+    """Same line-start rule as parse_referenced_issues — refs in narrative
+    prose between bullets and the next heading don't count."""
+    text = (
+        "# Plan\n\n## Shipped\n\n- PR #415\n\n"
+        "Adapter #2 was the first one merged.\n"
+        "**Note:** also see #888 follow-up.\n\n## Body\n"
+    )
+    assert ap.parse_shipped_section(text) == [415]
+
+
+def test_archive_one_archives_via_shipped_section_when_pr_merged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Regression for #89 — a plan whose tracking issue was recycled (still
+    OPEN) but which shipped via a merged PR can archive by declaring the PR
+    in a `## Shipped` section. Archive uses the PR merge date."""
+    plan = tmp_path / "2026-05-03-recycled-issue.md"
+    plan.write_text("# Plan\n\n## Shipped\n\n- PR #415\n\n## Body\n\nDetails.\n")
+    patch_gh_by_arg(
+        monkeypatch,
+        {"issue view 415": '{"state": "MERGED", "closedAt": "2026-05-02T15:30:00Z"}'},
+    )
+
+    result = ap.archive_one(plan, "brockamer/findajob", dry_run=True, yes=True)
+
+    captured = capsys.readouterr()
+    assert result is not None
+    assert "skipping" not in result, f"merged-PR Shipped section must archive; got: {result}"
+    assert "archived/2026-05" in result
+    assert "2026-05-02" in captured.out
+
+
+def test_archive_one_skips_shipped_section_with_open_pr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A `## Shipped` section whose listed PR is not MERGED still refuses to
+    archive — the predicate is "evidence of shipping," not just "the section
+    exists"."""
+    plan = tmp_path / "still-shipping.md"
+    plan.write_text("# Plan\n\n## Shipped\n\n- PR #999\n\n## Body\n")
+    patch_gh_by_arg(
+        monkeypatch,
+        {"issue view 999": '{"state": "OPEN", "closedAt": null}'},
+    )
+
+    result = ap.archive_one(plan, "brockamer/findajob", dry_run=True, yes=True)
+
+    assert result is not None
+    assert "skipping" in result
+    assert "[999]" in result
+
+
+def test_archive_one_shipped_takes_priority_over_issue_section(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When both `## Issue` (with an open recycled issue) and `## Shipped`
+    (with a merged PR) are present, archival uses the Shipped evidence
+    and ignores the open issue."""
+    plan = tmp_path / "mixed.md"
+    plan.write_text("# Plan\n\n## Issue\n\n- #414\n\n## Shipped\n\n- PR #415\n\n## Body\n")
+    patch_gh_by_arg(
+        monkeypatch,
+        {
+            "issue view 414": '{"state": "OPEN", "closedAt": null}',
+            "issue view 415": '{"state": "MERGED", "closedAt": "2026-05-02T15:30:00Z"}',
+        },
+    )
+
+    result = ap.archive_one(plan, "brockamer/findajob", dry_run=True, yes=True)
+
+    captured = capsys.readouterr()
+    assert result is not None
+    assert "skipping" not in result, (
+        f"Shipped section must take priority over open Issue refs; got: {result}"
+    )
+    assert "2026-05-02" in captured.out
 
 
 def test_archive_one_accepts_merged_pr_as_shipped(


### PR DESCRIPTION
## Summary

When a plan ships via a PR but its tracking issue is later recycled to track new scope, `archive-plan.py`'s "all referenced issues closed/merged" predicate refused to archive — the originally-tracked issue stays OPEN. Adds an explicit `## Shipped` section that declares shipping evidence directly:

```markdown
## Shipped

- PR #415 (merged 2026-05-02)
```

When present, listed PRs must all be MERGED; archival uses the latest PR merge date. Shipped is checked **first**, so it takes priority over `## Issue` refs that may have been recycled.

Closes #89.

(Replaces #92 — the original was auto-closed when its parent feature/86-shared-issue-ref-parser branch was deleted on PR #91 merge. This branch has been rebased onto main.)

## Implementation notes

- Generalized line-start parser via private `_parse_plan_section(text, heading_pattern)` helper. `parse_referenced_issues` and the new `parse_shipped_section` both go through it — same prose-rejection rules.
- Extended `_PLAN_LINE_REF_RE` to accept an optional `PR ` / `Issue ` label so the canonical `- PR #415` form parses. The label is **gated behind a list marker** — a bare prose line like `Issue #99 supersedes this work.` cannot match (regression test included), keeping the #87 false-positive class closed.

## Test plan

- [x] New tests: `## Shipped` parsed correctly; merged PR archives; OPEN PR refuses; `## Shipped` takes priority over `## Issue` with mixed-state plan; prose `Issue #99 ...` ignored.
- [x] Existing 21 archive-plan tests + 9 sweep tests still pass.
- [x] `pytest` — 222 passed
- [x] `ruff check .` clean
- [x] `mypy` strict clean
- [ ] Re-archive `2026-05-03-414-shared-key-and-indeed-restore.md` on findajob using `## Shipped: - PR #415` to verify the original repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)