### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.8.1"
+version = "0.9.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Minor release. Since v0.8.1:

**New feature:**
- #89 (PR #93) feat(archive-plan): support recycled-issue plans via `## Shipped` section.

**Bug fixes:**
- #85 (PR #90) fix(sweep): whitelist Status against kanban columns; flag the literal "No Status" string.
- #86 / #87 / #88 (PR #91) fix(plans): unify issue-ref parser between archive-plan and sweep; ignore prose refs inside `## Issue`.

## Test plan

- [x] `pytest` — 222 passed
- [x] `ruff check .` clean
- [x] `mypy` strict clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)