### PR TITLE
fix(file,comment): accept inline --body, reject --bod abbrev (#98)

### DIFF
--- a/commands/jared-file.md
+++ b/commands/jared-file.md
@@ -29,15 +29,16 @@ Flow:
    - `## Depends on` / `## Blocks` — fill in if applicable, else "(none)"
    - `## Planning` — fill in if a plan/spec already exists, else "(none)"
 
-   Write the body to a file path the CLI can read, or pipe it through
-   stdin with `--body-file -`.
+   Body content can be passed three ways: inline via `--body "<text>"`,
+   from a file via `--body-file <path>`, or from stdin via `--body-file -`.
+   Use exactly one — they're mutually exclusive.
 
 5. **File atomically.** One call does it all:
 
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared file \
      --title "<verb-first title>" \
-     --body-file <path or -> \
+     --body-file <path or ->          # OR --body "<inline text>" \
      --priority <High|Medium|Low> \
      --status "<status column>" \
      --label <label> \

--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -40,11 +40,11 @@ For any board operation, pick the right tier:
 **Tier 2 — multi-step orchestrations.** Any operation that would take more than one underlying call: filing an issue (create + add-to-board + set fields), moving an issue (lookup item-id + set Status), closing with verification (close + confirm auto-move), dependency edges (resolve both node-IDs + graphql mutation). Always use the `jared` CLI:
 
 ```
-${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared file --title "..." --body-file - --priority High
+${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared file --title "..." (--body "..." | --body-file <path or ->) --priority High
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared move <N> "In Progress"
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared set <N> <FieldName> <OptionName>
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared close <N>
-${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared comment <N> --body-file -
+${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared comment <N> (--body "..." | --body-file <path or ->)
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared blocked-by <dependent> <blocker> [--remove]
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared get-item <N>     # JSON lookup helper
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared summary          # fast one-screen status

--- a/skills/jared/references/jared-cli.md
+++ b/skills/jared/references/jared-cli.md
@@ -130,19 +130,22 @@ OK: closed #12, board auto-moved to Done
 
 ---
 
-## `jared comment <issue_number> --body-file PATH`
+## `jared comment <issue_number> (--body TEXT | --body-file PATH)`
 
-**Purpose.** Add a comment to an issue. `--body-file -` reads from stdin,
-which is the typical pattern for session notes or anything multi-line.
+**Purpose.** Add a comment to an issue. Three input forms, mutually exclusive:
+`--body "<text>"` for inline content, `--body-file <path>` for a markdown file,
+`--body-file -` to read from stdin (the typical pattern for session notes or
+anything multi-line).
 
 ```
+jared comment <issue_number> --body "Quick one-liner update."
 jared comment <issue_number> --body-file session-note.md
 cat session-note.md | jared comment <issue_number> --body-file -
 ```
 
 ---
 
-## `jared file --title ... --body-file ... --priority ...`
+## `jared file --title ... (--body ... | --body-file ...) --priority ...`
 
 **Purpose.** Atomic create-issue + add-to-board + set-Priority + set-Status
 + post-create verification. Kills the `gh issue create` / `gh project
@@ -157,6 +160,9 @@ jared file \
   --status "Up Next" \
   --label enhancement \
   --field "Work Stream=Planning"
+
+# Or inline body, parity with `gh issue create --body`:
+jared file --title "Quick fix" --body "One-line summary of the bug." --priority Low
 ```
 
 **Arguments:**
@@ -164,7 +170,7 @@ jared file \
 | Flag | Required | Notes |
 |---|---|---|
 | `--title` | yes | Issue title; keep ≤ 70 chars, verb-first. |
-| `--body-file` | yes | Path to the markdown body (see `assets/issue-body.md.template`). |
+| `--body` / `--body-file` | yes (exactly one) | `--body "<text>"` for inline content; `--body-file <path>` for a markdown file; `--body-file -` reads stdin. Mutually exclusive. |
 | `--priority {High,Medium,Low}` | yes | Enforced to avoid filing with null Priority. |
 | `--status` | no | Any Status column. Default: `Backlog`. |
 | `--label` | no | Repeatable. |

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -28,6 +28,7 @@ from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     OptionNotFound,
     check_closed_not_done,
     fetch_recent_comments_batch,
+    resolve_body,
 )
 
 ALL_SUBCOMMANDS = [
@@ -360,23 +361,6 @@ def _cmd_close(args: argparse.Namespace) -> int:
     return rc
 
 
-def _resolve_body(body: str | None, body_file: str | None) -> str:
-    """Resolve body content from either inline text or a file path / stdin.
-
-    Exactly one of `body` / `body_file` is set (argparse mutex group enforces).
-    `body_file == "-"` reads stdin. Other values are filesystem paths.
-
-    Single seam for #98 (inline --body support) and #97 (PII pre-flight
-    redactor will hook here so both flags get scanned identically).
-    """
-    if body is not None:
-        return body
-    assert body_file is not None  # argparse mutex group makes this unreachable
-    if body_file == "-":
-        return sys.stdin.read()
-    return Path(body_file).read_text()
-
-
 def _cmd_file(args: argparse.Namespace) -> int:
     """Atomic: create issue, add to project, set Priority + Status + extras.
 
@@ -414,7 +398,7 @@ def _cmd_file(args: argparse.Namespace) -> int:
     # --body-file - (stdin). gh issue create still wants a path, so we round-
     # trip through a temp file. Single resolution seam keeps #97's redactor
     # ergonomic — one place to scan.
-    body = _resolve_body(args.body, args.body_file)
+    body = resolve_body(args.body, args.body_file)
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".md", delete=False, encoding="utf-8"
     ) as tf:
@@ -596,7 +580,7 @@ def _cmd_blocked_by(args: argparse.Namespace) -> int:
 
 def _cmd_comment(args: argparse.Namespace) -> int:
     board = Board.from_path(Path(args.board))
-    body = _resolve_body(args.body, args.body_file)
+    body = resolve_body(args.body, args.body_file)
 
     # gh issue comment requires a file path, even when we got the body
     # from stdin — write a temp file, invoke, clean up.

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -46,9 +46,15 @@ ALL_SUBCOMMANDS = [
 
 
 def build_parser() -> argparse.ArgumentParser:
+    # allow_abbrev=False is defense against #98: argparse's default abbrev
+    # silently routed `--body` to `--body-file` and the user's literal markdown
+    # ended up as a path to `gh issue create --body-file <markdown>`. Subparsers
+    # below get their own allow_abbrev=False to enforce this on the actual
+    # body-bearing flags (file, comment).
     parser = argparse.ArgumentParser(
         prog="jared",
         description="jared — GitHub Projects v2 board operations.",
+        allow_abbrev=False,
     )
     parser.add_argument(
         "--board",
@@ -92,11 +98,19 @@ def build_parser() -> argparse.ArgumentParser:
     close_p.add_argument("issue_number", type=int)
     close_p.set_defaults(func=_cmd_close)
 
-    comment = sub.add_parser("comment", help="Add a comment to an issue.")
+    comment = sub.add_parser(
+        "comment",
+        help="Add a comment to an issue.",
+        allow_abbrev=False,
+    )
     comment.add_argument("issue_number", type=int)
-    comment.add_argument(
+    comment_body = comment.add_mutually_exclusive_group(required=True)
+    comment_body.add_argument(
+        "--body",
+        help="Inline body text.",
+    )
+    comment_body.add_argument(
         "--body-file",
-        required=True,
         help='Path to markdown file, or "-" for stdin.',
     )
     comment.set_defaults(func=_cmd_comment)
@@ -104,9 +118,18 @@ def build_parser() -> argparse.ArgumentParser:
     file_p = sub.add_parser(
         "file",
         help="File a new issue + add to board + set fields atomically.",
+        allow_abbrev=False,
     )
     file_p.add_argument("--title", required=True)
-    file_p.add_argument("--body-file", required=True)
+    file_body = file_p.add_mutually_exclusive_group(required=True)
+    file_body.add_argument(
+        "--body",
+        help="Inline body text.",
+    )
+    file_body.add_argument(
+        "--body-file",
+        help='Path to markdown file, or "-" for stdin.',
+    )
     file_p.add_argument("--priority", required=True, choices=["High", "Medium", "Low"])
     file_p.add_argument("--status", help="Status column (default: Backlog)")
     file_p.add_argument("--label", action="append", help="Issue label (repeatable)")
@@ -337,6 +360,23 @@ def _cmd_close(args: argparse.Namespace) -> int:
     return rc
 
 
+def _resolve_body(body: str | None, body_file: str | None) -> str:
+    """Resolve body content from either inline text or a file path / stdin.
+
+    Exactly one of `body` / `body_file` is set (argparse mutex group enforces).
+    `body_file == "-"` reads stdin. Other values are filesystem paths.
+
+    Single seam for #98 (inline --body support) and #97 (PII pre-flight
+    redactor will hook here so both flags get scanned identically).
+    """
+    if body is not None:
+        return body
+    assert body_file is not None  # argparse mutex group makes this unreachable
+    if body_file == "-":
+        return sys.stdin.read()
+    return Path(body_file).read_text()
+
+
 def _cmd_file(args: argparse.Namespace) -> int:
     """Atomic: create issue, add to project, set Priority + Status + extras.
 
@@ -370,7 +410,17 @@ def _cmd_file(args: argparse.Namespace) -> int:
         board.option_id(name, value)
         extra_specs.append((name, value))
 
-    # Create the issue. gh prints the URL on stdout.
+    # Resolve body before any gh call: inline --body, --body-file path, or
+    # --body-file - (stdin). gh issue create still wants a path, so we round-
+    # trip through a temp file. Single resolution seam keeps #97's redactor
+    # ergonomic — one place to scan.
+    body = _resolve_body(args.body, args.body_file)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    ) as tf:
+        tf.write(body)
+        body_tmp_path = tf.name
+
     create_args = [
         "issue",
         "create",
@@ -379,7 +429,7 @@ def _cmd_file(args: argparse.Namespace) -> int:
         "--title",
         args.title,
         "--body-file",
-        args.body_file,
+        body_tmp_path,
     ]
     for label in args.label or []:
         create_args.extend(["--label", label])
@@ -388,6 +438,8 @@ def _cmd_file(args: argparse.Namespace) -> int:
     except GhInvocationError as e:
         print(f"error: gh issue create failed: {e}", file=sys.stderr)
         return 2
+    finally:
+        Path(body_tmp_path).unlink(missing_ok=True)
     if not issue_url.startswith("http"):
         print(f"error: unexpected gh issue create output: {issue_url[:200]}", file=sys.stderr)
         return 2
@@ -544,7 +596,7 @@ def _cmd_blocked_by(args: argparse.Namespace) -> int:
 
 def _cmd_comment(args: argparse.Namespace) -> int:
     board = Board.from_path(Path(args.board))
-    body = sys.stdin.read() if args.body_file == "-" else Path(args.body_file).read_text()
+    body = _resolve_body(args.body, args.body_file)
 
     # gh issue comment requires a file path, even when we got the body
     # from stdin — write a temp file, invoke, clean up.

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -988,3 +989,23 @@ def run_graphql(query: str, *, cache: str | None = None, **variables: str | int 
         flag = "-F" if isinstance(value, bool | int) and not isinstance(value, str) else "-f"
         args.extend([flag, f"{name}={value}"])
     return run_gh(args, cache=cache)
+
+
+def resolve_body(body: str | None, body_file: str | None) -> str:
+    """Resolve issue/comment body from inline text, a file path, or stdin.
+
+    Exactly one of `body` / `body_file` is set (the CLI's argparse mutex
+    group enforces this). `body_file == "-"` reads stdin; other values are
+    filesystem paths.
+
+    Single seam point — both `jared file` and `jared comment` route through
+    here. #97's PII pre-flight redactor will hook this function so inline
+    --body, --body-file paths, and stdin all get scanned for gitignored
+    claude-shaped local content identically before any GitHub write.
+    """
+    if body is not None:
+        return body
+    assert body_file is not None  # argparse mutex group makes this unreachable
+    if body_file == "-":
+        return sys.stdin.read()
+    return Path(body_file).read_text()

--- a/tests/test_cmd_comment.py
+++ b/tests/test_cmd_comment.py
@@ -89,6 +89,56 @@ def test_comment_from_stdin(
     assert bodies == ["comment from stdin"]
 
 
+def test_comment_with_inline_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--body <text> on `jared comment` mirrors `gh issue comment --body`."""
+    board_md = write_minimal_board(tmp_path)
+    _calls, bodies = _patch_gh_capturing_body_file(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "comment",
+            "42",
+            "--body",
+            "## Inline note\n\nFrom argv.",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert bodies == ["## Inline note\n\nFrom argv."]
+
+
+def test_comment_rejects_both_body_and_body_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    board_md = write_minimal_board(tmp_path)
+    body_file = tmp_path / "note.md"
+    body_file.write_text("from file")
+    _patch_gh_capturing_body_file(monkeypatch)
+
+    mod = import_cli()
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(
+            [
+                "--board",
+                str(board_md),
+                "comment",
+                "42",
+                "--body",
+                "from inline",
+                "--body-file",
+                str(body_file),
+            ]
+        )
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    assert "not allowed with" in captured.err or "mutually exclusive" in captured.err, captured.err
+
+
 def test_comment_handles_plain_text_url_response(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from pathlib import Path
 from textwrap import dedent
 
@@ -287,6 +288,169 @@ def test_file_emits_recovery_command_on_field_mutation_failure(
     assert str(issue_number) in captured.err, captured.err
     assert "--priority Medium" in captured.err, captured.err
     assert "rate limit exceeded" in captured.err, captured.err
+
+
+def _patch_gh_capturing_body_file(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    verify_number: int = 142,
+) -> tuple[list[list[str]], list[str | None]]:
+    """Same shape as tests/test_cmd_comment.py's helper, adapted to file's
+    full call sequence (issue create → item-add → graphql).
+
+    Snapshots `--body-file` content at call time so tests can assert on the
+    resolved body regardless of whether it came from --body, --body-file path,
+    or --body-file - stdin.
+    """
+    calls: list[list[str]] = []
+    bodies: list[str | None] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        if "--body-file" in args:
+            idx = args.index("--body-file")
+            body_path = args[idx + 1]
+            try:
+                bodies.append(Path(body_path).read_text())
+            except (FileNotFoundError, OSError):
+                bodies.append(None)
+        if "issue create" in joined:
+            return FakeGhResult(
+                stdout=f"https://github.com/brockamer/findajob/issues/{verify_number}\n"
+            )
+        if "item-add" in joined:
+            return FakeGhResult(stdout='{"id": "PVTI_new"}')
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        fake_run,
+    )
+    return calls, bodies
+
+
+def test_file_with_inline_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--body <text> passes inline content to gh; symmetric with `gh issue create --body`."""
+    board_md = _write_full_board(tmp_path)
+    _calls, bodies = _patch_gh_capturing_body_file(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "## Hello\n\nLiteral inline markdown.",
+            "--priority",
+            "Low",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert bodies == ["## Hello\n\nLiteral inline markdown."]
+
+
+def test_file_with_body_file_dash_stdin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--body-file - reads body from stdin (parity with `jared comment`)."""
+    board_md = _write_full_board(tmp_path)
+    _calls, bodies = _patch_gh_capturing_body_file(monkeypatch)
+    monkeypatch.setattr("sys.stdin", StringIO("piped body content"))
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body-file",
+            "-",
+            "--priority",
+            "Low",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert bodies == ["piped body content"]
+
+
+def test_file_rejects_both_body_and_body_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--body and --body-file are mutually exclusive; specifying both must error."""
+    board_md = _write_full_board(tmp_path)
+    body_file = tmp_path / "body.md"
+    body_file.write_text("from file")
+    _routed_fake(monkeypatch)
+
+    mod = import_cli()
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(
+            [
+                "--board",
+                str(board_md),
+                "file",
+                "--title",
+                "Test",
+                "--body",
+                "from inline",
+                "--body-file",
+                str(body_file),
+                "--priority",
+                "Low",
+            ]
+        )
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    assert "not allowed with" in captured.err or "mutually exclusive" in captured.err, captured.err
+
+
+def test_file_rejects_body_prefix_abbrev(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Regression for #98: argparse abbrev must not silently route --bod to --body.
+
+    Pre-fix, allow_abbrev=True (argparse default) accepted --bod as a unique
+    prefix of --body-file and assigned the next argv to body_file, sending the
+    user's literal markdown into `gh issue create --body-file <markdown>` →
+    `open: no such file or directory`. With allow_abbrev=False the parser
+    exits before any handler runs — assertion is on that absence: gh is never
+    invoked and the exit is argparse's, not the command's.
+    """
+    board_md = _write_full_board(tmp_path)
+    calls = _routed_fake(monkeypatch)
+
+    mod = import_cli()
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(
+            [
+                "--board",
+                str(board_md),
+                "file",
+                "--title",
+                "Test",
+                "--bod",
+                "hello world",
+                "--priority",
+                "Low",
+            ]
+        )
+    assert excinfo.value.code != 0
+    # No gh call should have happened — abbrev was rejected before the handler.
+    # If allow_abbrev had stayed True, --bod would have aliased to --body-file,
+    # `_cmd_file` would have run, and we'd see a `gh issue create` invocation.
+    assert not any("issue" in c and "create" in c for c in calls), (
+        f"--bod must not silently route to --body / --body-file; gh was invoked: {calls}"
+    )
 
 
 def test_file_makes_no_item_list_calls(


### PR DESCRIPTION
## Summary

Closes #98.

`jared file --body "hello world"` was failing with `open hello world: no such file or directory` — the user's literal markdown was being routed to `gh issue create --body-file <markdown>` and the filesystem layer was being asked to open the markdown as a path. Root cause: argparse's default `allow_abbrev=True` accepted `--body` as an unambiguous prefix of `--body-file` and silently assigned the user's text to `body_file`.

This PR adopts the user's preferred fix (Option A in the issue): match `gh issue create`'s dual-flag UX so `--body <text>` works inline and `--body-file <path>` works for files (with `-` for stdin), mutually exclusive. As defense-in-depth, `allow_abbrev=False` is set on the parser and on the body-bearing subparsers so `--bod` and similar prefixes are rejected before any handler runs.

- **Phase 1** (`888e059`): the fix itself — argparse mutex group on `file_p`/`comment_p`, `allow_abbrev=False`, body-resolution helper, `_cmd_file` rewired to read body and round-trip through a temp file.
- **Phase 2** (`72f9203`): refactor `resolve_body` into `lib/board.py` per CLAUDE.md's "shared piece → Board" guidance. No behavior change; sets up the seam #97's PII pre-flight redactor will hook.

## Test plan

- [x] 6 new tests covering inline `--body`, `--body-file -` stdin parity for `jared file`, the mutex-required error path on both subcommands, and prefix-abbrev rejection.
- [x] Full 228-test unit suite green (1 deselected = integration, opt-in).
- [x] `ruff check` clean.
- [x] `ruff format --check` clean.
- [x] `mypy --strict` clean (34 source files).
- [x] CLI `--help` shows the new `(--body BODY | --body-file BODY_FILE)` mutex form on both `file` and `comment`.
- [ ] Live smoke after merge: `jared file --title "smoke" --body "inline"` and `jared comment <N> --body "inline"` against a throwaway issue. (Reviewer's call, or in a later session.)

## Doc updates

- `commands/jared-file.md` — both `--body` and `--body-file` documented.
- `skills/jared/SKILL.md` — Tier 2 example shows the mutex form.
- `references/jared-cli.md` — argument table updated for both subcommands.

## Notes

- No version bump per `feedback_jared_git_workflow` "don't bump v0.x.y for these PRs alone" pattern. Bundle the bump with #97's PR when that lands.
- Per the same memory: feature branches are pre-authorized; merging agent-authored PRs is not. Leaving this PR open for explicit merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)