### PR TITLE
fix(file): resilient diagnostics on create-step failure + ghost-issue check (#100)

### DIFF
--- a/skills/jared/references/board-sweep.md
+++ b/skills/jared/references/board-sweep.md
@@ -54,6 +54,14 @@ Also flag items that have been in Blocked status for more than 7 days — propos
 
 Issues in Done since before the last release — fine to leave, but glance for anything that should have been closed differently (closed as "won't fix" but with no explanatory comment). Add a `wontfix` or `obsolete` label if appropriate.
 
+### 6b. Off-board issues (ghost detection)
+
+Open issues in the repo that have no project item — `gh issue create` ran somewhere outside `jared file` / `jared add-to-board` and the issue never landed on the kanban. The operator can't see it; Status and Priority are null; it sorts to the bottom and disappears.
+
+`sweep.py`'s `check_off_board_issues` intersects `gh issue list --state open` against `gh project item-list` and flags any difference. Each finding renders a `jared add-to-board <N> --priority Medium` recovery line — adjust priority before pasting.
+
+This is the durable backstop for the "any opaque `jared file` failure → fall back to raw `gh issue create` → orphan" pattern (issue #100). Detection is automatic; remediation is per-item with explicit operator approval.
+
 ### 7. Label hygiene
 
 - Deprecated labels (e.g., legacy `priority:` labels when the Priority field is canonical) — strip.

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -417,17 +417,32 @@ def _cmd_file(args: argparse.Namespace) -> int:
     ]
     for label in args.label or []:
         create_args.extend(["--label", label])
+    # Preserve the staged temp file on any create-step failure so the user can
+    # retry without re-typing the body. #100: closes the fallback loop where
+    # an opaque `jared file` failure → Claude shells out to plain `gh issue
+    # create` → off-board ghost issue. The staged file is cleaned up on the
+    # success path further down.
     try:
         issue_url = board.run_gh_raw(create_args)
     except GhInvocationError as e:
         print(f"error: gh issue create failed: {e}", file=sys.stderr)
+        print(
+            f"  body staged at: {body_tmp_path} "
+            f"(retry with: --body-file {body_tmp_path})",
+            file=sys.stderr,
+        )
         return 2
-    finally:
-        Path(body_tmp_path).unlink(missing_ok=True)
     if not issue_url.startswith("http"):
         print(f"error: unexpected gh issue create output: {issue_url[:200]}", file=sys.stderr)
+        print(
+            f"  body staged at: {body_tmp_path} "
+            f"(retry with: --body-file {body_tmp_path})",
+            file=sys.stderr,
+        )
         return 2
     issue_number = int(issue_url.rsplit("/", 1)[-1])
+    # Past the create step — issue exists, no need to keep the staged body.
+    Path(body_tmp_path).unlink(missing_ok=True)
 
     # assume_new=True skips the find_item_id membership scan that #4's perf
     # fix removed from the filing hot path. On failure the issue exists on

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -405,6 +405,24 @@ def _cmd_file(args: argparse.Namespace) -> int:
         tf.write(body)
         body_tmp_path = tf.name
 
+    # Round-trip fence: read the staged file back and verify it matches
+    # what we tried to write. Catches a different failure mode than the
+    # gh-error path below — silent staging corruption (filesystem oddity,
+    # future routing surprise) where gh would otherwise succeed with
+    # empty/wrong body and the user gets a corrupt issue with no signal
+    # anything went wrong. Cheap I/O on a tmpfs-backed file.
+    if Path(body_tmp_path).read_text(encoding="utf-8") != body:
+        print(
+            "error: inline --body failed to stage to temp file (round-trip mismatch)",
+            file=sys.stderr,
+        )
+        print(
+            f"  staged at: {body_tmp_path} — retry with --body-file <path>",
+            file=sys.stderr,
+        )
+        Path(body_tmp_path).unlink(missing_ok=True)
+        return 2
+
     create_args = [
         "issue",
         "create",

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -362,6 +362,45 @@ def check_native_dependencies(
     return findings
 
 
+def check_off_board_issues(
+    items: list[dict[str, Any]],
+    issues_by_number: dict[int, dict[str, Any]],
+) -> list[str]:
+    """Flag open repo issues that have no corresponding project item.
+
+    The "off-board ghost" pattern (#100): an issue is created on the repo
+    via raw `gh issue create` (or any path that bypasses `jared file` /
+    `jared add-to-board`), so it never lands on the project board. The
+    operator can't see it in the kanban view; Status and Priority are
+    null; it sorts to the bottom and disappears.
+
+    `_cmd_file` makes this hard to produce on purpose, but the fallback
+    path is real: when `jared file` errors opaquely, sessions sometimes
+    drop to plain `gh issue create` to keep moving — leaving an orphan
+    behind. This check is the durable backstop.
+
+    Caller passes `issues_by_number` already filtered to repo-open
+    issues (see `fetch_open_issues_bulk` which uses `--state open`).
+    A board item with content.state=CLOSED still counts as "on the
+    board" — that's a different drift handled by `check_closed_not_done`.
+    """
+    on_board = {
+        (i.get("content") or {}).get("number")
+        for i in items
+        if (i.get("content") or {}).get("number") is not None
+    }
+    findings = []
+    for n, issue in sorted(issues_by_number.items()):
+        if n in on_board:
+            continue
+        title = (issue.get("title") or "")[:80]
+        findings.append(
+            f"#{n}: {title} — Propose: jared add-to-board {n} --priority Medium "
+            "(adjust priority as needed)"
+        )
+    return findings
+
+
 def check_legacy_priority_labels(issues_by_number: dict[int, dict[str, Any]]) -> list[str]:
     findings = []
     for n, issue in issues_by_number.items():
@@ -649,6 +688,14 @@ def main() -> int:
             print(f"  {format_closed_not_done_line(entry)}")
     else:
         print("  None")
+    print()
+
+    print("== Off-board issues (open in repo, missing from project) ==")
+    if not issues_by_number:
+        print("  (skipped — no issue data)")
+    else:
+        for f in check_off_board_issues(items, issues_by_number) or ["None"]:
+            print(f"  {f}")
     print()
 
     print("== Session-note freshness (In Progress, last 3 days) ==")

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -160,6 +160,120 @@ def test_file_with_custom_status_and_extra_field(
     )
 
 
+def test_file_preserves_staged_body_on_create_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Regression for #100: when `gh issue create` fails, the staged temp body
+    file must be preserved (not unlinked) and its path printed in stderr so
+    the user can retry with --body-file <staged-path> without re-typing the body.
+
+    Pre-fix, `_cmd_file` unlinked the temp file in `finally:` regardless of
+    outcome, leaving the user to reconstruct the body from scratch. The
+    failure mode then drove sessions to fall back to plain `gh issue create`,
+    which succeeds at the issue level but skips add-to-board → off-board
+    ghost issue. Preserving the stage closes that fallback path.
+    """
+    board_md = _write_full_board(tmp_path)
+    inline_body = "## Title\n\nMulti-line body content with **markdown**."
+
+    captured_paths: list[str] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        joined = " ".join(args)
+        if "issue create" in joined:
+            # Capture the staged path so the test can verify it survives.
+            if "--body-file" in args:
+                idx = args.index("--body-file")
+                captured_paths.append(args[idx + 1])
+            return FakeGhResult(
+                stdout="",
+                returncode=1,
+                stderr="GraphQL: API rate limit exceeded for installation",
+            )
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            inline_body,
+            "--priority",
+            "Low",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc != 0, captured.err
+
+    # Staged temp file must still exist with the original body content.
+    assert len(captured_paths) == 1, f"expected one staged path; got {captured_paths}"
+    staged = Path(captured_paths[0])
+    assert staged.exists(), f"staged body must be preserved on create failure: {staged}"
+    assert staged.read_text() == inline_body
+
+    # The error message must surface the staged path so the user can retry.
+    assert str(staged) in captured.err, captured.err
+    # And include a clear, retry-shaped recovery line — not just gh's stderr.
+    assert "--body-file" in captured.err, captured.err
+    assert "rate limit exceeded" in captured.err, captured.err  # underlying gh stderr preserved
+
+    # Cleanup so we don't leave the file behind in tmp_path.
+    staged.unlink(missing_ok=True)
+
+
+def test_file_unlinks_staged_body_on_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The flip side of preserve-on-failure: on success, the staged body is
+    cleaned up so /tmp doesn't accumulate junk.
+
+    Implementation note: the temp path can be observed at gh-call time via
+    --body-file argv; after main() returns, that path should no longer exist.
+    """
+    board_md = _write_full_board(tmp_path)
+    captured_paths: list[str] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        joined = " ".join(args)
+        if "issue create" in joined:
+            if "--body-file" in args:
+                idx = args.index("--body-file")
+                captured_paths.append(args[idx + 1])
+            return FakeGhResult(stdout="https://github.com/brockamer/findajob/issues/42\n")
+        if "item-add" in joined:
+            return FakeGhResult(stdout='{"id": "PVTI_new"}')
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "OK body",
+            "--priority",
+            "Low",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+
+    assert len(captured_paths) == 1
+    staged = Path(captured_paths[0])
+    assert not staged.exists(), f"staged body must be cleaned up on success: {staged}"
+
+
 def test_file_emits_recovery_command_on_post_create_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -274,6 +274,64 @@ def test_file_unlinks_staged_body_on_success(
     assert not staged.exists(), f"staged body must be cleaned up on success: {staged}"
 
 
+def test_file_inline_body_staging_round_trip_mismatch_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Phase 2 fence (#100): if the staged temp file's content doesn't match
+    what we tried to write, refuse to call gh.
+
+    This catches a different failure mode from preserve-on-create-failure:
+    here, staging itself silently produced wrong content, and gh would
+    succeed with empty/wrong body — the user gets a corrupt issue with no
+    signal. After #98 this should be unreachable, but it's a cheap fence
+    against the next routing surprise.
+
+    We simulate the silent corruption by monkeypatching Path.read_text to
+    return empty for the staged tmp file. A real-world cause would be a
+    filesystem write that didn't take (disk full, encoding error, future
+    refactor that loses bytes).
+    """
+    board_md = _write_full_board(tmp_path)
+    real_read_text = Path.read_text
+
+    def maybe_truncating_read_text(self: Path, *a: object, **kw: object) -> str:
+        # Only intercept the temp body file (created in /tmp directly,
+        # not under any subdirectory). The board file lives under
+        # tmp_path/docs/, so we won't break Board parsing.
+        if self.parent == Path("/tmp") and self.suffix == ".md":
+            return ""
+        return real_read_text(self, *a, **kw)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", maybe_truncating_read_text)
+    calls = _routed_fake(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "Real body content that will not survive the round-trip.",
+            "--priority",
+            "Low",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc != 0, captured.err
+    # CLI-shape error, not a gh error. Must mention the failure mode.
+    assert "round-trip" in captured.err or "stage" in captured.err, captured.err
+    # Retry guidance points at --body-file.
+    assert "--body-file" in captured.err, captured.err
+    # Critical: gh must NOT have been invoked. Fence trips before any
+    # network call, so no risk of a corrupt issue landing on the repo.
+    assert not any("issue" in c and "create" in c for c in calls), (
+        f"fence must trip before gh issue create; got calls: {calls}"
+    )
+
+
 def test_file_emits_recovery_command_on_post_create_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_sweep_checks.py
+++ b/tests/test_sweep_checks.py
@@ -324,6 +324,95 @@ def test_check_plan_spec_drift_still_flags_genuinely_orphaned_plans(
     assert any("no ## Issue section" in f for f in findings)
 
 
+def _open_issue(number: int, title: str = "") -> dict[str, Any]:
+    """Shape matches what `gh issue list --json number,title,...` returns."""
+    return {"number": number, "title": title or f"Issue {number}", "labels": []}
+
+
+def test_check_off_board_issues_returns_empty_when_all_on_board() -> None:
+    """Healthy case: every open repo issue has a project item."""
+    mod = import_sweep()
+    items = [
+        _item(1, "OPEN", "In Progress"),
+        _item(2, "OPEN", "Up Next"),
+        _item(3, "OPEN", "Backlog"),
+    ]
+    issues_by_number = {
+        1: _open_issue(1),
+        2: _open_issue(2),
+        3: _open_issue(3),
+    }
+    assert mod.check_off_board_issues(items, issues_by_number) == []
+
+
+def test_check_off_board_issues_flags_repo_issue_missing_from_project() -> None:
+    """The whole point of this check (#100): an issue exists on the repo but
+    isn't on the board — Status is null, Priority is null, the operator can't
+    see it without a sweep. Surface it with a `jared add-to-board` recovery."""
+    mod = import_sweep()
+    items = [
+        _item(1, "OPEN", "In Progress"),
+        _item(2, "OPEN", "Up Next"),
+    ]
+    issues_by_number = {
+        1: _open_issue(1),
+        2: _open_issue(2),
+        # 99 is open on the repo but absent from the project.
+        99: _open_issue(99, title="Ghost issue from gh fallback"),
+    }
+    findings = mod.check_off_board_issues(items, issues_by_number)
+    assert len(findings) == 1
+    assert "#99" in findings[0]
+    assert "Ghost issue from gh fallback" in findings[0]
+    # Recovery line must be paste-and-run for the operator.
+    assert "jared add-to-board 99" in findings[0]
+    assert "--priority" in findings[0]
+
+
+def test_check_off_board_issues_handles_multiple_ghosts() -> None:
+    mod = import_sweep()
+    items = [_item(1, "OPEN", "Backlog")]
+    issues_by_number = {
+        1: _open_issue(1),
+        50: _open_issue(50, title="ghost A"),
+        51: _open_issue(51, title="ghost B"),
+    }
+    findings = mod.check_off_board_issues(items, issues_by_number)
+    nums = sorted(int(f.split("#")[1].split(":")[0]) for f in findings)
+    assert nums == [50, 51]
+
+
+def test_check_off_board_issues_ignores_closed_repo_issues() -> None:
+    """The repo issue list is already filtered to --state open by
+    fetch_open_issues_bulk, so closed issues don't appear in
+    issues_by_number. But document the contract: this check trusts the
+    caller to pass open issues only — it doesn't re-filter.
+    """
+    mod = import_sweep()
+    items = [_item(1, "OPEN", "Backlog")]
+    # Caller already filtered; only pass open ones in.
+    issues_by_number = {1: _open_issue(1)}
+    assert mod.check_off_board_issues(items, issues_by_number) == []
+
+
+def test_check_off_board_issues_ignores_closed_board_items() -> None:
+    """A board item whose content state is CLOSED still 'covers' a
+    repo-open issue with the same number — but that's a different drift
+    pattern (the repo says open, the board has it closed). Handled by
+    `check_closed_not_done`, not here. This check only flags repo-open
+    issues that have NO project item at all.
+    """
+    mod = import_sweep()
+    items = [
+        _item(1, "OPEN", "Backlog"),
+        _item(99, "CLOSED", "Done"),  # board has it
+    ]
+    issues_by_number = {1: _open_issue(1), 99: _open_issue(99)}
+    # 99 is on the board (even if mismatched state) — not flagged here.
+    findings = mod.check_off_board_issues(items, issues_by_number)
+    assert findings == []
+
+
 def test_format_closed_not_done_line_includes_propose_command() -> None:
     """The render-site formatter names the remediation command so the groom
     flow has a concrete next action to propose with per-item approval.


### PR DESCRIPTION
## Summary

Closes #100. Defense-in-depth on top of #98 (PR #99): even when `_cmd_file` errors opaquely, sessions should never fall back to raw `gh issue create` and create off-board ghost issues. Three layers, all three acceptance criteria from #100:

- **Phase 1 (`792fdc2`)** — preserve the staged temp body on `gh issue create` failure; surface the path with `--body-file <path>` retry guidance. Closes the immediate "I have to re-type the body" pain.
- **Phase 2 (`39ba8f4`)** — round-trip fence after staging. Reads the temp file back and compares against the body; refuses to call gh on mismatch. Catches silent staging corruption (gh would otherwise succeed with corrupt content and the user wouldn't know). Defense against future routing surprises post-#98.
- **Phase 3 (`85703c3`)** — `check_off_board_issues` in `sweep.py`. Intersects open repo issues with project items, flags any open repo issue not on the board with a `jared add-to-board <N> --priority Medium` recovery line. Durable backstop.

## Reasoning correction

`792fdc2`'s commit message claimed Phase 2 was "subsumed by Phase 1." Per advisor review, that was wrong: Phase 1 fires when gh fails (recovery: retry with staged body), Phase 2 fires when staging itself silently corrupts (gh would *succeed* with bad content). Phase 2's commit message (`39ba8f4`) corrects this and explains the distinction. Both fences ship together to close all three acceptance criteria from #100.

## Test plan

- [x] +8 tests across `tests/test_cmd_file.py` (3) and `tests/test_sweep_checks.py` (5):
  - `test_file_preserves_staged_body_on_create_failure` — Phase 1
  - `test_file_unlinks_staged_body_on_success` — Phase 1 cleanup contract
  - `test_file_inline_body_staging_round_trip_mismatch_errors` — Phase 2 fence (RED-then-GREEN verified by reverting)
  - `test_check_off_board_issues_*` ×5 — Phase 3 detector matrix
- [x] Full unit suite: 236 passed, 1 deselected (integration, opt-in).
- [x] `ruff check` clean.
- [x] `ruff format --check` clean.
- [x] `mypy --strict` clean (34 source files).
- [ ] Live smoke after merge: cause a `gh issue create` failure (e.g., transient auth) and confirm the staged path shows up in stderr; run `/jared-groom` against findajob to confirm the new ghost-issue section renders.

## Doc updates

- `references/board-sweep.md` — new section "6b. Off-board issues (ghost detection)" describing the new check and its motivation.

## Notes

- Per `feedback_jared_git_workflow`: feature branch is pre-authorized; merge is not. Leaving open for explicit user merge.
- No version bump per same memory's "don't bump for these PRs alone" pattern; bundle with #97's PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)