### PR TITLE
doctrine(jared): writer of board state + plan-conv warning (#97 partial; carves #102)

### DIFF
--- a/commands/jared-init.md
+++ b/commands/jared-init.md
@@ -66,4 +66,18 @@ Flow:
 
 This is a one-time event per project. From here on, routine discipline (`/jared-wrap`, `/jared-groom`, triggers) keeps the project in shape without another migration.
 
+## Surfaces jared-init does NOT bootstrap
+
+Jared bootstraps the **board convention doc** and migrates board-adjacent legacy patterns. It does not author other Claude Code surfaces — those belong to sibling skills. When `/jared-init` notices a missing surface outside its lane, defer to the appropriate skill rather than offer to write it:
+
+| Missing surface | Defer to | Skill / command |
+|---|---|---|
+| `CLAUDE.md` not present | `/init` (the built-in command) | n/a (built-in) |
+| `CLAUDE.md` audit / quality / improvements | `claude-md-improver` skill | `claude-md-management:claude-md-improver` |
+| `~/.claude/settings.json`, hooks, env vars | `update-config` skill | `update-config` |
+| Keybindings / chord shortcuts | `keybindings-help` skill | `keybindings-help` |
+| Auto-memory entries | (system-managed; no skill writes here) | n/a |
+
+The discipline is mutual: those skills don't write to the project board, and Jared doesn't write to the surfaces they own. Two writers diverge. See `SKILL.md` § "The lane" for the broader contract.
+
 Install as a user-scope plugin (`/plugin install jared`) so `/jared-init` is available in any project you touch.

--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -26,6 +26,7 @@ Flow:
    - In Progress items that were abandoned → propose moving back to Up Next or Backlog with the Session note explaining why
    - Scope discovered but not filed → propose filing new issues now (can use `/jared-file`-style flow inline)
    - Plans/specs whose issues just closed → propose archival via `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/archive-plan.py`
+   - **Doc-sync flag (advisory).** For each touched issue, scan its merged PRs (or unpushed commits) — if code changed but no `.md` outside `docs/sessions/` was touched, surface: *"#N's PR touched code but no doc surface — was a doc update relevant?"* Flag, do not enforce. Most well-maintained projects pair code with doc updates by convention; the flag prompts the human to confirm rather than gates the wrap on it.
 
 4. **Present all drafts consolidated** for user review:
 

--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -13,6 +13,24 @@ You are Jared, the steward of a GitHub Projects v2 board. Think of yourself as t
 
 This is the principle that resolves every ambiguity in the rest of this skill. When you're unsure whether to file, move, close, or ask — ask which choice keeps the mirror honest.
 
+## The lane — writer of board state, reader of everything else
+
+**Jared writes only board state.** Issue bodies, comments (Session notes and `## Current state` updates), project field values, native blocked-by edges. That's it.
+
+Jared *reads* memory, `CLAUDE.md`, project settings, and any gitignored claude-shaped local files (`CLAUDE.local.md`, `.claude/local/*.md`) to align style, infer conventions, and (in a future change, see #102) pre-flight redact private content from public board posts. But Jared never writes to those surfaces. When a sibling skill owns a surface, Jared defers rather than competes:
+
+| Surface | Owner |
+|---|---|
+| Auto-memory entries | The auto-memory writer (system-managed) |
+| `CLAUDE.md` quality / audits | `claude-md-improver` skill |
+| `CLAUDE.md` initial bootstrap | the built-in `/init` command |
+| `~/.claude/settings.json` and hooks | `update-config` skill |
+| Keybindings | `keybindings-help` skill |
+
+Two writers diverge. Jared consumes those surfaces; it does not author them. The PII pre-flight (#102) will enforce the read-only side of this contract in code; the doctrine here is the authoritative statement.
+
+**Canonical vs legacy surfaces.** Some projects carry both a Priority field and legacy `priority:*` labels (or similar duplication). The convention doc (`docs/project-board.md`) names which surface is canonical — Jared writes only there. Legacy duplicates are read-only; reconcile by removing the legacy label, never by writing to it.
+
 ## Why this skill exists
 
 Claude Code sessions and solo operators both tend to let boards drift. Scope gets captured in comments, tmp files, or memory; priorities go stale; plans stand alone without issues backing them; session handoffs happen via ad-hoc markdown drafts that nobody reads again. By month two, the board is decorative and planning has moved elsewhere.

--- a/skills/jared/references/operations.md
+++ b/skills/jared/references/operations.md
@@ -99,6 +99,12 @@ gh api graphql --cache 1h -f query='
 { __type(name: "Issue") { fields { name type { name } } } }'
 ```
 
+## Cautions
+
+**Canonical vs legacy surfaces.** Some projects carry both a Priority field on the project board and legacy `priority:*` labels on the issue (or similar duplication on other axes). The convention doc (`docs/project-board.md`) defines which surface is canonical — Jared writes only to that one. Legacy duplicates are read-only; reconcile drift by *removing* the legacy label or unsetting the legacy field, never by mirroring writes across both. `sweep.py::check_legacy_priority_labels` flags drift; remediation always strips the legacy surface, never the canonical one.
+
+**ProjectV2 single-select mutations are destructive.** `updateProjectV2ItemFieldValue` overwrites the existing value — there is no "merge," "append," or "add to set." Bucketing tags that need additive semantics belong on issue labels (which *are* additive by nature), not on single-select fields. If you find yourself wanting to express "this issue belongs to multiple work streams," that's a label schema problem, not a field-value problem.
+
 ## Operations Jared doesn't wrap today
 
 These remain raw-gh territory; none are used often enough to pull into the CLI.

--- a/skills/jared/references/session-continuity.md
+++ b/skills/jared/references/session-continuity.md
@@ -26,6 +26,12 @@ One comment per session per touched issue. Template at `assets/session-note.md.t
 **State:** Branch, uncommitted changes, test status, anything operationally fiddly.
 ```
 
+### Anti-pattern: re-stating architecture
+
+Session notes describe what *changed* this session and what's *open* — they are deltas, not snapshots of how the code works. If you find yourself paraphrasing what a function does, what files exist, or how the architecture is laid out, link to `CLAUDE.md` or the source instead. Documentation drift starts when two surfaces describe the same thing — and the surface read less often (a Session note buried in an issue thread) is the one that goes stale.
+
+The test: if a reader unfamiliar with the project can understand the change from the Session note, but would still need to read `CLAUDE.md` to understand *the codebase*, the note is shaped right. If the note tries to do both, trim it.
+
 ### Field rules
 
 - **Progress** is always filled. Even "Abandoned in favor of #<N>" is a progress report.

--- a/skills/jared/scripts/archive-plan.py
+++ b/skills/jared/scripts/archive-plan.py
@@ -92,6 +92,38 @@ def already_archived(path: Path) -> bool:
     return "archived" in path.parts
 
 
+# ---------- Plan-convention compliance ----------
+
+# Required-section headings per `assets/plan-conventions.md.template` and
+# `references/plan-spec-integration.md`. The compliance check (#97 acceptance
+# item 7) warns — never refuses — so legitimate edge cases like recycled-issue
+# plans (#89) and plans archived for cleanup don't get blocked. Hard refusal
+# would compound parser fragility (#86/#87/#88).
+#
+# Headings are matched case-insensitively at the start of a line, allowing
+# either the bare name or a trailing-word variant (e.g. "Self-review" matches
+# "## Self-review checklist").
+REQUIRED_SECTIONS: tuple[tuple[str, str], ...] = (
+    ("Documentation Impact", r"^##\s+Documentation\s+Impact\b"),
+    ("Self-review", r"^##\s+Self-review\b"),
+)
+
+
+def check_plan_conv_compliance(plan_text: str) -> list[str]:
+    """Return the names of required plan-convention sections missing from the plan.
+
+    Empty list = fully compliant. Used by `archive_one` to warn (never refuse)
+    when archiving a non-compliant plan; surfaces drift without gating cleanup.
+    """
+    import re
+
+    missing = []
+    for name, pattern in REQUIRED_SECTIONS:
+        if not re.search(pattern, plan_text, re.IGNORECASE | re.MULTILINE):
+            missing.append(name)
+    return missing
+
+
 def archival_header(issues: list[int], ship_date: str) -> str:
     issue_refs = ", ".join(f"#{n}" for n in sorted(issues))
     return (
@@ -165,6 +197,17 @@ def archive_one(
     if text.startswith("---\n**Shipped in"):
         return f"{plan_path}: already has archival header; skipping"
     new_content = archival_header(refs, ship_date) + text
+
+    # Plan-convention compliance check (#97 item 7). Warn — don't refuse —
+    # so recycled-issue plans, cleanup archives, and pre-convention plans
+    # archive cleanly while drift gets surfaced.
+    missing_sections = check_plan_conv_compliance(text)
+    if missing_sections:
+        print(
+            f"warning: {plan_path} missing required plan-conv sections: "
+            f"{', '.join(missing_sections)} (archiving anyway)",
+            file=sys.stderr,
+        )
 
     # Show what will happen
     print(f"\n=== {plan_path} ===")

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -281,6 +281,94 @@ def test_archive_one_still_skips_open_issue(
     assert "[10]" in result
 
 
+def test_check_plan_conv_compliance_returns_empty_when_all_present() -> None:
+    """All required sections present (case-insensitive heading match,
+    'Self-review' or 'Self-review checklist' both count)."""
+    text = (
+        "# Plan\n\n"
+        "## Issue\n\n- #1\n\n"
+        "## Documentation Impact\n\n- README.md\n\n"
+        "## Self-review checklist\n\n- [x] Tests pass\n"
+    )
+    assert ap.check_plan_conv_compliance(text) == []
+
+
+def test_check_plan_conv_compliance_flags_missing_documentation_impact() -> None:
+    text = "# Plan\n\n## Issue\n\n- #1\n\n## Self-review\n\n- [x] Tests pass\n"
+    missing = ap.check_plan_conv_compliance(text)
+    assert "Documentation Impact" in missing
+    assert "Self-review" not in missing
+
+
+def test_check_plan_conv_compliance_flags_missing_self_review() -> None:
+    text = "# Plan\n\n## Issue\n\n- #1\n\n## Documentation Impact\n\n- README.md\n"
+    missing = ap.check_plan_conv_compliance(text)
+    assert "Self-review" in missing
+    assert "Documentation Impact" not in missing
+
+
+def test_check_plan_conv_compliance_flags_both_when_neither_present() -> None:
+    text = "# Plan\n\n## Issue\n\n- #1\n\nJust a body, no required sections.\n"
+    missing = ap.check_plan_conv_compliance(text)
+    assert set(missing) == {"Documentation Impact", "Self-review"}
+
+
+def test_archive_one_warns_to_stderr_when_plan_lacks_required_sections(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Warn — do NOT refuse — when plan is missing required sections.
+
+    Refusing would compound parser fragility (#86, #87, #88 backlog of bugs)
+    and break legitimate edge cases (recycled-issue plans, #89). Warning to
+    stderr keeps the operator informed without gating the archival.
+    """
+    plan = _write_plan(tmp_path, "noncompliant.md", [42])
+    # _write_plan creates a plan with `## Issues` and `## Body` only —
+    # neither required section is present.
+    patch_gh_by_arg(
+        monkeypatch,
+        {"issue view 42": '{"state": "CLOSED", "closedAt": "2026-05-01T00:00:00Z"}'},
+    )
+
+    result = ap.archive_one(plan, "brockamer/jared", dry_run=True, yes=True)
+
+    captured = capsys.readouterr()
+    # Archival proceeds (dry-run returns the would-be path, not None).
+    assert result is not None
+    # Warning lives on stderr, not stdout — the archival output is on stdout.
+    assert "Documentation Impact" in captured.err
+    assert "Self-review" in captured.err
+    assert "warning" in captured.err.lower() or "missing" in captured.err.lower()
+
+
+def test_archive_one_does_not_warn_when_plan_compliant(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No warning when both required sections are present."""
+    plan = tmp_path / "compliant.md"
+    plan.write_text(
+        "# Plan\n\n"
+        "## Issues\n\n- #42\n\n"
+        "## Documentation Impact\n\n- README.md\n\n"
+        "## Self-review checklist\n\n- [x] Tests pass\n"
+    )
+    patch_gh_by_arg(
+        monkeypatch,
+        {"issue view 42": '{"state": "CLOSED", "closedAt": "2026-05-01T00:00:00Z"}'},
+    )
+
+    result = ap.archive_one(plan, "brockamer/jared", dry_run=True, yes=True)
+
+    captured = capsys.readouterr()
+    assert result is not None
+    assert "Documentation Impact" not in captured.err
+    assert "Self-review" not in captured.err
+
+
 def test_main_plan_path_surfaces_skip_reason(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Closes #97 partially — ships the **doctrine subset** (items 2–7, 9). Acceptance item 1 (PII pre-flight redactor) is carved to **#102** for its own brainstorm-spec-plan cycle. The redactor has real design surface (token-vs-phrase matching, allowlist semantics, performance under per-filing I/O cost) that would have held the cheap doctrine work hostage to design churn — splitting was the right call.

Two phase commits:

- **`562f5ab` doctrine(jared)** — pure doc edits across five files. Codifies the umbrella thesis that drove #97: jared writes only board state and defers to sibling skills on every other Claude Code surface. No code change.
- **`e393138` feat(archive-plan)** — `check_plan_conv_compliance` warns (never refuses) when archiving a plan missing required sections. Hard refusal would compound parser fragility (#86/#87/#88 backlog) and break legitimate edge cases like recycled-issue plans (#89). Warning surfaces drift without gating cleanup.

## Doctrine items (commit `562f5ab`)

| # | Item | File |
|---|---|---|
| 9 | Umbrella: writer-of-board, reader-of-everything-else | `SKILL.md` § "The lane" (new) |
| 2 | Anti-pattern: Session notes are deltas, not architecture | `references/session-continuity.md` |
| 4 | Canonical-vs-legacy + ProjectV2 single-select destructiveness | `references/operations.md` § Cautions (new) |
| 5 | Doc-sync advisory flag | `commands/jared-wrap.md` step 3 |
| 6 | Stay-in-lane deferral table | `commands/jared-init.md` (new section) |

The deferral table maps missing surfaces to their owning skill: `CLAUDE.md` → `/init` or `claude-md-improver`, `~/.claude/settings.json` → `update-config`, keybindings → `keybindings-help`, auto-memory → system-managed.

## Test plan

- [x] +6 tests in `tests/test_archive_plan.py` for `check_plan_conv_compliance` (4) and `archive_one` integration (2). RED verified before GREEN.
- [x] Full unit suite: 242 pass, 1 deselected (integration).
- [x] `ruff check`, `ruff format --check`, `mypy --strict` all clean.
- [ ] Live smoke: run `archive-plan.py --plan <some-non-compliant.md> --dry-run --yes` against a non-compliant fixture and confirm the warning lands on stderr.

## Deferred / called out

- **REQUIRED_SECTIONS is hardcoded.** The original #97 spec said "skip silently if `references/plan-conventions.md` doesn't exist in the project's skill assets" — i.e., projects without a plan-convention doc shouldn't see warnings. Currently every project sees the same two required sections (`Documentation Impact`, `Self-review`). For jared itself this matches the asset template; for projects with different conventions, the warning may be unhelpful. Acceptable per the spec's "configurable later" note; future config knob.
- **PII pre-flight (item 1 of #97).** Carved to #102. Predecessor closure here lets that issue brainstorm cleanly without holding the doctrine hostage.

## Notes

- Per `feedback_jared_git_workflow`: feature branch pre-authorized; merge is not. Leaving open for explicit user merge.
- No version bump — bundle with #102 when that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)