### PR TITLE
fix(board): drop dead issueDependencies fallback in fetch_blocked_by_edges (#118)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -428,9 +428,7 @@ class Board:
             )
             item_id = str(data.get("id") or "")
         if not item_id:
-            raise GhInvocationError(
-                f"item-add returned no id for issue {issue_number} after retry"
-            )
+            raise GhInvocationError(f"item-add returned no id for issue {issue_number} after retry")
         return item_id
 
     def add_existing_to_board(
@@ -782,44 +780,29 @@ def fetch_blocked_by_edges(
     open issues in `repo`. Replaces the per-issue N+1 pattern that
     `dependency-graph.py` used to use.
 
-    Tries the `blockedBy` field first; on a schema error (older repos
-    expose `issueDependencies` under a different name) falls back to
-    `issueDependencies`. Raises if neither is available.
-
     `cache` is forwarded to gh as `--cache <duration>` — pass "60s" for
     advisory uses (sweep, dependency-graph) so re-runs within a minute
     skip the network and the GraphQL points entirely.
     """
     owner, name = repo.split("/", 1)
-    for field_name in ("blockedBy", "issueDependencies"):
-        q = (
-            "query($o:String!,$r:String!,$c:String){repository(owner:$o,name:$r){"
-            f"issues(first:100,after:$c,states:OPEN){{pageInfo{{hasNextPage endCursor}}"
-            f"nodes{{number {field_name}(first:20){{nodes{{number state}}}}}}}}}}}}"
-        )
-        result: dict[int, list[dict[str, Any]]] = {}
-        cursor: str | None = None
-        try:
-            while True:
-                kwargs: dict[str, str] = {"o": owner, "r": name}
-                if cursor:
-                    kwargs["c"] = cursor
-                data = run_graphql(q, cache=cache, **kwargs)["data"]["repository"]["issues"]
-                for node in data["nodes"]:
-                    result[node["number"]] = node[field_name]["nodes"]
-                if not data["pageInfo"]["hasNextPage"]:
-                    break
-                cursor = data["pageInfo"]["endCursor"]
-            return result
-        except GhInvocationError as e:
-            # Schema may expose `issueDependencies` instead of `blockedBy`.
-            # Match the gh error verbiage loosely so future GraphQL phrasing
-            # changes don't silently bypass the fallback.
-            msg = str(e)
-            if "Field" in msg and ("doesn" in msg or "isn't" in msg):
-                continue
-            raise
-    raise RuntimeError("Neither blockedBy nor issueDependencies field is available")
+    q = (
+        "query($o:String!,$r:String!,$c:String){repository(owner:$o,name:$r){"
+        "issues(first:100,after:$c,states:OPEN){pageInfo{hasNextPage endCursor}"
+        "nodes{number blockedBy(first:20){nodes{number state}}}}}}"
+    )
+    result: dict[int, list[dict[str, Any]]] = {}
+    cursor: str | None = None
+    while True:
+        kwargs: dict[str, str] = {"o": owner, "r": name}
+        if cursor:
+            kwargs["c"] = cursor
+        data = run_graphql(q, cache=cache, **kwargs)["data"]["repository"]["issues"]
+        for node in data["nodes"]:
+            result[node["number"]] = node["blockedBy"]["nodes"]
+        if not data["pageInfo"]["hasNextPage"]:
+            break
+        cursor = data["pageInfo"]["endCursor"]
+    return result
 
 
 # ---------- Plan/spec issue-ref parsing ----------

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -718,44 +718,6 @@ def test_fetch_blocked_by_edges_paginates(monkeypatch: pytest.MonkeyPatch) -> No
     assert any("c=CUR1" in arg for arg in captured[1])
 
 
-def test_fetch_blocked_by_edges_schema_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """If `blockedBy` raises a Field-doesn't-exist error, retry with `issueDependencies`."""
-    from skills.jared.scripts.lib import board
-
-    call_responses = iter(
-        [
-            # First attempt — blockedBy not on this schema.
-            ("", 1, "Field 'blockedBy' doesn't exist on type 'Issue'"),
-            # Second attempt — issueDependencies works.
-            (
-                (
-                    '{"data": {"repository": {"issues": {'
-                    '"pageInfo": {"hasNextPage": false, "endCursor": null},'
-                    '"nodes": [{"number": 7, "issueDependencies": '
-                    '{"nodes": [{"number": 4, "state": "OPEN"}]}}]'
-                    "}}}}"
-                ),
-                0,
-                "",
-            ),
-        ]
-    )
-
-    class FakeResult:
-        def __init__(self, stdout: str, rc: int, stderr: str) -> None:
-            self.stdout = stdout
-            self.returncode = rc
-            self.stderr = stderr
-
-    def fake_run(args: list[str], **kw: object) -> FakeResult:
-        return FakeResult(*next(call_responses))
-
-    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
-
-    edges = board.fetch_blocked_by_edges("brockamer/findajob")
-    assert edges == {7: [{"number": 4, "state": "OPEN"}]}
-
-
 def test_fetch_blocked_by_edges_passes_cache_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     """cache='60s' threads through to the underlying gh api invocation."""
     from skills.jared.scripts.lib import board


### PR DESCRIPTION
## Summary

- `fetch_blocked_by_edges` had a fallback to `issueDependencies` for "older repos" — but that field never existed on GitHub's `Issue` type. Schema introspection confirms only `blockedBy`, `blocking`, and `issueDependenciesSummary` exist. The fallback was dead code that could never succeed.
- The corresponding test (`test_fetch_blocked_by_edges_schema_fallback`) only passed because it mocked a successful second-call response shape — it didn't verify the field's existence in the live schema.
- Simplifies the helper to a direct `blockedBy` query (lets any error propagate cleanly) and removes the dead test.

Closes #118.

## Test plan

- [x] `pytest` — 292 passed (was 293; one dead test removed)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy --strict` clean
- [x] Live smoke: `dependency-graph.py --repo brockamer/jared --summary` produces same output as before — `Critical path (2): #54 → #60`, no cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)