### PR TITLE
feat(ties): semantic-tie analysis in conversational layer (#80)

### DIFF
--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -64,6 +64,25 @@ Flow:
 
    The block is **advisory** — never gate the start on tie resolution. Operators may close superseded predecessors, sequence feeders first, fold same-file issues into the target's PR, or ignore the block entirely. Each tie carries a confidence tag (`strong` / `medium` / `weak`) and a heuristic suggested action.
 
+   **Semantic ties (your judgment, not the CLI's).** The deterministic six analyzers in `jared ties` cover cross-references, blocked-by edges, milestones, file paths, labels, and title tokens. They cannot detect *semantic* relationships — when two issues describe the same scope in different words, or when an open issue's work may already have shipped under another. That judgment belongs in this conversation, not in a Python subprocess: you have the target issue's full body (loaded in step 5), the deterministic ties' digest, and the broader board context.
+
+   After running `jared ties`, scan the open and recently-closed issues for two specific shapes:
+
+   - **possibly-already-done** — another issue substantially covers the target's scope. Look at recent closures (last 7 days surfaced by `jared next-session-prompt`) and the active Backlog.
+   - **semantic-overlap** — another open issue covers meaningfully overlapping scope (not merely milestone-mate or shared-label adjacency — those are deterministic-tier signals already covered).
+
+   When something stands out, render it in a separate sub-block after the deterministic ties, mirroring the deterministic block's `[<confidence>, <label>]` shape with `llm` as the confidence tier:
+
+   ```
+   Semantic ties (advisory):
+     #N [llm, semantic-overlap]   <one-line rationale>
+     #M [llm, possibly-already-done]   <one-line rationale>
+   ```
+
+   Be strict — empty is the right and expected answer when nothing semantic stands out. The `llm` confidence value exists in `lib/ties.py`'s `Confidence` literal precisely so this prose-rendered tag stays consistent with the deterministic block's tagging convention.
+
+   This intentionally lives in the conversational layer rather than as a Python LLM call inside `jared ties`. The active Claude session already has the full context; spending API tokens on a fresh subprocess to redo work the conversation can do natively is duplicative. See `references/llm-assistance.md` (when filed per #123) for the broader doctrine on LLM-in-CLI vs LLM-in-conversation.
+
 8. **Announce the session plan.** Prepend the **posture block** captured in step 1 verbatim — it's the live board state, the cross-issue context for what's in flight and what's queued.
 
    When step 6 generated guidance at start-time (or loaded existing guidance from the body), include a **guidance block** in the announce. The label distinguishes the source so the user knows what they're confirming:

--- a/skills/jared/scripts/lib/ties.py
+++ b/skills/jared/scripts/lib/ties.py
@@ -15,17 +15,25 @@ from dataclasses import dataclass
 from typing import Literal
 
 SignalName = Literal[
+    # Deterministic signals (six original).
     "cross_ref",
     "blocked_by",
     "milestone",
     "title_tokens",
     "labels",
     "file_paths",
+    # LLM-overlay signals (#80) — produced only by the optional LLM analyzer,
+    # never by the deterministic six. Surfaced in a separate sub-block in
+    # the announce so deterministic and semantic ties don't cross-contaminate.
+    "possibly_already_done",
+    "semantic_overlap",
 ]
-Confidence = Literal["strong", "medium", "weak"]
+Confidence = Literal["strong", "medium", "weak", "llm"]
 # Threshold and Confidence model different roles (filter cutoff vs. signal
 # strength) but share the same domain — Literal members are unordered, so
-# they are the same type. Aliasing makes the relationship explicit.
+# they are the same type. Aliasing makes the relationship explicit. The
+# "llm" value is reserved for the LLM-overlay path; threshold filtering on
+# the deterministic side never produces or accepts it.
 Threshold = Confidence
 
 # Default stop-words for label-intersection signal. Project-board.md may override.
@@ -36,8 +44,10 @@ DEFAULT_LABEL_STOP_WORDS: frozenset[str] = frozenset(
 # Output cap on number of ties surfaced.
 MAX_TIES_DISPLAYED = 8
 
-# Confidence weights for combined_score.
-CONFIDENCE_WEIGHT: dict[Confidence, int] = {"strong": 3, "medium": 2, "weak": 1}
+# Confidence weights for combined_score. "llm" weights as medium-equivalent (2)
+# because semantic ties carry comparable evidence value to single-signal medium
+# deterministic hits — neither is bullet-proof, both deserve operator attention.
+CONFIDENCE_WEIGHT: dict[Confidence, int] = {"strong": 3, "medium": 2, "weak": 1, "llm": 2}
 
 # Score cap so a single candidate firing every signal doesn't dominate sorting.
 MAX_COMBINED_SCORE = 5
@@ -380,6 +390,9 @@ _RELATIONSHIP_LABELS: dict[SignalName, str] = {
     "file_paths": "same-file",
     "title_tokens": "adjacent",
     "labels": "adjacent",
+    # LLM-overlay labels mirror the SignalName for clarity in rendered output.
+    "possibly_already_done": "possibly-already-done",
+    "semantic_overlap": "semantic-overlap",
 }
 
 


### PR DESCRIPTION
## Summary

Replaces PR #124 (closed). Two commits, both targeted:

| Commit | Change |
|---|---|
| `cd8c473` | Phase 1 type plumbing: `Confidence` literal grows `"llm"`; `SignalName` grows `"possibly_already_done"` and `"semantic_overlap"`; relationship labels mapped. No behavior change; no tests added. |
| `c666643` | `commands/jared-start.md`: instructs the active Claude to scan for semantic ties after running `jared ties`, surfacing findings as a `Semantic ties (advisory):` sub-block with `[llm, ...]` confidence tagging. |

## Why this shape

`jared ties` is invoked from `/jared-start`, where the Claude Code session already has the target issue body, the open-issues digest, and broader board context loaded. Adding a Python LLM call inside the CLI subprocess (PR #124's approach) was duplicative work — it spent API tokens on a fresh Haiku invocation to redo what the conversation can do natively, with full context.

Per #123's rule of thumb: LLM-in-CLI is justified when the CLI runs outside Claude Code, prompt caching amortizes across many calls, or output needs JSON for tooling. None of those apply to `jared ties` in practice. The corrected pattern is doctrine in the slash-command markdown that points the active Claude at the work, not Python that re-invokes Claude from a subprocess.

#80's body has been re-shaped to reflect this approach. Session note posted explaining the pivot. #123 captures the broader LLM-in-CLI vs conversational-layer doctrine.

Closes #80.

## What's gone

Discarded from PR #124:

- `lib/ties_llm.py` — Python LLM analyzer module (220 LOC)
- `tests/test_ties_llm.py` — 15 mocked-SDK tests
- `--llm` flag on `jared ties` subcommand
- `Board.llm_overlay_enabled()` method
- Optional `[llm]` extra in `pyproject.toml`
- JSON output wrapper change `{"ties": [...], "llm_hits": [...]}` (reverted to bare list)

The branch `feat/80-llm-ties-overlay` was deleted locally; the remote branch lingers (closed-not-deleted) with the full discarded history.

## Test plan

- [x] `pytest`: 301 passed (Phase 1 added no tests; doctrine change is markdown only)
- [x] `ruff check` clean
- [x] `mypy --strict` clean
- [x] **Live behavior** verified at the doctrine level: in this session, the conversational layer demonstrates exactly the pattern the doctrine prescribes — when surfacing ties for a target issue, scan open and recently-closed issues for semantic relationships and render only when something substantive stands out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)