### PR TITLE
feat(126): imperative ## Model & execution guidance + wrap-time retrospective audit

### DIFF
--- a/commands/jared-file.md
+++ b/commands/jared-file.md
@@ -26,7 +26,7 @@ Flow:
    - `## Current state` — "Not started."
    - `## Decisions` — "(none yet)"
    - `## Acceptance criteria` — in `<details>` block, list criteria
-   - `## Model & execution guidance` — classify the work into Cheap (Haiku-class) / Standard (Sonnet-class) / Smart (Opus / `advisor()`) tiers, name subagent dispatch hints (`Explore`, `general-purpose`, `claude-code-guide`, `advisor()`), and outline a short Execution sketch. See SKILL.md § "Model & execution guidance" for the rendered example. Skip this section if the project's `docs/project-board.md` has `- model-guidance: disabled` in `## Jared config`.
+   - `## Model & execution guidance` — classify the work into imperative-shaped tiers using `USE`-led headers: **Cheap-tier work (USE a Haiku subagent)**, **Standard-tier work (USE a Sonnet subagent)**, **Smart-tier moments (USE `advisor()`)**. Name subagent dispatches with per-line `USE` framing (e.g., `` `feature-dev:code-explorer` — USE to trace how X ships ``). Outline a short Execution sketch. The imperative framing is load-bearing: descriptive labels (e.g., "Cheap (Haiku-class)") drift out of context as sessions grow; verb-led directives ("USE a Haiku subagent") hold at dispatch time. See SKILL.md § "Model & execution guidance" for the rendered example. Skip this section if the project's `docs/project-board.md` has `- model-guidance: disabled` in `## Jared config`.
    - `## Depends on` / `## Blocks` — fill in if applicable, else "(none)"
    - `## Planning` — fill in if a plan/spec already exists, else "(none)"
 

--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -45,7 +45,7 @@ Flow:
 6. **Model guidance backstop.** Scan the issue body for an `## Model & execution guidance` H2.
 
    - If present: load it as part of context; surface its content in step 8's announce so the user can confirm or amend.
-   - If absent AND the project's `docs/project-board.md` does not have `- model-guidance: disabled` in `## Jared config`: generate a fresh evaluation by classifying each acceptance criterion (and the issue summary) into Cheap (Haiku-class) / Standard (Sonnet-class) / Smart (Opus / `advisor()`) tiers, then drafting Subagent dispatch hints and an Execution sketch. Use the same shape the file-time section uses — see SKILL.md § "Model & execution guidance" for the rendered example.
+   - If absent AND the project's `docs/project-board.md` does not have `- model-guidance: disabled` in `## Jared config`: generate a fresh evaluation in the imperative shape — each acceptance criterion (and the issue summary) classified under verb-led headers (**Cheap-tier work (USE a Haiku subagent)**, **Standard-tier work (USE a Sonnet subagent)**, **Smart-tier moments (USE `advisor()`)**), plus per-line `USE`-framed subagent dispatches and an Execution sketch. Use the same shape the file-time section uses — see SKILL.md § "Model & execution guidance" for the rendered example.
    - If absent AND the kill switch is set: skip; load no guidance.
 
    When generated at start-time, the guidance is surfaced in step 8 as a labeled block (`Model & execution guidance (generated at start-time)`) so the user can confirm or amend before step 9.
@@ -89,13 +89,13 @@ Flow:
 
    ```
    Model & execution guidance (<from issue body | generated at start-time>):
-     Cheap (Haiku-class):
+     Cheap-tier work (USE a Haiku subagent):
        - <bullet>
-     Standard (Sonnet-class):
+     Standard-tier work (USE a Sonnet subagent):
        - <bullet>
-     Smart (Opus / advisor()):
+     Smart-tier moments (USE `advisor()`):
        - <bullet>
-     Subagent dispatch hints:
+     Subagent dispatches (USE these for the noted task):
        - <bullet>
      Execution sketch:
        1. <step>

--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -23,6 +23,24 @@ Flow:
 
    **Pre-flight redaction.** Session notes and `## Current state` updates posted via `jared comment` are scanned by the same pre-flight as `jared file`. Drafts referencing private content from `CLAUDE.local.md` will be refused on post — fix the draft, don't fight the redactor. See `references/pii-pre-flight.md`.
 
+   **Guidance audit append.** If this issue carries `## Model & execution guidance` (in its body OR in a prior `## Session <YYYY-MM-DD> — Model & execution guidance (start-time backstop)` comment), append a `## Guidance audit (#N)` H2 to the Session-note draft as a sibling section to `## Session YYYY-MM-DD` — not a bold-labeled field inside it. One comment per wrap, two H2s inside. Three default questions, honest self-report:
+
+   ```
+   ## Guidance audit (#N)
+
+   - Cheap-tier mechanical work: dispatched to Haiku subagents?  [yes / no / N/A]
+   - Smart-tier decisions: routed through `advisor()`?           [yes / no / N/A]
+   - Subagent dispatches: used the prescribed agents?            [yes / no / N/A]
+   ```
+
+   A `no` answer requires a one-line "why" appended beneath that bullet (e.g., `no — skipped because the spec was already complete after exploration and dispatching would have added latency without quality gain`). `N/A` is appropriate when no work of that tier happened in this session.
+
+   **Skip the audit append when:**
+   - `docs/project-board.md`'s `## Jared config` contains `- model-guidance: disabled`, OR
+   - The touched issue has no `## Model & execution guidance` H2 anywhere (no body section, no start-time backstop comment).
+
+   The audit's value isn't the recorded data — it's the trigger. Asking the question at wrap-time is what corrected behavior in the 2026-05-13 findajob#150 session that surfaced this discipline; codifying the question removes the dependency on the operator noticing the gap. See SKILL.md § "Model & execution guidance" for the file-time framing the audit reflects against.
+
 3. **Reconcile drift.** Before posting, check for:
    - In Progress items that were actually completed → propose closing
    - In Progress items that were abandoned → propose moving back to Up Next or Backlog with the Session note explaining why

--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -251,9 +251,11 @@ See `references/human-readable-board.md` for title/body templates and `assets/is
 
 ## Model & execution guidance — every issue declares its tier mix
 
-Every issue body carries a `## Model & execution guidance` section that names which parts of the work are Cheap (Haiku-class), Standard (Sonnet-class), and Smart (Opus / `advisor()`), plus a short Subagent dispatch hints subsection and an Execution sketch. The point: when a session pulls the issue, model selection is a property of the issue, not session-floor knowledge that gets re-derived each time.
+Every issue body carries a `## Model & execution guidance` section that names which parts of the work are cheap-tier (USE a Haiku subagent), standard-tier (USE a Sonnet subagent), and smart-tier (USE `advisor()`), plus a short Subagent dispatches subsection and an Execution sketch. The point: when a session pulls the issue, model selection is a property of the issue, not session-floor knowledge that gets re-derived each time.
 
-**File-time composition is the contract.** When you compose the body of a new issue in `/jared-file`, fill in the four subsections from the template. Use the abstract tier labels (Cheap / Standard / Smart) — model names age faster than the cost structure does. Name real Claude Code primitives in the dispatch hints: `Explore` (Haiku-default, read-only search), `general-purpose` (inherits, multi-step), `claude-code-guide` (Haiku-default, Claude Code questions), and `advisor()` for the senior reviewer pass.
+**Framing is imperative, not descriptive.** Tier labels are verb-led directives — `Cheap-tier work (USE a Haiku subagent)`, not `Cheap (Haiku-class)`. The descriptive shape reads as a category and drifts out of context as the session grows; the imperative shape reads as an instruction and holds at dispatch time. Per-line subagent dispatches use the same `USE` framing: `` `feature-dev:code-explorer` — USE to trace how X ships `` rather than `` `feature-dev:code-explorer` to trace how X ships ``.
+
+**File-time composition is the contract.** When you compose the body of a new issue in `/jared-file`, fill in the four subsections from the template. Use the abstract tier labels (Cheap / Standard / Smart) — model names age faster than the cost structure does. Name real Claude Code primitives in the dispatch lines: `Explore` (Haiku-default, read-only search), `general-purpose` (inherits, multi-step), `claude-code-guide` (Haiku-default, Claude Code questions), and `advisor()` for the senior reviewer pass.
 
 **Start-time backstop.** When `/jared-start` pulls an issue whose body has no `## Model & execution guidance` H2, the start flow generates the evaluation on the fly and surfaces it as part of the proposed-plan announce. User confirmation in step 8 implicitly approves the evaluation; on approval, jared posts it as a Session-note-shaped comment on the issue (timestamped `## Session YYYY-MM-DD — Model & execution guidance (start-time backstop)`). The body is not retroactively amended — comments are append-only and durable, body edits are not. See `commands/jared-start.md` for the exact step ordering.
 
@@ -264,21 +266,21 @@ Every issue body carries a `## Model & execution guidance` section that names wh
 ```markdown
 ## Model & execution guidance
 
-**Cheap (Haiku-class):**
+**Cheap-tier work (USE a Haiku subagent):**
 - Reading existing test fixtures and identifying the patch surface in `lib/board.py`.
 - Generating the placeholder docstring for the new public method.
 
-**Standard (Sonnet-class):**
+**Standard-tier work (USE a Sonnet subagent):**
 - Implementing `Board.parse_optional_field` and wiring it into `_parse`.
 - Writing the unit test for the three input cases (default, explicit, missing).
 
-**Smart (Opus / `advisor()`):**
+**Smart-tier moments (USE `advisor()`):**
 - Final review pass before the PR opens — verifying the field-name choice doesn't collide with existing parsing and that the default-False behavior is right.
 
-**Subagent dispatch hints:**
-- Use `Explore` for the initial scan of how other optional fields are parsed in `lib/board.py`.
-- Use `general-purpose` for the implementation phase if the parent session is on Opus and wants to delegate.
-- Call `advisor()` once before the final commit.
+**Subagent dispatches (USE these for the noted task):**
+- `Explore` — USE for the initial scan of how other optional fields are parsed in `lib/board.py`.
+- `general-purpose` — USE for the implementation phase if the parent session is on Opus and wants to delegate.
+- `advisor()` — USE once before the final commit for the senior reviewer pass.
 
 **Execution sketch:**
 1. Explore the existing parse pattern for one optional field.

--- a/skills/jared/assets/issue-body.md.template
+++ b/skills/jared/assets/issue-body.md.template
@@ -18,17 +18,17 @@ Not started.
 
 ## Model & execution guidance
 
-**Cheap (Haiku-class):**
+**Cheap-tier work (USE a Haiku subagent):**
 - (parts that are read-only, mechanical, or pattern-matching)
 
-**Standard (Sonnet-class):**
+**Standard-tier work (USE a Sonnet subagent):**
 - (parts that are routine implementation, test writing, refactor)
 
-**Smart (Opus / `advisor()`):**
+**Smart-tier moments (USE `advisor()`):**
 - (parts that need design judgment, cross-cutting reasoning, or pre-merge review)
 
-**Subagent dispatch hints:**
-- (which Claude Code agents to call — `Explore`, `general-purpose`, `claude-code-guide`, `advisor()`)
+**Subagent dispatches (USE these for the noted task):**
+- `agent-name` — USE to <do X>  (real Claude Code agents: `Explore`, `general-purpose`, `claude-code-guide`)
 
 **Execution sketch:**
 1. (first step)

--- a/skills/jared/assets/issue-body.md.template
+++ b/skills/jared/assets/issue-body.md.template
@@ -36,10 +36,10 @@ Not started.
 3. (commit / PR boundary)
 
 <!-- Skip this section entirely if the project's docs/project-board.md
-     contains "Model guidance: disabled" in its metadata block. The
-     /jared-start backstop will lazily generate guidance for issues
-     filed before this discipline existed. See SKILL.md § "Model &
-     execution guidance" for the rendered example and rationale. -->
+     contains "- model-guidance: disabled" in the ## Jared config
+     section. The /jared-start backstop will lazily generate guidance
+     for issues filed before this discipline existed. See SKILL.md §
+     "Model & execution guidance" for the rendered example and rationale. -->
 
 <!--
 Dependencies are tracked natively via GitHub's `blockedBy` API, not in body markup.

--- a/skills/jared/assets/session-note.md.template
+++ b/skills/jared/assets/session-note.md.template
@@ -18,7 +18,7 @@
      A "no" answer requires a one-line "why" beneath that bullet. "N/A" is
      correct when no work of that tier happened in this session. -->
 
-## Guidance audit (#<N>)
+## Guidance audit (#N)
 
 - Cheap-tier mechanical work: dispatched to Haiku subagents?  [yes / no / N/A]
 - Smart-tier decisions: routed through `advisor()`?           [yes / no / N/A]

--- a/skills/jared/assets/session-note.md.template
+++ b/skills/jared/assets/session-note.md.template
@@ -9,3 +9,17 @@
 **Gotchas:** Anything future-me needs to know that isn't in the code. Empty if none.
 
 **State:** Branch, uncommitted changes, test status, anything operationally fiddly.
+
+<!-- INCLUDE THE FOLLOWING H2 ONLY when this issue carries ## Model & execution
+     guidance (body section OR start-time backstop comment) AND the project's
+     docs/project-board.md ## Jared config does not contain
+     "- model-guidance: disabled". Otherwise delete this comment and the H2
+     below. Sibling H2 to ## Session above — one comment, two sections inside.
+     A "no" answer requires a one-line "why" beneath that bullet. "N/A" is
+     correct when no work of that tier happened in this session. -->
+
+## Guidance audit (#<N>)
+
+- Cheap-tier mechanical work: dispatched to Haiku subagents?  [yes / no / N/A]
+- Smart-tier decisions: routed through `advisor()`?           [yes / no / N/A]
+- Subagent dispatches: used the prescribed agents?            [yes / no / N/A]

--- a/skills/jared/references/operations.md
+++ b/skills/jared/references/operations.md
@@ -137,7 +137,7 @@ Headers are imperative (verb-led directives) — `Cheap-tier work (USE a Haiku s
 | When | Where | What |
 |---|---|---|
 | File-time | `/jared-file` body composition | Section is part of every new issue body. |
-| Start-time | `/jared-start` step 5a | If the body has no `## Model & execution guidance` H2, generate evaluation, surface in announce, post as Session-note-shaped comment on user approval. |
+| Start-time | `/jared-start` step 6 | If the body has no `## Model & execution guidance` H2, generate evaluation, surface in announce, post as Session-note-shaped comment on user approval. |
 
 **Project-level kill switch.** Add this bullet to `## Jared config` in `docs/project-board.md`:
 

--- a/skills/jared/references/operations.md
+++ b/skills/jared/references/operations.md
@@ -114,23 +114,23 @@ Every issue body filed through `/jared-file` carries a `## Model & execution gui
 ```markdown
 ## Model & execution guidance
 
-**Cheap (Haiku-class):**
+**Cheap-tier work (USE a Haiku subagent):**
 - <bullet>
 
-**Standard (Sonnet-class):**
+**Standard-tier work (USE a Sonnet subagent):**
 - <bullet>
 
-**Smart (Opus / `advisor()`):**
+**Smart-tier moments (USE `advisor()`):**
 - <bullet>
 
-**Subagent dispatch hints:**
-- <bullet — names real Claude Code agents: Explore, general-purpose, claude-code-guide, advisor()>
+**Subagent dispatches (USE these for the noted task):**
+- `agent-name` — USE to <do X>  (real Claude Code agents: Explore, general-purpose, claude-code-guide; `advisor()` for the senior reviewer pass)
 
 **Execution sketch:**
 1. <step>
 ```
 
-Use abstract tier labels (Cheap / Standard / Smart) — model names age faster than the cost structure. The dispatch-hints subsection names *real* Claude Code primitives so the puller doesn't re-derive them. Full doctrine and rendered example in SKILL.md § "Model & execution guidance".
+Headers are imperative (verb-led directives) — `Cheap-tier work (USE a Haiku subagent)`, not `Cheap (Haiku-class)`. The descriptive shape reads as a category and drifts out of context as the session grows; the imperative shape reads as an instruction and holds at dispatch time. Per-line subagent dispatches use the same `USE` framing. Use abstract tier labels (Cheap / Standard / Smart) — model names age faster than the cost structure. Full doctrine and rendered example in SKILL.md § "Model & execution guidance".
 
 **Two enforcement points:**
 


### PR DESCRIPTION
## Summary

Closes #126. Two-phase doctrine change to make jared's `## Model & execution guidance` section *direct* model and subagent choice at dispatch time, rather than describe categories that drift out of context as sessions grow.

- **Phase 1 (1cb3b03):** restructure the guidance section in five surfaces (`issue-body.md.template`, `SKILL.md`, `references/operations.md`, `commands/jared-file.md`, `commands/jared-start.md`) so tier labels are verb-led directives — **Cheap-tier work (USE a Haiku subagent):** rather than **Cheap (Haiku-class):**. Per-line subagent dispatches gain the same `USE` framing.
- **Phase 2 (d64baf0):** add a wrap-time `## Guidance audit (#N)` H2 to Session-note drafts for guidance-bearing issues. Three default questions (Cheap-tier dispatch / Smart-tier `advisor()` / subagent dispatches); `no` answers carry a one-line "why". Skipped when the kill switch (`- model-guidance: disabled` in `## Jared config`) is set or the issue carries no guidance.
- **Review-pass (2bb6819):** three corrections caught by `feature-dev:code-reviewer` on Opus — kill-switch spelling, stale `step 5a` → `step 6` ref, placeholder consistency.

## Doctrine

All three dispatch points (file-time, start-time backstop, wrap-time) are skill-layer prose — **no Python parsing**, **no fixtures-as-code**, **no `lib/board.py` edits**. Per memory `feedback_jared_doctrine_first`, adding a parsed field with no CLI consumer would replicate the #114 Phase 4 → Phase 6 dead-code revert. The acceptance criterion was deliberately rewritten in the issue body before any code was touched, changing "fixture/test verifies emits/omits" to "verified by manual smoke."

## Surfacing incident

2026-05-13 during `brockamer/findajob#150`: Claude proceeded on the parent-session model regardless of what the guidance prescribed, dispatched a subagent without a `model:` override, and skipped `advisor()` on a genuine smart-tier decision. The guidance was functioning as retrospective rationalization rather than dispatch-time direction. Phase 1 closes the gap at decision time; Phase 2 closes it at session end.

## Prior art consulted

- arXiv on pragmatic influence in LLM instructions (imperative framing produces "systematic and reproducible shifts in directive prioritization")
- Reflexion 2023 / LangChain reflection pattern (Phase 2 is the verbal-reflection-buffer shape co-located with the work it audits)
- Augment Code AI routing guide / wshobson/agents (no surfaced prior art for per-task tier hints in issue templates; jared's pattern appears domain-novel)

## Test plan

- [x] Manual smoke on live board: `#126` (has `## Model & execution guidance` H2) → audit included; `#60` (no guidance H2 anywhere) → audit omitted.
- [x] Cross-file consistency: all five guidance-bearing files render identical sub-block headers.
- [x] Doctrine-first compliance: kill-switch spelling identical across all seven surfaces.
- [x] Contrast references retained: `SKILL.md:256` and `references/operations.md:133` still teach the new shape against the deprecated one.
- [ ] Wrap this session: produce a Session-note for `#126` with the audit block (live exercise of Phase 2 against the very issue it implements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)