### PR TITLE
feat(stage): split deferred_reason by failure mode

### DIFF
--- a/skills/jared/scripts/stage.py
+++ b/skills/jared/scripts/stage.py
@@ -60,6 +60,7 @@ _ACCEPTANCE_SECTION = re.compile(
     re.DOTALL,
 )
 _BLOCKED_BY_SECTION = re.compile(r"##\s+Blocked by\s*\n(.*?)(?=\n##(?!#)|\Z)", re.DOTALL)
+_ACCEPTANCE_HEADING_ANY = re.compile(r"^##\s+Acceptance\b", re.MULTILINE)
 _ISSUE_REF = re.compile(r"#(\d+)")
 
 _PRIORITY_RANK = {"High": 0, "Medium": 1, "Low": 2}
@@ -182,6 +183,34 @@ def is_pullable(item: dict[str, Any]) -> bool:
     return len(real_bullets) >= 1
 
 
+def not_pullable_reason(item: dict[str, Any]) -> str:
+    """Classify why an item failed is_pullable. Mirrors is_pullable's checks.
+
+    Surfaces the specific remediation each failure mode needs, so the smoke
+    output doubles as a normalisation hint instead of a uniform "no acceptance
+    criteria" line for every failure shape. Precondition: is_pullable(item)
+    is False — callers filter first.
+    """
+    body = item.get("body", "") or ""
+    if not body.strip():
+        return "not pullable — empty body"
+
+    first_para = body.split("\n\n", 1)[0].strip()
+    if not first_para or first_para == _TEMPLATE_FIRST_PARA:
+        return "not pullable — placeholder summary"
+
+    if _ACCEPTANCE_SECTION.search(body):
+        return "not pullable — acceptance section uses placeholder bullets"
+
+    if _ACCEPTANCE_HEADING_ANY.search(body):
+        return (
+            "not pullable — non-canonical acceptance section; normalize to "
+            "'## Acceptance criteria' wrapped in <details><summary>Expand</summary>"
+        )
+
+    return "not pullable — no acceptance section"
+
+
 def _format_milestone(item: dict[str, Any], *, today: date) -> str:
     milestone = item.get("milestone") or {}
     if not isinstance(milestone, dict):
@@ -288,7 +317,7 @@ def stage_proposals(
     pullable = [i for i in backlog if is_pullable(i)]
     not_pullable = [i for i in backlog if not is_pullable(i)]
     for item in not_pullable:
-        deferred.append(DeferredItem(item, "not pullable — no acceptance criteria"))
+        deferred.append(DeferredItem(item, not_pullable_reason(item)))
 
     dep_ready = [i for i in pullable if has_no_open_blockers(i, items)]
     dep_blocked = [i for i in pullable if not has_no_open_blockers(i, items)]

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -86,6 +86,94 @@ class TestIsPullable:
         assert stage.is_pullable(item) is False
 
 
+class TestNotPullableReason:
+    """`not_pullable_reason` should give the operator a self-describing
+    remediation hint per failure mode — not a uniform "no acceptance criteria"
+    line. Covers each branch in order so a regression on one is caught locally."""
+
+    def test_empty_body(self) -> None:
+        stage = import_stage()
+        assert stage.not_pullable_reason({"body": ""}) == "not pullable — empty body"
+
+    def test_placeholder_summary(self) -> None:
+        stage = import_stage()
+        item = {
+            "body": (
+                "One-sentence summary of what this issue is about and why it matters.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n<summary>Expand</summary>\n\n"
+                "- Real criterion\n\n"
+                "</details>"
+            )
+        }
+        assert stage.not_pullable_reason(item) == "not pullable — placeholder summary"
+
+    def test_placeholder_bullets(self) -> None:
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n<summary>Expand</summary>\n\n"
+                "- Criterion 1\n"
+                "- Criterion 2\n\n"
+                "</details>"
+            )
+        }
+        assert (
+            stage.not_pullable_reason(item)
+            == "not pullable — acceptance section uses placeholder bullets"
+        )
+
+    def test_non_canonical_heading_short_form(self) -> None:
+        """`## Acceptance` (no `criteria` suffix), no <details> wrapper."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary.\n\n"
+                "## Acceptance\n\n"
+                "- Real criterion 1\n"
+                "- Real criterion 2\n"
+            )
+        }
+        reason = stage.not_pullable_reason(item)
+        assert "non-canonical" in reason
+        assert "## Acceptance criteria" in reason
+        assert "<details>" in reason
+
+    def test_non_canonical_missing_details_wrapper(self) -> None:
+        """Canonical `## Acceptance criteria` heading but no <details> wrapper."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary.\n\n"
+                "## Acceptance criteria\n\n"
+                "- Real criterion 1\n"
+                "- Real criterion 2\n"
+            )
+        }
+        assert "non-canonical" in stage.not_pullable_reason(item)
+
+    def test_no_acceptance_section_at_all(self) -> None:
+        stage = import_stage()
+        item = {"body": "Real summary.\n\n## Decisions\n\n(none)\n"}
+        assert stage.not_pullable_reason(item) == "not pullable — no acceptance section"
+
+    def test_prose_mention_of_acceptance_in_backticks_not_counted(self) -> None:
+        """Backticked prose like `` `## Acceptance` `` must not trigger the
+        non-canonical branch — only line-start headings do. Otherwise issue
+        #131's own body (which discusses the variant in prose) would self-report
+        as non-canonical."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Body mentions `## Acceptance` in prose, not as a heading.\n\n"
+                "## Decisions\n\n(none)\n"
+            )
+        }
+        assert stage.not_pullable_reason(item) == "not pullable — no acceptance section"
+
+
 class TestHasNoOpenBlockers:
     def _items(self, *defs: dict[str, Any]) -> list[dict[str, Any]]:
         return list(defs)
@@ -362,7 +450,7 @@ class TestStageProposals:
         assert result.promotions == []
         assert len(result.deferred) == 1
         assert result.deferred[0].item["number"] == 1
-        assert "not pullable" in result.deferred[0].reason
+        assert result.deferred[0].reason == "not pullable — no acceptance section"
 
     def test_blocked_item_with_closed_blocker_returns_to_backlog(self) -> None:
         stage = import_stage()


### PR DESCRIPTION
## Summary

- Replaces the uniform `"not pullable — no acceptance criteria"` deferred reason with five self-describing branches (empty body, placeholder summary, placeholder bullets, non-canonical heading, no section). The smoke output now doubles as a remediation hint per item.
- `_ACCEPTANCE_SECTION` regex is **unchanged** — see #131's Decisions for the "don't broaden, migrate instead" rationale. `<details>` remains required (load-bearing per `references/human-readable-board.md` and `references/design-rationale.md`).
- Tests cover each of the five branches plus the prose-mention edge case (backticked `## Acceptance` in body text must not trigger the non-canonical branch — issue #131's own body would have self-reported otherwise).

## Out-of-repo state — migrated legacy issue bodies

These three pre-template-stabilization issues used `## Acceptance` (no `criteria` suffix) without `<details>` wrapper. Edited in this PR via `gh issue edit` to canonical shape; content otherwise unchanged:

- #60 — perf(verify): measure post-#51-and-#55 GraphQL delta on findajob
- #54 — perf(api): ETag/conditional GET for stable per-issue checks
- #52 — perf(board): cross-process on-disk snapshot cache

A reviewer diffing the branch won't see evidence of these edits in code — they're GitHub-side state. Listing them here so the PR record is durable.

## Acceptance criteria discharge

From #131:
- ✅ Decision documented in `## Decisions` on the issue (commit-prior).
- ✅ Tests gate the behavior change (`TestNotPullableReason`, 7 tests).
- ✅ Live-board smoke produces a less-noisy deferred list (verified — 3 migrated items now pullable; remaining unpullable items get specific reasons).
- ✅ `SKILL.md § "Periodically — stage"` — no update needed; that section is doctrine surface (when/why to invoke), not the enumerated deferred-reason set. The diagnostic shape stays a runtime concern.

## Test plan

- [x] `pytest tests/test_stage.py` — 53 pass (7 new in `TestNotPullableReason`)
- [x] `pytest` full suite — 354 pass, 1 deselected
- [x] `ruff check` clean on changed files
- [x] `mypy skills/jared/scripts/stage.py` clean
- [x] Live-board smoke: `stage.py --report-only` against brockamer/jared shows migrated items leaving the Deferred list and surfacing in correct downstream sections (Almost ready / Still Blocked w/ real-world annotation)

Closes #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)