### PR TITLE
fix(stage): _ACCEPTANCE_SECTION accepts <details> without literal <summary>Expand</summary>

### DIFF
--- a/skills/jared/scripts/stage.py
+++ b/skills/jared/scripts/stage.py
@@ -56,7 +56,7 @@ class StageProposals:
 _TEMPLATE_FIRST_PARA = "One-sentence summary of what this issue is about and why it matters."
 _PLACEHOLDER_CRITERIA = re.compile(r"^\s*-\s*Criterion\s*\d+\s*$", re.MULTILINE)
 _ACCEPTANCE_SECTION = re.compile(
-    r"##\s+Acceptance criteria\s*\n+<details>\s*\n+<summary>Expand</summary>(.*?)</details>",
+    r"##\s+Acceptance criteria\s*\n+<details>(.*?)</details>",
     re.DOTALL,
 )
 _BLOCKED_BY_SECTION = re.compile(r"##\s+Blocked by\s*\n(.*?)(?=\n##(?!#)|\Z)", re.DOTALL)

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -85,6 +85,67 @@ class TestIsPullable:
         }
         assert stage.is_pullable(item) is False
 
+    def test_no_summary_details_shape_is_pullable(self) -> None:
+        """`<details>` with no `<summary>` line at all. Real-world shape
+        surfaced by findajob#679 and findajob#680 (2026-05-15) — #134."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary paragraph describing the work.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n\n"
+                "- Real criterion 1\n"
+                "- Real criterion 2\n\n"
+                "</details>"
+            )
+        }
+        assert stage.is_pullable(item) is True
+
+    def test_arbitrary_summary_text_is_pullable(self) -> None:
+        """`<summary>` text other than the canonical `Expand` — e.g.
+        `<summary>Acceptance criteria</summary>`. Real-world shape — #134."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary paragraph describing the work.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n<summary>Acceptance criteria</summary>\n\n"
+                "- Real criterion 1\n"
+                "- Real criterion 2\n\n"
+                "</details>"
+            )
+        }
+        assert stage.is_pullable(item) is True
+
+    def test_legacy_expand_summary_still_pullable(self) -> None:
+        """Regression: the canonical `<summary>Expand</summary>` shape that
+        `jared file` produces must continue to pass after the regex relaxation
+        for #134."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary paragraph describing the work.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n<summary>Expand</summary>\n\n"
+                "- Real criterion 1\n\n"
+                "</details>"
+            )
+        }
+        assert stage.is_pullable(item) is True
+
+    def test_unclosed_details_is_not_pullable(self) -> None:
+        """Defensive: the relaxed regex must still require `</details>` to
+        close — otherwise the match could span unrelated content. Locks down
+        AC bullet 5 of #134."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary.\n\n## Acceptance criteria\n\n<details>\n\n- Real criterion 1\n"
+                # no closing </details>
+            )
+        }
+        assert stage.is_pullable(item) is False
+
 
 class TestNotPullableReason:
     """`not_pullable_reason` should give the operator a self-describing
@@ -129,12 +190,7 @@ class TestNotPullableReason:
         """`## Acceptance` (no `criteria` suffix), no <details> wrapper."""
         stage = import_stage()
         item = {
-            "body": (
-                "Real summary.\n\n"
-                "## Acceptance\n\n"
-                "- Real criterion 1\n"
-                "- Real criterion 2\n"
-            )
+            "body": ("Real summary.\n\n## Acceptance\n\n- Real criterion 1\n- Real criterion 2\n")
         }
         reason = stage.not_pullable_reason(item)
         assert "non-canonical" in reason


### PR DESCRIPTION
## Summary

- `Board._ACCEPTANCE_SECTION` (in `skills/jared/scripts/stage.py:58`) required the literal `<summary>Expand</summary>` line inside the `<details>` wrapper, false-deferring well-formed acceptance sections that used bare `<details>` or alternate summary text. Surfaced on 2026-05-15 when `findajob#679` and `findajob#680` got marked "not pullable — no acceptance criteria" during `/jared-stage` despite having populated criteria.
- Regex relaxes to match any content between `<details>` and `</details>`. The `## Acceptance criteria` H2 anchor and `</details>` close still bound the match; the downstream bullet filter (`_PLACEHOLDER_CRITERIA`) naturally skips `<summary>` lines whether present or not.
- Adds 4 test fixtures covering: no-summary shape (the findajob shape), arbitrary-summary shape, legacy `<summary>Expand</summary>` regression, and a defensive unclosed-`<details>` negative test (locks AC bullet 5).

Closes #134.

## Test plan

- [x] `pytest` — 358 passed, 1 deselected (integration tests)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy` — clean (38 source files)
- [x] 2 of the new fixtures fail with the prior regex (RED), all pass after the change (GREEN)
- [x] All `TestNotPullableReason` tests still pass — bodies without `<details>` continue to route through `_ACCEPTANCE_HEADING_ANY` for the "non-canonical" diagnostic, behavior unchanged for those cases

## Context

Considered a broader refactor (#135 — "move canonical-body-shape discipline check out of `is_pullable`") that would have decoupled content and discipline checks across a new `lib/body_shape.py` module + filing-time + groom-time gates. Closed #135 as premature after weighing it against CLAUDE.md's "don't add abstractions beyond what the task requires" — the architectural smell only manifested as this one regex bug, and the empirical board audit (5/5 canonical issues, 0 would flag in sweep) showed no measurable drift to defend against. The smaller fix here serves jared's users better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)