### PR TITLE
fix(close): always set Status=Done after gh issue close (#137)

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -8,8 +8,6 @@ import json
 import re
 import sys
 import tempfile
-import time
-from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -270,38 +268,6 @@ def _cmd_move(args: argparse.Namespace) -> int:
     return _cmd_set(args)
 
 
-_CLOSE_VERIFY_ATTEMPTS = 3
-_CLOSE_VERIFY_SLEEP_SECS = 1.0
-
-
-def _poll_for_project_item(
-    board: Board,
-    issue_number: int,
-    *,
-    predicate: Callable[[dict[str, Any]], bool],
-    attempts: int,
-    sleep_secs: float,
-) -> dict[str, Any] | None:
-    """Poll the issue's projectItems until predicate(item) holds or attempts run out.
-
-    GitHub's project operations are eventually-consistent: auto-move on close
-    can lag the next read by hundreds of milliseconds. Uses the scoped
-    per-issue projectItems query via Board.fetch_item_for_issue (~1-3 GraphQL
-    points) instead of a full item-list scan. Fix for #22/#109.
-
-    Returns a dict with at least `id` plus lowercased single-select fields,
-    or None if no match passes the predicate within `attempts` tries.
-    Sleep only happens *between* attempts.
-    """
-    for i in range(attempts):
-        match = board.fetch_item_for_issue(issue_number)
-        if match is not None and predicate(match):
-            return match
-        if i < attempts - 1:
-            time.sleep(sleep_secs)
-    return None
-
-
 def _cmd_close(args: argparse.Namespace) -> int:
     board = _load_board(args.board)
 
@@ -315,25 +281,16 @@ def _cmd_close(args: argparse.Namespace) -> int:
         ]
     )
 
-    # GitHub auto-moves closed issues to Done via its board workflow, but
-    # the propagation is eventually-consistent. Poll a few times before
-    # falling back to an explicit Status=Done via _cmd_set.
-    match = _poll_for_project_item(
-        board,
-        args.issue_number,
-        predicate=lambda item: item.get("status") == "Done",
-        attempts=_CLOSE_VERIFY_ATTEMPTS,
-        sleep_secs=_CLOSE_VERIFY_SLEEP_SECS,
-    )
-    if match is not None:
-        print(f"OK: closed #{args.issue_number}, board auto-moved to Done")
-        return 0
-
+    # Defense-in-depth (#137): GitHub's "Item closed → Done" project workflow
+    # has an observable false-positive mode where a post-close poll can claim
+    # Status=Done while the field hasn't actually changed (verified #135 repro).
+    # Always run the explicit set — cheap no-op if the workflow did fire,
+    # genuine save if it didn't. Source of truth is the field write, not a poll.
     args.field_name = "Status"
     args.value = "Done"
     rc = _cmd_set(args)
     if rc == 0:
-        print(f"OK: closed #{args.issue_number} (manual move to Done)")
+        print(f"OK: closed #{args.issue_number}, Status=Done")
     return rc
 
 

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -58,47 +58,24 @@ def _graphql_item_response(*, project_number: int, status: str, item_id: str = "
     )
 
 
-def test_close_succeeds_when_board_auto_moves(
+def test_close_always_sets_status_done_defense_in_depth(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    board_md = _write_board_with_status(tmp_path)
-    calls = patch_gh_by_arg(
-        monkeypatch,
-        {
-            "issue close": "",
-            "api graphql": _graphql_item_response(project_number=7, status="Done"),
-        },
-    )
-
-    mod = import_cli()
-    rc = mod.main(["--board", str(board_md), "close", "42"])
-
-    captured = capsys.readouterr()
-    assert rc == 0, captured.err
-    # Must have invoked gh issue close
-    assert any("issue" in c and "close" in c for c in calls)
-    # Polling must use graphql, NOT the wide item-list scan that #22 fixes.
-    assert not any("item-list" in " ".join(c) for c in calls)
-    # Must NOT have invoked item-edit — auto-move handled it
-    assert not any("item-edit" in c for c in calls)
-    assert "#42" in captured.out
-
-
-def test_close_falls_back_to_explicit_move_when_auto_move_lags(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # No sleeping in tests — global time.sleep -> no-op for the retry loop.
+    """After `jared close <N>`, item-edit Status=Done MUST run unconditionally
+    — even when the board's auto-move workflow appears to have already moved
+    the item to Done. Defense-in-depth for #137: GitHub's project auto-move
+    has an observable false-positive mode where the GraphQL poll claims
+    Status=Done but the field hasn't actually changed (#135 reproduction).
+    The explicit set after close is the source of truth.
+    """
     monkeypatch.setattr("time.sleep", lambda _s: None)
-
     board_md = _write_board_with_status(tmp_path)
-    # Board never auto-moves to Done — graphql keeps returning Backlog.
-    # _cmd_set fallback now also uses find_item_id → graphql (fix for #109),
-    # so total graphql calls = 3 (polling) + 1 (fallback find_item_id) = 4.
     calls = patch_gh_by_arg(
         monkeypatch,
         {
             "issue close": "",
-            "api graphql": _graphql_item_response(project_number=7, status="Backlog"),
+            # Even if GraphQL says Done, the CLI must still item-edit Status=Done.
+            "api graphql": _graphql_item_response(project_number=7, status="Done"),
             "item-edit": "{}",
         },
     )
@@ -108,25 +85,24 @@ def test_close_falls_back_to_explicit_move_when_auto_move_lags(
 
     captured = capsys.readouterr()
     assert rc == 0, captured.err
-    # 3 poll attempts + 1 find_item_id in _cmd_set fallback = 4 graphql calls.
-    graphql_calls = [c for c in calls if "graphql" in " ".join(c)]
-    assert len(graphql_calls) == 4
-    # Fallback path: explicit item-edit to Status=Done
     edit = next((c for c in calls if "item-edit" in c), None)
-    assert edit is not None, "expected explicit item-edit fallback"
+    assert edit is not None, "expected explicit item-edit even when graphql claims Done"
     joined = " ".join(edit)
     assert "PVTSSF_status" in joined
     assert "OPTION_done" in joined
 
 
-def test_close_filters_graphql_to_current_project(
+def test_close_targets_correct_project_when_issue_on_multiple_boards(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Issue may belong to multiple ProjectV2 items; only the one whose
-    project.number matches the board counts as the auto-move target."""
+    """Issue may belong to multiple ProjectV2 items; the post-close set
+    must resolve to the item on the board configured in project-board.md,
+    never a sibling project's item. Scoping happens in `Board.find_item_id`
+    → `fetch_item_for_issue` which filters by `project.number`.
+    """
     board_md = _write_board_with_status(tmp_path)
-    # Same issue attached to two projects: Done on project 99 (unrelated),
-    # Backlog on project 7 (our board). Fixture must return Backlog.
+    # Same issue attached to two projects: project 99 (unrelated, PVTI_other),
+    # project 7 (our board, PVTI_ours). The item-edit must reference PVTI_ours.
     multi_project_response = json.dumps(
         {
             "data": {
@@ -165,16 +141,12 @@ def test_close_filters_graphql_to_current_project(
             }
         }
     )
-    monkeypatch.setattr("time.sleep", lambda _s: None)
 
     calls = patch_gh_by_arg(
         monkeypatch,
         {
             "issue close": "",
             "api graphql": multi_project_response,
-            "item-list": (
-                '{"items": [{"id": "PVTI_ours", "content": {"number": 42}, "status": "Backlog"}]}'
-            ),
             "item-edit": "{}",
         },
     )
@@ -184,6 +156,9 @@ def test_close_filters_graphql_to_current_project(
 
     captured = capsys.readouterr()
     assert rc == 0, captured.err
-    # Must have fallen back — project 99's Done doesn't satisfy the predicate
-    # because we scope to project_number=7.
-    assert any("item-edit" in c for c in calls)
+    edit = next((c for c in calls if "item-edit" in c), None)
+    assert edit is not None, "expected item-edit on board-scoped item"
+    joined = " ".join(edit)
+    # The mutation must reference our board's item-id, never the sibling project's.
+    assert "PVTI_ours" in joined
+    assert "PVTI_other" not in joined


### PR DESCRIPTION
## Summary

Bug #137: `jared close <N>` reports `OK: closed #N, board auto-moved to Done` via the polling success path, but the issue's board Status field can remain unchanged on direct issue closure (verified on #135 this session — required manual `jared move 135 "Done"` to recover).

GitHub's "Item closed → Done" project workflow has an observable false-positive mode where a post-close GraphQL poll can claim `Status=Done` while the field hasn't actually changed. The `Out of scope` line on #137 already established: don't try to fix the workflow; fix jared to be robust regardless.

## Fix — defense-in-depth

Drop the polling success path entirely. After `gh issue close`, always invoke `_cmd_set Status=Done` — a cheap no-op when the workflow did fire, a genuine save when it didn't. The field write is the source of truth, not a poll.

- Removes `_poll_for_project_item`, `_CLOSE_VERIFY_*` constants, unused `time` and `Callable` imports.
- Replaces the two old "happy path" / "fallback path" success messages with a single accurate `"OK: closed #N, Status=Done"`.
- New regression test `test_close_always_sets_status_done_defense_in_depth`: even when GraphQL claims `Status=Done`, the CLI must still issue the explicit `item-edit`. Failed against the old code for the exact reason the bug exists.
- Reshapes the multi-project scoping test around the surviving `_cmd_set → find_item_id` path; tightens its assertion to verify item-edit references the right project's item-id.
- Two obsolete tests deleted: `test_close_succeeds_when_board_auto_moves` (codified the now-removed "skip the set when polling reports Done" optimization that was the bug) and `test_close_falls_back_to_explicit_move_when_auto_move_lags` (was about polling-then-fallback ordering that no longer exists).

Net: **-68 lines, +31 lines** of cleaner, more defensive code.

## Test plan

- [x] `pytest` — 357 passed, 1 deselected (integration)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy` — clean
- [ ] **Live verification (#137 acceptance #5):** the close of #137 itself via `jared close 137` after this PR merges; observe `Status=Done` lands correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)