### PR TITLE
docs(CLAUDE.md): add /jared-stage to Layout inventory (#142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ These aren't just docs — the CLI validates them:
 
 ```
 .claude-plugin/           plugin.json + marketplace.json (self-hosted single-plugin marketplace)
-commands/                 Slash-command stubs (/jared, /jared-file, /jared-start, /jared-groom,
-                          /jared-wrap, /jared-reshape, /jared-init)
+commands/                 Slash-command stubs (/jared, /jared-file, /jared-groom, /jared-init,
+                          /jared-reshape, /jared-stage, /jared-start, /jared-wrap)
 skills/jared/
   SKILL.md                The skill contract — what Jared is, when to trigger, the discipline
   references/             Loaded on demand: operations.md, structural-review.md, board-sweep.md,


### PR DESCRIPTION
## Summary
- Add `/jared-stage` to the `commands/` Layout inventory in `CLAUDE.md`.
- Sort the list alphabetically (bare `/jared` first) so future omissions are obvious — the prior lifecycle order is what hid this gap to begin with.

## Why
Surfaced by the #139 README fresh-eyes audit. `/jared-stage` shipped via #128 and is wired in `commands/jared-stage.md`, but `CLAUDE.md`'s Layout enumeration still listed 7 commands. README parallel landed in the #139 PR; CLAUDE.md was per-AC#4 deferred to a separate scope.

## Test plan
- [x] `grep "/jared-" CLAUDE.md` — `/jared-stage` now present, no count claim of "7 commands" elsewhere.
- [x] Diff is `CLAUDE.md`-only, 1 hunk.
- [x] List comparison matches `ls commands/` (8 entries).

Closes #142