### PR TITLE
chore(jared): bump version to v0.17.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.16.0"
+version = "0.17.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Version bump for v0.17.0 release.

Closes the `Phase 2 — perf settled` milestone:
- #52 cross-process snapshot cache for `gh project item-list`
- #54 Phase 2.a REST migration for per-issue state checks

#147 filed for the deferred ETag layer (Phase 2.b).

## Test plan

- [x] `.claude-plugin/plugin.json` version bumped to 0.17.0
- [x] `pyproject.toml` version mirrors
- [ ] After merge: tag `v0.17.0` and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)