### PR TITLE
docs(claude-md): drop hardcoded version string (caught in v0.17.0 wrap)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,4 +106,4 @@ Use `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared <subcommand>`. **Never har
 
 ## Versioning
 
-Semantic versioning in `.claude-plugin/plugin.json` (currently `0.2.0-dev`). Git tag `v<x.y.z>` per release. `pyproject.toml` version tracks the plugin version but isn't published as a package.
+Semantic versioning in `.claude-plugin/plugin.json` and mirrored in `pyproject.toml`. Git tag `v<x.y.z>` per release. `pyproject.toml` configures dev tooling and pins venv deps but isn't published as a package — the version field exists for parity, not distribution. Check `.claude-plugin/plugin.json` for the current version rather than relying on this paragraph (which used to hardcode it).


### PR DESCRIPTION
## Summary

`CLAUDE.md` said `currently 0.2.0-dev` but the plugin is at v0.17.0 (17 minor versions since). Caught during the v0.17.0 wrap session.

Replaced the brittle "currently <version>" line with a pointer to `.claude-plugin/plugin.json` as the source of truth.

## Test plan

- [x] CLAUDE.md no longer claims a specific version number
- [x] `pyproject.toml`'s otherwise-cryptic version field is explained

🤖 Generated with [Claude Code](https://claude.com/claude-code)