### PR TITLE
perf(jared): ETag/conditional GET on top of REST issue-state fetch (#147)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import datetime as dt
 import json
 import os
@@ -680,14 +681,12 @@ def run_gh(args: list[str], *, cache: str | None = None) -> Any:
         raise GhInvocationError(f"gh returned non-JSON output: {stdout[:200]}") from e
 
 
-def fetch_issue_state_rest(repo: str, number: int) -> tuple[str, str | None]:
-    """Return (state, closed_at) for an issue via the REST API (#54).
+_HTTP_STATUS_RE = re.compile(r"HTTP/[\d.]+\s+(\d+)")
+_ETAG_HEADER_RE = re.compile(r"^Etag:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
 
-    Uses `gh api repos/<repo>/issues/<n>` so the call hits the REST `core`
-    rate-limit bucket (5000/hr) instead of the `graphql` bucket. For batch
-    state checks (archive-plan.py scanning many plans, dependency-graph.py
-    open-state filters), this removes the calls from GraphQL pressure
-    entirely.
+
+def _parse_issue_state_payload(data: dict[str, Any]) -> tuple[str, str | None]:
+    """Extract (state, closed_at) from a REST /repos/.../issues/<n> JSON body.
 
     State is mapped to GraphQL's `IssueState`/`PullRequestState` enum so
     existing consumers continue to work unchanged:
@@ -696,12 +695,8 @@ def fetch_issue_state_rest(repo: str, number: int) -> tuple[str, str | None]:
         (REST otherwise reports state="closed" for merged PRs, losing
         the merged-vs-closed-unmerged distinction archive-plan needs).
       - "CLOSED" / "OPEN" mapped from REST's lowercase `state`.
-      - "UNKNOWN" on any gh failure (missing repo, 404, network).
+      - "UNKNOWN" on a payload missing or with a non-string `state`.
     """
-    try:
-        data = run_gh(["api", f"repos/{repo}/issues/{number}"])
-    except GhInvocationError:
-        return "UNKNOWN", None
     state = data.get("state")
     if not isinstance(state, str):
         return "UNKNOWN", None
@@ -712,6 +707,118 @@ def fetch_issue_state_rest(repo: str, number: int) -> tuple[str, str | None]:
     if isinstance(pr, dict) and pr.get("merged_at"):
         return "MERGED", closed_at
     return state.upper(), closed_at
+
+
+def _fetch_issue_rest_with_etag(repo: str, number: int) -> dict[str, Any] | None:
+    """Fetch the REST issue body with ETag/conditional GET (#147).
+
+    With a cached ETag the call sends `If-None-Match`; a 304 resolves to the
+    cached body without consuming REST `core` (GitHub doesn't count 304s
+    against the primary bucket). Misses and first calls go through `-i` so
+    the response ETag can be captured for the next call.
+
+    Cannot use `run_gh*` here: `gh api -i` exits non-zero on 304 even on
+    success, and stripping stdout would mangle the headers/body separator.
+    Calls `subprocess.run` directly and parses the HTTP status line itself.
+    Returns the parsed JSON body on success, or None on any failure mode.
+    """
+    cached = cache.get_issue_etag(repo, number)
+    args = ["gh", "api", "-i", f"repos/{repo}/issues/{number}"]
+    if cached is not None:
+        cached_etag, _cached_body = cached
+        args.extend(["-H", f"If-None-Match: {cached_etag}"])
+
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_child_env(),
+    )
+
+    status = _extract_http_status(result.stdout, result.stderr)
+    if status is None:
+        return None
+
+    if status == 304:
+        if cached is None:
+            return None
+        _cached_etag, cached_body = cached
+        return cached_body
+
+    if status != 200:
+        return None
+
+    body = _parse_etag_response_body(result.stdout)
+    if body is None:
+        return None
+    new_etag = _extract_etag_header(result.stdout)
+    if new_etag:
+        with contextlib.suppress(OSError):
+            cache.set_issue_etag(repo, number, etag=new_etag, body=body)
+    return body
+
+
+def _extract_http_status(stdout: str, stderr: str) -> int | None:
+    """Find the first `HTTP/<v> <code>` status line in stdout (then stderr)."""
+    for blob in (stdout, stderr):
+        for line in blob.splitlines():
+            m = _HTTP_STATUS_RE.match(line)
+            if m:
+                return int(m.group(1))
+    return None
+
+
+def _extract_etag_header(stdout: str) -> str | None:
+    m = _ETAG_HEADER_RE.search(stdout)
+    return m.group(1).strip() if m else None
+
+
+def _parse_etag_response_body(stdout: str) -> dict[str, Any] | None:
+    """Split `gh api -i` stdout on the headers/body boundary and parse JSON.
+
+    Accepts both `\\r\\n\\r\\n` and `\\n\\n` separators since `gh api -i`
+    can emit either depending on how the output stream is buffered.
+    """
+    separator = "\r\n\r\n" if "\r\n\r\n" in stdout else "\n\n"
+    parts = stdout.split(separator, 1)
+    if len(parts) < 2:
+        return None
+    try:
+        body = json.loads(parts[1])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(body, dict):
+        return None
+    return body
+
+
+def fetch_issue_state_rest(repo: str, number: int) -> tuple[str, str | None]:
+    """Return (state, closed_at) for an issue via the REST API (#54).
+
+    Uses `gh api repos/<repo>/issues/<n>` so the call hits the REST `core`
+    rate-limit bucket (5000/hr) instead of the `graphql` bucket. For batch
+    state checks (archive-plan.py scanning many plans, dependency-graph.py
+    open-state filters), this removes the calls from GraphQL pressure
+    entirely.
+
+    Adds ETag/conditional GET on top (#147): when caching is enabled the
+    first call captures the response ETag, and subsequent calls send
+    `If-None-Match` so a 304 short-circuits to the cached body without
+    consuming REST `core`. `JARED_NO_CACHE=1` bypasses the ETag layer and
+    falls back to the unconditional `gh api` flow.
+    """
+    if os.environ.get("JARED_NO_CACHE") == "1":
+        try:
+            data = run_gh(["api", f"repos/{repo}/issues/{number}"])
+        except GhInvocationError:
+            return "UNKNOWN", None
+        return _parse_issue_state_payload(data)
+
+    data = _fetch_issue_rest_with_etag(repo, number)
+    if data is None:
+        return "UNKNOWN", None
+    return _parse_issue_state_payload(data)
 
 
 def _child_env() -> dict[str, str]:

--- a/skills/jared/scripts/lib/cache.py
+++ b/skills/jared/scripts/lib/cache.py
@@ -84,3 +84,57 @@ def get_item_list(
     if time.time() - fetched_at > ttl_seconds:
         return None
     return items
+
+
+def _etag_cache_path(
+    repo: str,
+    number: int,
+    cache_dir: Path | None = None,
+) -> Path:
+    base = cache_dir if cache_dir is not None else _default_cache_dir()
+    return base / "etags" / repo / f"{number}.json"
+
+
+def get_issue_etag(
+    repo: str,
+    number: int,
+    *,
+    cache_dir: Path | None = None,
+) -> tuple[str, dict[str, Any]] | None:
+    """Return (etag, body) for a cached REST issue response, or None.
+
+    Companion to `fetch_issue_state_rest`'s conditional-GET layer (#147).
+    Stores etag and body together in one JSON file so a reader can never
+    observe a stale-etag/fresh-body pair — `os.replace` is the single
+    atomicity boundary, matching `set_item_list`'s pattern. Returns None
+    when the file is missing, malformed, or the body isn't a dict.
+    """
+    path = _etag_cache_path(repo, number, cache_dir)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    etag = payload.get("etag")
+    body = payload.get("body")
+    if not isinstance(etag, str) or not etag or not isinstance(body, dict):
+        return None
+    return etag, body
+
+
+def set_issue_etag(
+    repo: str,
+    number: int,
+    *,
+    etag: str,
+    body: dict[str, Any],
+    cache_dir: Path | None = None,
+) -> None:
+    """Atomically write the (ETag, JSON body) pair for a REST issue response."""
+    path = _etag_cache_path(repo, number, cache_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"etag": etag, "body": body}
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, path)

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -28,6 +28,7 @@ def _merged_pr_json(closed_at: str) -> str:
         f'"pull_request": {{"merged_at": "{closed_at}"}}}}'
     )
 
+
 REPO_ROOT = Path(__file__).parents[1]
 SCRIPT_PATH = REPO_ROOT / "skills" / "jared" / "scripts" / "archive-plan.py"
 
@@ -42,6 +43,15 @@ def _import_archive_plan() -> ModuleType:
 
 
 ap = _import_archive_plan()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_etag_layer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`patch_gh_by_arg` returns raw JSON bodies, not HTTP-formatted responses.
+    Bypass the ETag/conditional-GET layer (#147) so `fetch_issue_state_rest`
+    goes through the unconditional REST path that parses those bodies directly.
+    """
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
 
 
 def _write_plan(tmp_path: Path, filename: str, refs: list[int]) -> Path:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -57,6 +57,73 @@ def test_different_projects_use_separate_cache_files(tmp_path: Path) -> None:
     assert cache.get_item_list(project_number=5, cache_dir=tmp_path) == [{"b": 2}]
 
 
+def test_issue_etag_set_then_get_round_trips(tmp_path: Path) -> None:
+    cache.set_issue_etag(
+        "brockamer/jared",
+        52,
+        etag='W/"abc123"',
+        body={"state": "closed", "number": 52},
+        cache_dir=tmp_path,
+    )
+    result = cache.get_issue_etag("brockamer/jared", 52, cache_dir=tmp_path)
+    assert result == ('W/"abc123"', {"state": "closed", "number": 52})
+
+
+def test_issue_etag_returns_none_when_absent(tmp_path: Path) -> None:
+    assert cache.get_issue_etag("brockamer/jared", 99, cache_dir=tmp_path) is None
+
+
+def test_issue_etag_handles_repo_with_slash_in_path(tmp_path: Path) -> None:
+    """The repo name 'owner/name' must produce a nested directory, not a literal slash."""
+    cache.set_issue_etag(
+        "brockamer/jared",
+        52,
+        etag='"abc"',
+        body={"state": "open"},
+        cache_dir=tmp_path,
+    )
+    expected = tmp_path / "etags" / "brockamer" / "jared" / "52.json"
+    assert expected.exists()
+
+
+def test_issue_etag_returns_none_on_corrupted_json(tmp_path: Path) -> None:
+    path = tmp_path / "etags" / "brockamer" / "jared" / "52.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not valid")
+    assert cache.get_issue_etag("brockamer/jared", 52, cache_dir=tmp_path) is None
+
+
+def test_issue_etag_returns_none_when_etag_missing(tmp_path: Path) -> None:
+    """A payload missing the 'etag' field must not resolve to a stale hit."""
+    import json as _json
+
+    path = tmp_path / "etags" / "brockamer" / "jared" / "52.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(_json.dumps({"body": {"state": "open"}}))
+    assert cache.get_issue_etag("brockamer/jared", 52, cache_dir=tmp_path) is None
+
+
+def test_issue_etag_different_issues_use_separate_files(tmp_path: Path) -> None:
+    cache.set_issue_etag(
+        "brockamer/jared",
+        52,
+        etag='"a"',
+        body={"n": 52},
+        cache_dir=tmp_path,
+    )
+    cache.set_issue_etag(
+        "brockamer/jared",
+        53,
+        etag='"b"',
+        body={"n": 53},
+        cache_dir=tmp_path,
+    )
+    a = cache.get_issue_etag("brockamer/jared", 52, cache_dir=tmp_path)
+    b = cache.get_issue_etag("brockamer/jared", 53, cache_dir=tmp_path)
+    assert a == ('"a"', {"n": 52})
+    assert b == ('"b"', {"n": 53})
+
+
 def _minimal_board(tmp_path: Path) -> Path:
     p = tmp_path / "docs" / "project-board.md"
     p.parent.mkdir(parents=True)

--- a/tests/test_issue_state_etag.py
+++ b/tests/test_issue_state_etag.py
@@ -1,0 +1,285 @@
+"""Tests for the ETag/conditional GET layer on fetch_issue_state_rest (#147).
+
+The ETag layer wraps `fetch_issue_state_rest`:
+  - First call: `gh api -i` returns 200 with headers + body. The wrapper
+    captures the ETag and writes both etag + body to disk.
+  - Second call: sends `If-None-Match: <etag>` and gets 304 (exit 1, no
+    body). The wrapper recognizes 304 and returns the cached body.
+  - JARED_NO_CACHE=1 falls back to the unconditional REST path tested
+    elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from skills.jared.scripts.lib import cache
+
+
+def _make_200_response(etag: str, body_json: str) -> str:
+    """Build a `gh api -i` 200 response: status line, headers, blank, body."""
+    return (
+        "HTTP/2.0 200 OK\r\n"
+        "Content-Type: application/json; charset=utf-8\r\n"
+        f"Etag: {etag}\r\n"
+        "\r\n"
+        f"{body_json}"
+    )
+
+
+def _make_304_response(etag: str) -> tuple[str, str, int]:
+    """Build a `gh api -i` 304 response shape (stdout, stderr, returncode).
+
+    Mirrors the empirical shape verified against `gh api -i repos/cli/cli/issues/1
+    -H 'If-None-Match: ...'`: stdout has headers only (no body), stderr is
+    `gh: HTTP 304`, exit code is 1.
+    """
+    stdout = f"HTTP/2.0 304 Not Modified\r\nEtag: {etag}\r\n\r\n"
+    return stdout, "gh: HTTP 304", 1
+
+
+def test_first_call_with_empty_cache_sends_no_conditional_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cache miss path: no If-None-Match header in the gh args."""
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = _make_200_response('W/"abc123"', '{"state": "open"}')
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: Any) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    state, _closed_at = board.fetch_issue_state_rest("brockamer/jared", 52)
+    assert state == "OPEN"
+    assert len(captured) == 1
+    args = captured[0]
+    assert args[:3] == ["gh", "api", "-i"]
+    assert "If-None-Match:" not in " ".join(args)
+
+
+def test_first_call_writes_etag_and_body_to_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful 200 response must populate the on-disk ETag cache."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stdout = _make_200_response(
+            'W/"abc123"', '{"state": "closed", "closed_at": "2026-05-16T10:00:00Z"}'
+        )
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    state, closed_at = board.fetch_issue_state_rest("brockamer/jared", 52)
+    assert state == "CLOSED"
+    assert closed_at == "2026-05-16T10:00:00Z"
+
+    cache_dir = Path(os.environ["JARED_CACHE_DIR"])
+    cached = cache.get_issue_etag("brockamer/jared", 52, cache_dir=cache_dir)
+    assert cached is not None
+    etag, body = cached
+    assert etag == 'W/"abc123"'
+    assert body["state"] == "closed"
+    assert body["closed_at"] == "2026-05-16T10:00:00Z"
+
+
+def test_second_call_sends_conditional_header_and_uses_cached_body_on_304(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With a cached ETag, the wrapper sends If-None-Match and returns cached body on 304."""
+    from skills.jared.scripts.lib import board
+
+    cache_dir = Path(os.environ["JARED_CACHE_DIR"])
+    cache.set_issue_etag(
+        "brockamer/jared",
+        52,
+        etag='W/"abc123"',
+        body={
+            "state": "closed",
+            "closed_at": "2026-05-16T10:00:00Z",
+            "pull_request": None,
+        },
+        cache_dir=cache_dir,
+    )
+
+    captured: list[list[str]] = []
+    stdout_304, stderr_304, rc_304 = _make_304_response('"abc123"')
+
+    class FakeResult:
+        returncode = rc_304
+        stdout = stdout_304
+        stderr = stderr_304
+
+    def fake_run(args: list[str], **kw: Any) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    state, closed_at = board.fetch_issue_state_rest("brockamer/jared", 52)
+    assert state == "CLOSED"
+    assert closed_at == "2026-05-16T10:00:00Z"
+
+    args = captured[0]
+    assert "-H" in args
+    h_idx = args.index("-H")
+    assert args[h_idx + 1] == 'If-None-Match: W/"abc123"'
+
+
+def test_304_with_pull_request_merged_at_returns_merged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cached body must round-trip through _parse_issue_state_payload so
+    merged PRs keep reporting as MERGED even when served from the 304 path."""
+    from skills.jared.scripts.lib import board
+
+    cache_dir = Path(os.environ["JARED_CACHE_DIR"])
+    cache.set_issue_etag(
+        "brockamer/jared",
+        415,
+        etag='W/"pr-merged"',
+        body={
+            "state": "closed",
+            "closed_at": "2026-05-02T15:30:00Z",
+            "pull_request": {"merged_at": "2026-05-02T15:30:00Z"},
+        },
+        cache_dir=cache_dir,
+    )
+
+    stdout_304, stderr_304, rc_304 = _make_304_response('"pr-merged"')
+
+    class FakeResult:
+        returncode = rc_304
+        stdout = stdout_304
+        stderr = stderr_304
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    state, _ = board.fetch_issue_state_rest("brockamer/jared", 415)
+    assert state == "MERGED"
+
+
+def test_no_cache_env_var_bypasses_etag_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARED_NO_CACHE=1 skips `-i` and conditional GET entirely."""
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = '{"state": "open"}'
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: Any) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    state, _ = board.fetch_issue_state_rest("brockamer/jared", 99)
+    assert state == "OPEN"
+    args = captured[0]
+    assert "-i" not in args
+    assert "If-None-Match:" not in " ".join(args)
+
+
+def test_gh_failure_without_http_status_returns_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Network failure / bad invocation surfaces UNKNOWN, not a crash."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: connection refused"
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    state, closed_at = board.fetch_issue_state_rest("brockamer/jared", 99999)
+    assert state == "UNKNOWN"
+    assert closed_at is None
+
+
+def test_304_with_no_cached_body_returns_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If gh returns 304 but the cache is empty (e.g. it was nuked between the
+    If-None-Match send and the response read), surface UNKNOWN rather than
+    a silent stale read."""
+    from skills.jared.scripts.lib import board
+
+    stdout_304, stderr_304, rc_304 = _make_304_response('"abc123"')
+
+    class FakeResult:
+        returncode = rc_304
+        stdout = stdout_304
+        stderr = stderr_304
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    state, _ = board.fetch_issue_state_rest("brockamer/jared", 52)
+    assert state == "UNKNOWN"
+
+
+def test_corrupt_cache_falls_through_to_fresh_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed cache file must be treated as a miss so a normal 200 fetch
+    repopulates it. The wrapper should not crash on parse errors."""
+    from skills.jared.scripts.lib import board
+
+    cache_dir = Path(os.environ["JARED_CACHE_DIR"])
+    path = cache_dir / "etags" / "brockamer" / "jared" / "52.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not valid json")
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = _make_200_response('W/"new"', '{"state": "open"}')
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: Any) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    state, _ = board.fetch_issue_state_rest("brockamer/jared", 52)
+    assert state == "OPEN"
+    assert "If-None-Match:" not in " ".join(captured[0])
+
+    cached = cache.get_issue_etag("brockamer/jared", 52, cache_dir=cache_dir)
+    assert cached is not None
+    assert cached[0] == 'W/"new"'

--- a/tests/test_issue_state_rest.py
+++ b/tests/test_issue_state_rest.py
@@ -1,4 +1,9 @@
-"""Tests for fetch_issue_state_rest — REST migration for per-issue state checks (#54)."""
+"""Tests for fetch_issue_state_rest — REST migration for per-issue state checks (#54).
+
+These tests cover the unconditional REST path with `JARED_NO_CACHE=1` set so
+the FakeResult fixtures return raw JSON bodies (no HTTP status line). The
+ETag/conditional GET layer (#147) is covered in test_issue_state_etag.py.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +15,7 @@ import pytest
 def test_fetch_issue_state_rest_returns_closed_with_closed_at(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
     from skills.jared.scripts.lib import board
 
     captured_args: list[list[str]] = []
@@ -35,6 +41,7 @@ def test_fetch_issue_state_rest_returns_closed_with_closed_at(
 
 
 def test_fetch_issue_state_rest_returns_open_with_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
     from skills.jared.scripts.lib import board
 
     class FakeResult:
@@ -58,6 +65,7 @@ def test_fetch_issue_state_rest_returns_merged_for_merged_pr(
     """REST returns state="closed" for merged PRs; the helper must surface
     the merged-vs-closed-unmerged distinction via `pull_request.merged_at`
     so archive-plan's `## Shipped` predicate (merged-only) keeps working."""
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
     from skills.jared.scripts.lib import board
 
     class FakeResult:
@@ -82,6 +90,7 @@ def test_fetch_issue_state_rest_returns_closed_for_unmerged_pr(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A PR that was closed without merging must NOT report as MERGED."""
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
     from skills.jared.scripts.lib import board
 
     class FakeResult:
@@ -104,6 +113,7 @@ def test_fetch_issue_state_rest_returns_closed_for_unmerged_pr(
 def test_fetch_issue_state_rest_returns_unknown_on_gh_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
     from skills.jared.scripts.lib import board
 
     class FakeResult:


### PR DESCRIPTION
## Summary

Wraps `fetch_issue_state_rest` (REST `core` bucket, post-#54) with an ETag/conditional GET layer: the first call captures the response ETag and writes it to disk; subsequent calls send `If-None-Match: <etag>` so a 304 short-circuits to the cached body without consuming the rate-limit bucket. `JARED_NO_CACHE=1` bypasses to the unconditional path.

Phase 2.b of #54, descoped during the perf-cohort PR per advisor recommendation. Pulls #147.

## Acceptance evidence

Direct empirical benchmark (15 recently-closed issues × 2 passes, fresh `JARED_CACHE_DIR`):

| Pass | core delta | meaning |
|------|-----------:|---------|
| Cold (cache empty) | 15 | one REST call per issue (baseline) |
| Warm (cache populated) | **0** | every call resolved to 304, rate-limit-free |

States match 15/15 between passes; 15 etag cache files written.

**Note on the substitution**: acceptance criterion #1 names `archive-plan.py --scan` against 12 plans. All plans in this repo are currently archived, so `--scan` is a no-op locally. The direct-call benchmark exercises the same `fetch_issue_state_rest` codepath and isolates the core-bucket signal, so the result is functionally equivalent.

## Design notes

- **Cache file shape deviates from #147 body**. The issue suggested two files (`<n>.etag` + `<n>.json`); this PR uses a single `<n>.json` carrying `{etag, body}`. Rationale: a single `os.replace` matches `set_item_list`'s atomic-rename pattern exactly and eliminates the torn-pair window that two separate `os.replace` calls would open.
- **gh-api-i exit-code-1-on-304 gotcha** (flagged in #147's empirical findings): the wrapper uses `subprocess.run` directly with `check=False`, then parses the HTTP status line from stdout (or stderr fallback) independent of returncode. The 304 test fixture mirrors the real shape including `returncode = 1`.
- **Activation discipline**: #147's body says "only pull when archive-plan/dependency-graph shows measurable REST core pressure." The technical condition (the saving is measurable and free when unused) is satisfied. Whether current usage warrants leaning on it remains the operator's call.

## Test plan

- [x] `pytest` — 388 passed, 1 deselected (integration), no regressions
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy --strict` — Success: no issues found in 42 source files
- [x] Real-world benchmark — 15 cold REST calls → 0 warm REST calls; states identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)