### PR TITLE
fix(stage): fetch milestones via GraphQL companion, restore proximity sort (#145)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -1007,6 +1007,50 @@ def fetch_blocked_by_edges(
     return result
 
 
+def fetch_milestone_map(
+    repo: str,
+    *,
+    cache: str | None = None,
+) -> dict[int, dict[str, Any]]:
+    """One paginated GraphQL call → `{issue_number: {"title", "due_on"}}` for all
+    open issues in `repo` that have a milestone set.
+
+    `gh project item-list` does not include milestone data; stage.py's
+    `_format_milestone` and `milestone_proximity_days` depend on this companion
+    fetch to populate the milestone field on each item. Mirrors
+    `fetch_blocked_by_edges`'s pagination pattern.
+
+    Issues with no milestone are omitted from the result; callers should treat
+    a missing key as "no milestone." The GraphQL `dueOn` field is normalised to
+    snake_case `due_on` at this boundary so stage.py's pure functions keep
+    their existing snake_case access pattern.
+    """
+    owner, name = repo.split("/", 1)
+    q = (
+        "query($o:String!,$r:String!,$c:String){repository(owner:$o,name:$r){"
+        "issues(first:100,after:$c,states:OPEN){pageInfo{hasNextPage endCursor}"
+        "nodes{number milestone{title dueOn}}}}}"
+    )
+    result: dict[int, dict[str, Any]] = {}
+    cursor: str | None = None
+    while True:
+        kwargs: dict[str, str] = {"o": owner, "r": name}
+        if cursor:
+            kwargs["c"] = cursor
+        data = run_graphql(q, cache=cache, **kwargs)["data"]["repository"]["issues"]
+        for node in data["nodes"]:
+            milestone = node.get("milestone")
+            if milestone:
+                result[node["number"]] = {
+                    "title": milestone.get("title"),
+                    "due_on": milestone.get("dueOn"),
+                }
+        if not data["pageInfo"]["hasNextPage"]:
+            break
+        cursor = data["pageInfo"]["endCursor"]
+    return result
+
+
 # ---------- Plan/spec issue-ref parsing ----------
 #
 # Shared between archive-plan.py and sweep.py so the two scripts can't

--- a/skills/jared/scripts/stage.py
+++ b/skills/jared/scripts/stage.py
@@ -32,6 +32,9 @@ from lib.board import Board  # type: ignore[import-not-found]  # noqa: E402
 from lib.board import (  # noqa: E402
     fetch_blocked_by_edges as _fetch_blocked_by_edges,
 )
+from lib.board import (  # noqa: E402
+    fetch_milestone_map as _fetch_milestone_map,
+)
 
 
 @dataclass(frozen=True)
@@ -212,8 +215,15 @@ def not_pullable_reason(item: dict[str, Any]) -> str:
 
 
 def _format_milestone(item: dict[str, Any], *, today: date) -> str:
-    milestone = item.get("milestone") or {}
-    if not isinstance(milestone, dict):
+    """Render an item's milestone for the stage output line.
+
+    Pre-#145 this function fell through to "(unknown) (no due date)" for items
+    without a milestone — the exact string that triggered the original bug
+    report. Now: None / empty-dict / non-dict all return "(no milestone)"
+    honestly. Title-only and full milestones render their respective shapes.
+    """
+    milestone = item.get("milestone")
+    if not isinstance(milestone, dict) or not milestone:
         return "(no milestone)"
     title = milestone.get("title") or "(unknown)"
     due_on = milestone.get("due_on")
@@ -370,8 +380,14 @@ def fetch_items_for_stage(board: Any) -> list[dict[str, Any]]:
     if not raw_items:
         return []
 
-    # One paginated GraphQL call → {issue_number: [{number, state}, …]}
+    # Two bulk GraphQL companion fetches — `gh project item-list` returns
+    # neither blocked-by edges nor milestones, so stage.py composes each item
+    # from three sources:
+    #   1. board.board_items() — Status, Priority, content basics (cached)
+    #   2. fetch_blocked_by_edges — issueDependencies graph (paginated)
+    #   3. fetch_milestone_map    — milestone {title, due_on} (paginated, #145)
     edges_map: dict[int, list[dict[str, Any]]] = _fetch_blocked_by_edges(board.repo)
+    milestone_map: dict[int, dict[str, Any]] = _fetch_milestone_map(board.repo)
 
     normalised: list[dict[str, Any]] = []
     for raw in raw_items:
@@ -388,7 +404,7 @@ def fetch_items_for_stage(board: Any) -> list[dict[str, Any]]:
                 "title": content.get("title", ""),
                 "body": content.get("body", ""),
                 "state": content.get("state", "OPEN"),
-                "milestone": content.get("milestone"),
+                "milestone": milestone_map.get(number),
                 "createdAt": content.get("createdAt") or content.get("created_at"),
                 "blocked_by_native": blocked_by_native,
             }

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -838,6 +838,134 @@ def test_fetch_blocked_by_edges_passes_cache_flag(monkeypatch: pytest.MonkeyPatc
     assert "--cache" in captured[0] and "60s" in captured[0]
 
 
+def test_fetch_milestone_map_single_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One paginated GraphQL call → {number: {title, due_on}} with dueOn normalised."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"data": {"repository": {"issues": {'
+            '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+            '"nodes": ['
+            '{"number": 10, "milestone": {"title": "Phase 2", "dueOn": "2026-05-31T00:00:00Z"}},'
+            '{"number": 11, "milestone": {"title": "v1.0", "dueOn": "2026-07-01T00:00:00Z"}},'
+            '{"number": 12, "milestone": null}'
+            "]}}}}"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    milestones = board.fetch_milestone_map("brockamer/jared")
+    # Issues with milestones present, normalised to snake_case due_on
+    assert milestones == {
+        10: {"title": "Phase 2", "due_on": "2026-05-31T00:00:00Z"},
+        11: {"title": "v1.0", "due_on": "2026-07-01T00:00:00Z"},
+    }
+    # Issue #12 (no milestone) is omitted from the result
+    assert 12 not in milestones
+
+
+def test_fetch_milestone_map_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Helper walks pageInfo.hasNextPage; merges all pages into a single map."""
+    from skills.jared.scripts.lib import board
+
+    page_responses = iter(
+        [
+            (
+                '{"data": {"repository": {"issues": {'
+                '"pageInfo": {"hasNextPage": true, "endCursor": "CUR1"},'
+                '"nodes": [{"number": 1, "milestone": '
+                '{"title": "M1", "dueOn": "2026-06-01T00:00:00Z"}}]'
+                "}}}}"
+            ),
+            (
+                '{"data": {"repository": {"issues": {'
+                '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+                '"nodes": [{"number": 2, "milestone": '
+                '{"title": "M2", "dueOn": "2026-07-01T00:00:00Z"}}]'
+                "}}}}"
+            ),
+        ]
+    )
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stderr = ""
+
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult(next(page_responses))
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    milestones = board.fetch_milestone_map("brockamer/jared")
+    assert set(milestones) == {1, 2}
+    assert milestones[1]["due_on"] == "2026-06-01T00:00:00Z"
+    assert milestones[2]["title"] == "M2"
+    # Two paginated calls, second one carries the cursor.
+    assert len(captured) == 2
+    assert any("c=CUR1" in arg for arg in captured[1])
+
+
+def test_fetch_milestone_map_passes_cache_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cache='60s' threads through to the underlying gh api invocation."""
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"data": {"repository": {"issues": {'
+            '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+            '"nodes": []}}}}'
+        )
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    board.fetch_milestone_map("brockamer/jared", cache="60s")
+    assert "--cache" in captured[0] and "60s" in captured[0]
+
+
+def test_fetch_milestone_map_handles_missing_due_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A milestone with no dueOn yields due_on=None, not omission."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stdout = (
+            '{"data": {"repository": {"issues": {'
+            '"pageInfo": {"hasNextPage": false, "endCursor": null},'
+            '"nodes": ['
+            '{"number": 20, "milestone": {"title": "Unscheduled", "dueOn": null}}'
+            "]}}}}"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    milestones = board.fetch_milestone_map("brockamer/jared")
+    assert milestones == {20: {"title": "Unscheduled", "due_on": None}}
+
+
 def test_fetch_recent_comments_batch_single_call(monkeypatch: pytest.MonkeyPatch) -> None:
     """One aliased GraphQL call covers many issues; returns {number: [comments]}."""
     from skills.jared.scripts.lib import board

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -396,6 +396,37 @@ class TestRankingHelpers:
         days = stage.days_in_backlog(item, today=date.today())
         assert 13 <= days <= 15  # allow 1d slack for test timing
 
+    def test_format_milestone_renders_title_and_due_date(self) -> None:
+        """#145: with a populated milestone, render `<title> (due YYYY-MM-DD, Nd)`."""
+        stage = import_stage()
+        item = {
+            "milestone": {
+                "title": "Phase 2 — perf settled",
+                "due_on": "2026-05-31T00:00:00Z",
+            }
+        }
+        result = stage._format_milestone(item, today=date(2026, 5, 16))
+        assert result == "Phase 2 — perf settled (due 2026-05-31, 15d)"
+
+    def test_format_milestone_no_milestone_returns_placeholder(self) -> None:
+        stage = import_stage()
+        result = stage._format_milestone({}, today=date(2026, 5, 16))
+        assert result == "(no milestone)"
+
+    def test_format_milestone_missing_due_on(self) -> None:
+        """Title-only milestone (no due_on) renders title plus '(no due date)'."""
+        stage = import_stage()
+        item = {"milestone": {"title": "Unscheduled"}}
+        result = stage._format_milestone(item, today=date(2026, 5, 16))
+        assert result == "Unscheduled (no due date)"
+
+    def test_format_milestone_missing_title(self) -> None:
+        """Due_on-only milestone (no title) falls through to (unknown)."""
+        stage = import_stage()
+        item = {"milestone": {"due_on": "2026-05-31T00:00:00Z"}}
+        result = stage._format_milestone(item, today=date(2026, 5, 16))
+        assert result == "(unknown) (due 2026-05-31, 15d)"
+
 
 class TestDeferredReason:
     def test_low_tier_reason(self) -> None:
@@ -593,6 +624,13 @@ class TestFetchItemsForStage:
     def test_returns_items_with_status_priority_body_milestone(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
+        """Milestone arrives via fetch_milestone_map, not gh project item-list.
+
+        Earlier versions of this test placed `milestone` inside `content` — a
+        contract `gh project item-list --format json` does not honour (see #145).
+        The fix routes milestone through a dedicated GraphQL companion fetch;
+        the test must mock that contract, not the wrong one.
+        """
         write_minimal_board(tmp_path)
         monkeypatch.chdir(tmp_path)
 
@@ -605,10 +643,6 @@ class TestFetchItemsForStage:
                             "title": "Test",
                             "body": "Summary.",
                             "state": "OPEN",
-                            "milestone": {
-                                "title": "M1",
-                                "due_on": "2026-07-01T00:00:00Z",
-                            },
                             "createdAt": "2026-05-01T00:00:00Z",
                         },
                         "status": "Backlog",
@@ -617,8 +651,7 @@ class TestFetchItemsForStage:
                 ]
             }
         )
-        # fetch_blocked_by_edges uses run_graphql → "api graphql …"
-        # Return empty edges (no open blockers for issue #1).
+        # fetch_blocked_by_edges → empty (no open blockers for issue #1).
         edges_json = json.dumps(
             {
                 "data": {
@@ -631,9 +664,36 @@ class TestFetchItemsForStage:
                 }
             }
         )
+        # fetch_milestone_map → issue #1 has milestone "M1", dueOn 2026-07-01.
+        milestone_json = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "issues": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [
+                                {
+                                    "number": 1,
+                                    "milestone": {
+                                        "title": "M1",
+                                        "dueOn": "2026-07-01T00:00:00Z",
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        )
+        # The two GraphQL calls are discriminated by query content — blockedBy
+        # vs milestone{ — so patch_gh_by_arg can route them distinctly.
         patch_gh_by_arg(
             monkeypatch,
-            responses={"item-list": items_json, "graphql": edges_json},
+            responses={
+                "item-list": items_json,
+                "blockedBy": edges_json,
+                "milestone{": milestone_json,
+            },
         )
 
         stage = import_stage()
@@ -649,7 +709,63 @@ class TestFetchItemsForStage:
         assert items[0]["body"] == "Summary."
         assert items[0]["milestone"] is not None
         assert items[0]["milestone"]["title"] == "M1"
+        # dueOn was normalised to snake_case due_on at the lib/board.py boundary.
+        assert items[0]["milestone"]["due_on"] == "2026-07-01T00:00:00Z"
         assert items[0]["blocked_by_native"] == []
+
+    def test_items_with_no_milestone_have_milestone_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Issues absent from the milestone-map get milestone=None on the item."""
+        write_minimal_board(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        items_json = json.dumps(
+            {
+                "items": [
+                    {
+                        "content": {
+                            "number": 2,
+                            "title": "Unmilestoned",
+                            "body": "Summary.",
+                            "state": "OPEN",
+                            "createdAt": "2026-05-01T00:00:00Z",
+                        },
+                        "status": "Backlog",
+                        "priority": "Low",
+                    },
+                ]
+            }
+        )
+        empty_graphql = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "issues": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [],
+                        }
+                    }
+                }
+            }
+        )
+        patch_gh_by_arg(
+            monkeypatch,
+            responses={
+                "item-list": items_json,
+                "blockedBy": empty_graphql,
+                "milestone{": empty_graphql,
+            },
+        )
+
+        stage = import_stage()
+        from skills.jared.scripts.lib.board import Board
+
+        board = Board.from_path(tmp_path / "docs" / "project-board.md")
+        items = stage.fetch_items_for_stage(board)
+
+        assert len(items) == 1
+        assert items[0]["milestone"] is None
 
 
 class TestMain:


### PR DESCRIPTION
## Summary

Closes #145.

- **Root cause was misdiagnosed in the original filing.** The issue body hypothesised a snake_case vs camelCase key-access bug in `_format_milestone`. Empirical testing at session start showed that hypothesis is wrong — `gh project item-list --format json` doesn't include a `milestone` field at all (keys are exactly `body, number, repository, title, type, url`). The data never reaches stage.py via that path.
- **Both `_format_milestone` and `milestone_proximity_days` were affected.** The former always rendered `"(unknown) (no due date)"`; the latter always returned `math.inf`, silently disabling the milestone-proximity tier in `rank_key`. The sort tier was effectively dead code since these helpers were introduced.
- **Fix mirrors `fetch_blocked_by_edges`.** New `fetch_milestone_map(repo)` in `lib/board.py` does one paginated GraphQL pass over open issues, returning `{issue_number: {title, due_on}}` with `dueOn` normalised to snake_case at the boundary. Wired into `fetch_items_for_stage` alongside the existing blocked-by fetch.
- **Two observable changes from one root cause:** (a) milestoned items render correctly as `"<title> (due YYYY-MM-DD, Nd)"`; (b) non-milestoned items render `"(no milestone)"` instead of the misleading `"(unknown) (no due date)"` fallback. Both shipped together — the formatter's null-case fix is necessary, or the original bug's exact symptom string still appears for empty-milestone rows.
- **Behaviour change worth flagging:** the milestone-proximity sort tier becomes functional. Within a priority band, milestoned items now sort before non-milestoned. Next `/jared-stage` runs' ordering may differ — especially for the v1.0-milestoned cluster (#76, #110, #111, #138, #140). This is the explicitly-requested behaviour.

#145's body has been updated mid-session to reflect the corrected diagnosis so future readers don't trace the original wrong hypothesis.

## Test plan

- [x] `pytest` — 397 passed (4 new, all green)
- [x] `ruff check .` && `ruff format --check .` — clean
- [x] `mypy` — strict, no issues found in 42 source files
- [x] **End-to-end verification:** ran `fetch_milestone_map("brockamer/jared")` against live API, confirmed 6 open milestoned issues fetch correctly with normalised `due_on`. Ran through `fetch_items_for_stage` + `_format_milestone` for each — milestoned items render as `"v1.0 — public install (due 2026-07-01, 46d)"`; unmilestoned render as `"(no milestone)"`.
- [x] **Fixed wrong-contract test:** `test_returns_items_with_status_priority_body_milestone` previously placed `milestone` inside `content` — a shape `gh project item-list` doesn't honour. Rewritten to mock the new GraphQL companion call; added a `test_items_with_no_milestone_have_milestone_none` case.

**Caveat:** end-to-end verification used direct `_format_milestone` invocation rather than a full `render()` Promote path, because no Backlog item was pullable at verify-time. The render path is a one-line passthrough (`stage.py:254`), so the formatter coverage is equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)