### PR TITLE
enhancement(stage): suppress epic-labeled parents from Deferred noise (#146)

### DIFF
--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -90,6 +90,7 @@ Suggested defaults (create via `gh label create` as needed):
 | `enhancement` | New capability |
 | `refactor` | Restructuring without behavior change |
 | `documentation` | Docs-only change |
+| `epic` | Durably parent-shaped — roadmap, checklist, strategic anchor. Lacks acceptance criteria by design; stays in Backlog as a long-horizon container. `/jared-stage` exempts these from "Deferred (this pass)" noise. |
 
 **Do not** create a `blocked` label. Blocked is a Status column on this board, not a label — see Status above.
 

--- a/skills/jared/scripts/stage.py
+++ b/skills/jared/scripts/stage.py
@@ -162,6 +162,22 @@ def deferred_reason(item: dict[str, Any], *, today: date) -> str:
     return "ranked below slot cap"
 
 
+def is_epic(item: dict[str, Any]) -> bool:
+    """True if the item carries the `epic` label.
+
+    Epic-labeled issues are durably parent-shaped — roadmaps, checklists,
+    strategic anchors. They legitimately lack acceptance criteria and exist
+    on Backlog as long-horizon containers, so /jared-stage exempts them from
+    the "Deferred (this pass)" surface (#146). See docs/project-board.md
+    `## Labels` for the convention.
+
+    `labels` arrives from gh project item-list as a plain list of strings
+    (top-level on the raw item; plumbed through fetch_items_for_stage).
+    """
+    labels = item.get("labels") or []
+    return "epic" in labels
+
+
 def is_pullable(item: dict[str, Any]) -> bool:
     """An item is pullable if its body has a real summary + non-placeholder
     acceptance criteria. See spec § "Filter semantics"."""
@@ -327,6 +343,10 @@ def stage_proposals(
     pullable = [i for i in backlog if is_pullable(i)]
     not_pullable = [i for i in backlog if not is_pullable(i)]
     for item in not_pullable:
+        if is_epic(item):
+            # #146: epics are durably parent-shaped and stay in Backlog by
+            # design; surfacing them as "deferred" every pass is noise.
+            continue
         deferred.append(DeferredItem(item, not_pullable_reason(item)))
 
     dep_ready = [i for i in pullable if has_no_open_blockers(i, items)]
@@ -407,6 +427,7 @@ def fetch_items_for_stage(board: Any) -> list[dict[str, Any]]:
                 "milestone": milestone_map.get(number),
                 "createdAt": content.get("createdAt") or content.get("created_at"),
                 "blocked_by_native": blocked_by_native,
+                "labels": raw.get("labels") or [],
             }
         )
     return normalised

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -457,6 +457,7 @@ def _item(
     state: str = "OPEN",
     created_days_ago: int = 7,
     blocked_by_native: list[int] | None = None,
+    labels: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build a stub item dict for stage_proposals tests."""
     default_body = (
@@ -477,7 +478,36 @@ def _item(
         "state": state,
         "createdAt": datetime.fromtimestamp(created, tz=UTC).isoformat(),
         "blocked_by_native": blocked_by_native or [],
+        "labels": labels or [],
     }
+
+
+class TestIsEpic:
+    """#146: items with the `epic` label are durably parent-shaped — exempt
+    from the not-pullable → Deferred surfacing."""
+
+    def test_epic_labeled_item_is_epic(self) -> None:
+        stage = import_stage()
+        assert stage.is_epic({"labels": ["epic"]}) is True
+
+    def test_epic_label_alongside_others(self) -> None:
+        stage = import_stage()
+        assert stage.is_epic({"labels": ["documentation", "epic"]}) is True
+
+    def test_non_epic_labels_are_not_epic(self) -> None:
+        stage = import_stage()
+        assert stage.is_epic({"labels": ["enhancement"]}) is False
+        assert stage.is_epic({"labels": ["bug"]}) is False
+
+    def test_no_labels_is_not_epic(self) -> None:
+        stage = import_stage()
+        assert stage.is_epic({}) is False
+        assert stage.is_epic({"labels": []}) is False
+
+    def test_labels_none_is_not_epic(self) -> None:
+        """Defensive: labels=None (e.g., absent from upstream) shouldn't crash."""
+        stage = import_stage()
+        assert stage.is_epic({"labels": None}) is False
 
 
 class TestStageProposals:
@@ -538,6 +568,52 @@ class TestStageProposals:
         assert len(result.deferred) == 1
         assert result.deferred[0].item["number"] == 1
         assert result.deferred[0].reason == "not pullable — no acceptance section"
+
+    def test_epic_labeled_unpullable_item_is_not_deferred(self) -> None:
+        """#146: epic-labeled items legitimately lack acceptance criteria.
+
+        They're durably parent-shaped (roadmaps, checklists, strategic
+        anchors). The Deferred section should suppress them rather than
+        re-reporting the same noise on every pass.
+        """
+        stage = import_stage()
+        items = [
+            _item(
+                number=1,
+                body="Roadmap parent issue.\n\n## Decisions\n\n(none)\n",  # no AC
+                labels=["epic"],
+            ),
+        ]
+        result = stage.stage_proposals(items, up_next_cap=3, today=date.today())
+        assert result.deferred == []
+
+    def test_epic_filter_doesnt_affect_pullable_items(self) -> None:
+        """An epic-labeled item that happens to have AC still routes normally.
+
+        We don't block promotion of epics with AC — the filter only suppresses
+        them from the Deferred noise. If someone reshapes an epic into a
+        pullable work unit, that's intentional and shouldn't be hidden.
+        """
+        stage = import_stage()
+        items = [_item(number=1, priority="High", labels=["epic"])]
+        result = stage.stage_proposals(items, up_next_cap=3, today=date.today())
+        # Epic-labeled and pullable: still promoted normally.
+        assert [p["number"] for p in result.promotions] == [1]
+        assert result.deferred == []
+
+    def test_non_epic_unpullable_item_still_deferred(self) -> None:
+        """Regression guard: the epic filter must not over-fire on plain labels."""
+        stage = import_stage()
+        items = [
+            _item(
+                number=1,
+                body="Real summary.\n\n## Decisions\n\n(none)\n",
+                labels=["enhancement"],  # NOT an epic
+            ),
+        ]
+        result = stage.stage_proposals(items, up_next_cap=3, today=date.today())
+        assert len(result.deferred) == 1
+        assert result.deferred[0].item["number"] == 1
 
     def test_blocked_item_with_closed_blocker_returns_to_backlog(self) -> None:
         stage = import_stage()


### PR DESCRIPTION
## Summary

Closes #146.

`/jared-stage`'s "Deferred (this pass)" section was re-reporting the same three parent issues every run — #76 (Jared roadmap), #110 (v1.0 readiness checklist), #111 (v1.0 showcase question). These legitimately lack acceptance criteria — they're long-horizon strategic anchors, not pullable work units. Conflating them with reshape-eligible items buried genuine reshape candidates in epic noise.

**Discriminator:** `epic` label. Created in the repo (`gh label create epic --color 5319e7`); documented in `docs/project-board.md ## Labels`. Future migration to GitHub's native issue-type taxonomy stays open per the issue body's "likely answer."

**Render policy:** skip entirely. Epic-labeled items skip the `not_pullable` → `deferred` path; never appear in the rendered output. Operators wanting the list can run `gh issue list --label epic`.

**Plumbing:** `labels` is plumbed through `fetch_items_for_stage` via `raw.get("labels")` — top-level on each `gh project item-list` raw item, parallel to `content`/`status`/`priority`/`milestone`. No companion fetch needed.

**Discovery during this session:** while implementing this, I noticed `milestone` is also top-level on raw items — which means the #145 / PR #152 `fetch_milestone_map` GraphQL companion fetch was unnecessary. Filed as #153 for follow-up rather than expanding this PR's scope.

**Applied in same session:** #76, #110, #111 labeled with `epic`. Verified end-to-end — the Deferred section is now absent from `stage.py` output.

## Test plan

- [x] `pytest` — 405 passed (8 new, all green)
- [x] `ruff check .` && `ruff format --check .` — clean
- [x] `mypy` — strict, no issues found in 42 source files
- [x] **End-to-end verification:** ran `JARED_NO_CACHE=1 stage.py --report-only`; Deferred section absent (previously had 3 parent-issue rows). Promote, Almost-ready, and Blocked-revisit sections continue rendering normally.
- [x] **Coverage:**
  - `TestIsEpic`: 5 tests covering label-present, alongside-others, non-epic-labels, no-labels, labels=None defensive
  - `TestStageProposals`: 3 new — epic-labeled non-pullable suppressed, epic-labeled pullable still promotes, non-epic non-pullable still deferred (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)