### PR TITLE
docs(workflows): document recommended Projects v2 workflow settings (#156)

### DIFF
--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -97,6 +97,25 @@ Suggested defaults (create via `gh label create` as needed):
 Project-specific scope labels (e.g., `infra`, `frontend`, `customer-facing`) belong here
 too — add them as needed.
 
+## Project workflows — recommended settings
+
+GitHub Projects v2 ships several auto-status workflows. Most are useful with
+Jared's discipline, but **"Pull request linked to issue" must be disabled** on
+a Jared-stewarded board.
+
+| Workflow | Recommended | Why |
+|---|---|---|
+| `Item added to project` | off | `jared file` sets Status explicitly. |
+| `Item closed` | on | Auto-moves Done when an item is closed. |
+| `Pull request linked to issue` | **off** | Sets Status=`In Progress` whenever a PR is linked — including retroactively when a *later* PR's commit body contains `closes #N` / `fixes #N` in prose. Reverts the Status that `jared close` just set. See #156. |
+| `Pull request merged` | on | Sets Status=Done on closing PR merge. |
+| `Auto-close issue` | on | Closes the issue when its PR merges. |
+| `Auto-add sub-issues to project` | on | Convenience. |
+
+To inspect or toggle workflows: open the project's *Workflows* tab in the GitHub UI, or use the GraphQL `deleteProjectV2Workflow` mutation (irreversible via API; re-create from the UI).
+
+**Discipline reminder:** when describing past PRs in commit bodies, avoid the closing keywords `closes #N` / `fixes #N` / `resolves #N` in narrative prose — GitHub's auto-link parser doesn't distinguish parentheticals from directives. Refer to past PRs by number alone (`PR #152`) or paraphrase (`addressed in #152`). Reserve closing keywords for the current PR's own intent, on a dedicated line.
+
 ## Triage checklist — new issue
 
 When a new issue is filed:

--- a/skills/jared/assets/project-board.md.template
+++ b/skills/jared/assets/project-board.md.template
@@ -58,6 +58,23 @@ Defaults:
 | `documentation` | Docs-only change |
 | `blocked` | Waiting on a dependency (must pair with `## Blocked by` in body) |
 
+## Project workflows — recommended settings
+
+GitHub Projects v2 ships several auto-status workflows. Most are useful with Jared's discipline, but **"Pull request linked to issue" must be disabled** on a Jared-stewarded board.
+
+| Workflow | Recommended | Why |
+|---|---|---|
+| `Item added to project` | off | `jared file` sets Status explicitly. |
+| `Item closed` | on | Auto-moves Done when an item is closed. |
+| `Pull request linked to issue` | **off** | Sets Status=`In Progress` whenever a PR is linked — including retroactively when a *later* PR's commit body contains `closes #N` / `fixes #N` in prose. Reverts the Status that `jared close` just set. |
+| `Pull request merged` | on | Sets Status=Done on closing PR merge. |
+| `Auto-close issue` | on | Closes the issue when its PR merges. |
+| `Auto-add sub-issues to project` | on | Convenience. |
+
+To inspect or toggle workflows: open the project's *Workflows* tab in the GitHub UI, or use the GraphQL `deleteProjectV2Workflow` mutation (irreversible via API; re-create from the UI).
+
+**Discipline reminder:** when describing past PRs in commit bodies, avoid the closing keywords `closes #N` / `fixes #N` / `resolves #N` in narrative prose — GitHub's auto-link parser doesn't distinguish parentheticals from directives. Refer to past PRs by number alone (`PR #152`) or paraphrase (`addressed in #152`). Reserve closing keywords for the current PR's own intent, on a dedicated line.
+
 ## Triage — new issue
 
 1. **Auto-add to board.** `gh issue create` does not auto-add; use `gh project item-add <N> --owner <OWNER> --url <URL>`.


### PR DESCRIPTION
## Summary

Resolves #156 (pending the operator's workflow toggle).

The Projects v2 "Pull request linked to issue" workflow sets Status=`In Progress` whenever a PR is *linked* to an issue — including retroactively, when a *later* PR's commit body mentions a closing keyword for an already-closed issue. This caused #145's project Status to revert from `Done` to `In Progress` hours after `jared close 145` had set it correctly.

The root cause: PR #155's commit body included the parenthetical prose `PR #152 (closes #145) shipped a paginated GraphQL companion fetch…` describing #152's behavior. GitHub's auto-link parser treated `closes #145` as a directive, retroactively linked PR #155 to #145, fired the workflow, and reverted the Status.

Per session discussion, the fix is **at the source** — disable the workflow rather than guard against it in Python. Justifications:
- `/jared-start` already sets Status=In Progress explicitly when work begins.
- The doctrine-first memory pushes against Python guards for a problem most cleanly solved at the source.
- Documentation alone wouldn't prevent recurrence; disabling removes the failure mode entirely.

## What this PR changes

- **`docs/project-board.md`** — adds a `## Project workflows — recommended settings` table documenting which of the six Projects v2 workflows should be on/off on a Jared-stewarded board, with the rationale for each. Includes a commit-body keyword hygiene reminder.
- **`skills/jared/assets/project-board.md.template`** — same section in the bootstrap template so new Jared-stewarded boards inherit the discipline.

## What this PR does NOT change

- **The actual workflow toggle on project #4.** GitHub's GraphQL API has `deleteProjectV2Workflow` (irreversible) but no `updateProjectV2Workflow`. Toggling requires either the web UI (recommended) or `gh api graphql -f query='mutation { deleteProjectV2Workflow(...) ... }'`. This action is the operator's hand — done out-of-band.
- **No Python code changes.** Per doctrine-first; this is project config, not code.

## Adjacent finding (not in scope)

The bootstrap template's `## Labels` section lists `blocked` as a defaults label — directly contradicting Jared's `feedback_pk_status_design` rule that Blocked is a Status column, not a label. The live `docs/project-board.md` is correct; only the template drifts. Worth filing as a follow-up after this lands.

## Test plan

- [x] `pytest` — 401 passed (no code touched, sanity check)
- [x] `ruff check .` — clean
- [x] Manual: read the rendered `docs/project-board.md` table — formats correctly in GitHub markdown
- [ ] **Operator action (post-merge):** disable "Pull request linked to issue" workflow on project #4 via UI or GraphQL `deleteProjectV2Workflow`
- [ ] **Verify (post-toggle):** close a test issue via PR, then merge a second PR whose body mentions `closes #<original>` in prose — confirm Status stays Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)