### PR TITLE
release: v0.18.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.17.0"
+version = "0.18.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## v0.18.0 — minor release

Cuts the version bump for the changes shipped after v0.17.0. Bumps `.claude-plugin/plugin.json` and `pyproject.toml` to `0.18.0`. After merge, tag `v0.18.0` and push.

## Changes since v0.17.0

### Features

- **`epic` label-aware Deferred filtering (#146).** `/jared-stage` skips items labeled `epic` from the "Deferred (this pass)" surface, eliminating the recurring noise of parent-shaped issues (#76, #110, #111 on this project's own board). New `is_epic(item)` helper + filter in `stage_proposals`; `labels` plumbed through `fetch_items_for_stage`. The `epic` label is documented in both `docs/project-board.md ## Labels` and the bootstrap template so new boards inherit the convention.

### Fixes

- **Milestone display + sort tier restored (#145).** `_format_milestone` and `milestone_proximity_days` now read real milestone data instead of always falling through to placeholders. The sort tier in `rank_key` was previously dead code (always `math.inf`); now functional. Non-milestoned items render an honest `(no milestone)` instead of the misleading `(unknown) (no due date)` fallback.

### Performance

- **`fetch_milestone_map` removed (#153).** Milestone data was top-level on `gh project item-list` raw items all along; the #145 fix's GraphQL companion was unnecessary. -227 / +36 lines. One fewer paginated GraphQL pass per `stage.py` invocation.
- **ETag / conditional GET on issue-state fetch (#147).** Per-issue state checks now send `If-None-Match` when a previously-seen ETag is cached. Unchanged issues return 304 and skip body parse. Material rate-budget relief on repeated sweeps.

### Docs

- **Projects v2 workflow recommendations + commit-body keyword hygiene (#156).** Documented which workflows to enable/disable on a Jared-stewarded board. "Pull request linked to issue" must be off — it fires retroactively on commit-body prose containing `closes #N` and reverts the Status that `jared close` just set. Bootstrap template carries the same section so new installs inherit it.
- CLAUDE.md no longer hardcodes the plugin version (#150).

## Companion non-code action

Operators on existing Jared-stewarded boards should **disable the "Pull request linked to issue" workflow** via the project's Workflows UI (or `deleteProjectV2Workflow` GraphQL). The brockamer/jared project #4 has been verified disabled as part of this release window. New installs inherit the recommendation via the bootstrap template.

## Test plan

- [x] All 401 unit tests pass (393 pre-session + 12 added across this release window − 4 deleted in #153 = 401)
- [x] `ruff check .` and `ruff format --check .` clean
- [x] `mypy` strict — no issues in 42 source files
- [x] End-to-end verified on this project's own board through the session
- [ ] **Post-merge:** tag `v0.18.0` and push (`git tag v0.18.0 && git push origin v0.18.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)