### PR TITLE
fix(stage): accurate reason message when acceptance section has no -bullets

### DIFF
--- a/skills/jared/scripts/stage.py
+++ b/skills/jared/scripts/stage.py
@@ -216,7 +216,10 @@ def not_pullable_reason(item: dict[str, Any]) -> str:
         return "not pullable — placeholder summary"
 
     if _ACCEPTANCE_SECTION.search(body):
-        return "not pullable — acceptance section uses placeholder bullets"
+        return (
+            "not pullable — acceptance section has no `-`-prefixed bullets "
+            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
+        )
 
     if _ACCEPTANCE_HEADING_ANY.search(body):
         return (

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -183,7 +183,47 @@ class TestNotPullableReason:
         }
         assert (
             stage.not_pullable_reason(item)
-            == "not pullable — acceptance section uses placeholder bullets"
+            == "not pullable — acceptance section has no `-`-prefixed bullets "
+            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
+        )
+
+    def test_numbered_list_bullets_fail(self) -> None:
+        """`1.`/`2.`-prefixed bullets fail is_pullable — no `-` lines."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n<summary>Expand</summary>\n\n"
+                "1. First criterion\n"
+                "2. Second criterion\n\n"
+                "</details>"
+            )
+        }
+        assert stage.is_pullable(item) is False
+        assert (
+            stage.not_pullable_reason(item)
+            == "not pullable — acceptance section has no `-`-prefixed bullets "
+            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
+        )
+
+    def test_prose_only_acceptance_fails(self) -> None:
+        """Prose paragraph (no bullets at all) fails is_pullable."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n<summary>Expand</summary>\n\n"
+                "Goals deferred until dependencies land; criteria will be concretized then.\n\n"
+                "</details>"
+            )
+        }
+        assert stage.is_pullable(item) is False
+        assert (
+            stage.not_pullable_reason(item)
+            == "not pullable — acceptance section has no `-`-prefixed bullets "
+            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
         )
 
     def test_non_canonical_heading_short_form(self) -> None:


### PR DESCRIPTION
## Summary

- `stage.py:not_pullable_reason()` returned "uses placeholder bullets" for every shape with zero `-`-prefixed real-content bullets — including numbered lists, prose paragraphs, and the literal `- Criterion N` placeholder. Original wording only matched the third case.
- Reworded to "acceptance section has no `-`-prefixed bullets (numbered list, prose, or `- Criterion N` placeholders all fail)" — accurate for all three shapes.
- Added explicit test cases for numbered-list and prose-only failure modes; updated the existing placeholder-bullets test to the new string.

Surfaced in [brockamer/findajob#694](https://github.com/brockamer/findajob/issues/694) (Path A): the failure-mode reason was misleading the operator into thinking numbered-list bullets were placeholder text.

## Test plan

- [x] `uv run pytest tests/test_stage.py` — 72 pass (was 70, +2 new)
- [x] `uv run python skills/jared/scripts/stage.py --report-only` against the findajob board shows the new wording on the still-deferred issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)