### PR TITLE
release: v0.18.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.18.0"
+version = "0.18.1"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Patch release. Single fix on top of v0.18.0.

- **Fix: accurate not-pullable reason when acceptance section has no `-` bullets (#160).** `/jared-stage`'s reason message no longer mislabels numbered-list or prose acceptance sections as "placeholder bullets". Reworded to cover all three failure modes accurately, with new tests for the numbered-list and prose-only cases.

## Test plan

- [x] `pytest -q` — 403 passed, 1 deselected
- [x] `.claude-plugin/plugin.json` bumped to 0.18.1
- [x] `pyproject.toml` bumped to 0.18.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)