### PR TITLE
fix(template): remove 'blocked' label from asset scaffold; pin invariant with test

### DIFF
--- a/skills/jared/assets/project-board.md.template
+++ b/skills/jared/assets/project-board.md.template
@@ -56,7 +56,8 @@ Defaults:
 | `enhancement` | New capability |
 | `refactor` | Restructuring without behavior change |
 | `documentation` | Docs-only change |
-| `blocked` | Waiting on a dependency (must pair with `## Blocked by` in body) |
+
+**Do not** create a `blocked` label. Blocked is a Status column on this board, not a label — see Status above.
 
 ## Project workflows — recommended settings
 

--- a/tests/test_asset_project_board_template.py
+++ b/tests/test_asset_project_board_template.py
@@ -1,0 +1,35 @@
+"""Tests for the asset scaffold `skills/jared/assets/project-board.md.template`.
+
+The asset file is the convention-doc scaffold referenced from SKILL.md and
+references/new-board.md — it's documentation that humans and Claude sessions
+read to understand the shape of a Jared-stewarded board.
+
+`bootstrap-project.py` does NOT render from this file (it has its own inline
+TEMPLATE — covered by test_bootstrap_project_defaults.py). So drift on the
+asset isn't caught by the rendering tests. #159 was exactly that drift: the
+asset's Labels table listed `blocked` as a default label, contradicting
+Jared's column-not-label rule and the live docs/project-board.md.
+
+This file pins the same `blocked`-rule invariants on the asset that
+test_bootstrap_project_defaults.py pins on the rendered TEMPLATE.
+"""
+
+from pathlib import Path
+
+ASSET_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "jared"
+    / "assets"
+    / "project-board.md.template"
+)
+
+
+def test_asset_template_omits_blocked_label_row() -> None:
+    content = ASSET_PATH.read_text()
+    assert "| `blocked` |" not in content
+
+
+def test_asset_template_has_blocked_label_callout() -> None:
+    content = ASSET_PATH.read_text()
+    assert "Do not" in content and "`blocked` label" in content


### PR DESCRIPTION
## Summary

- Drop the `blocked` row from the asset template's Labels table.
- Add the canonical "Do not create a `blocked` label" callout mirroring the live `docs/project-board.md`.
- New `tests/test_asset_project_board_template.py` pins both invariants on the asset itself, so the drift cannot recur silently.

## Why this needed its own test

`bootstrap-project.py` has its own inline `TEMPLATE` (already correct — covered by `test_render_doc_omits_blocked_label_row`). It does NOT render from `skills/jared/assets/project-board.md.template`. So the existing rendering tests caught nothing when the asset drifted. The asset is read by humans and Claude sessions as the convention-doc scaffold (referenced from `SKILL.md` and `references/new-board.md`), so its content matters even though no automation consumes it.

## Test plan

- [x] `pytest` — all 405 tests pass (2 new + existing 403)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — strict clean across 43 source files
- [x] Diff against `docs/project-board.md` § Labels confirms agreement on the no-blocked-label rule

## Follow-up worth filing

The diff also surfaced two other drifts between the asset and the live convention doc — the asset is missing the `epic` label row (which `/jared-stage` exempts from "Deferred" noise) and the "Project-specific scope labels" trailing paragraph. Out of #159's scope; worth filing as a separate issue during `/jared-wrap`.

Closes #159