### PR TITLE
fix(template): add epic row + scope-labels paragraph to asset Labels section

### DIFF
--- a/skills/jared/assets/project-board.md.template
+++ b/skills/jared/assets/project-board.md.template
@@ -56,8 +56,11 @@ Defaults:
 | `enhancement` | New capability |
 | `refactor` | Restructuring without behavior change |
 | `documentation` | Docs-only change |
+| `epic` | Durably parent-shaped — roadmap, checklist, strategic anchor. Lacks acceptance criteria by design; stays in Backlog as a long-horizon container. `/jared-stage` exempts these from "Deferred (this pass)" noise. |
 
 **Do not** create a `blocked` label. Blocked is a Status column on this board, not a label — see Status above.
+
+Project-specific scope labels (e.g., `infra`, `frontend`, `customer-facing`) belong here too — add them as needed.
 
 ## Project workflows — recommended settings
 

--- a/tests/test_asset_project_board_template.py
+++ b/tests/test_asset_project_board_template.py
@@ -33,3 +33,14 @@ def test_asset_template_omits_blocked_label_row() -> None:
 def test_asset_template_has_blocked_label_callout() -> None:
     content = ASSET_PATH.read_text()
     assert "Do not" in content and "`blocked` label" in content
+
+
+def test_asset_template_has_epic_label_row() -> None:
+    content = ASSET_PATH.read_text()
+    assert "| `epic` |" in content
+
+
+def test_asset_template_has_scope_labels_paragraph() -> None:
+    content = ASSET_PATH.read_text()
+    assert "Project-specific scope labels" in content
+    assert "`infra`" in content and "`frontend`" in content and "`customer-facing`" in content


### PR DESCRIPTION
## Summary

Follow-up to #168. Adds the two remaining asset-template Labels-section drifts that #170 carved out from the original #159 scope:

- Add `epic` row to the Labels table (wording identical to `docs/project-board.md` line 93).
- Add the "Project-specific scope labels" trailing paragraph telling new boards they can add scope labels.
- Extend `tests/test_asset_project_board_template.py` (added in #168) with two new assertions pinning these invariants.

## Why this needed its own PR

Both drifts are the same shape of silent drift as #159: the asset is a documentation scaffold referenced from `SKILL.md` and `references/new-board.md`, but `bootstrap-project.py` does not consume it (it has its own inline `TEMPLATE`). So the existing rendering tests catch nothing when the asset drifts.

After this PR, the asset/canonical parity diff for the Labels section shows only line-wrapping plus the intentional template-leaner `Defaults:` heading (vs the live doc's project-specific `Suggested defaults (create via `gh label create` as needed):`).

## Test plan

- [x] `pytest` — 407 tests pass (4 asset-template tests including 2 new + existing 403)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — strict clean across 43 source files
- [x] Final parity diff vs `docs/project-board.md` § Labels confirmed only intentional differences remain

Closes #170