### PR TITLE
release: v0.19.0 — guidance refactor + template fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.18.1"
+version = "0.19.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Release v0.19.0. Bumps version in `.claude-plugin/plugin.json` + `pyproject.toml`. Rolls up three unreleased merges since v0.18.1.

## What ships

- **#173 (refactor):** refined Fork D guidance shape — classification + `advisor()` + judgment-eval audit. Implements #172, follow-up to the #162 audit. Drops task-tier dispatch directives across 5 surfaces (Phase 1), flips wrap-time audit from compliance-eval to judgment-eval across 2 surfaces (Phase 2). See merge commit `08d2c2c` for the full description.
- **#171 (fix):** asset Labels section restored — adds back the `epic` row + scope-labels paragraph that drifted out of sync with the canonical doc.
- **#168 (fix):** removed `blocked` from default labels in the bootstrap project-board template. Blocked is a Status column, never a label. Invariant pinned with a test.

## Backward compatibility

- Existing issues' guidance sections are NOT retroactively rewritten — refined shape applies to newly-filed and newly-pulled issues only.
- `- model-guidance: disabled` kill switch in `docs/project-board.md ## Jared config` works the same way.
- All CLI surfaces unchanged.
- No `lib/board.py` edits, no fixtures, no Python parsing of new fields — doctrine-first throughout.

## Test plan

- [ ] After merge: `/plugin update jared` + `/reload-plugins` from inside Claude Code
- [ ] Manual smoke A — `jared file` produces an issue body whose `## Model & execution guidance` section uses the refined shape (leading caveat + Cheap/Standard tiers without `USE a Haiku/Sonnet subagent` parentheticals + Smart with `USE \`advisor()\`` retained + no standalone Subagent-dispatches block)
- [ ] Manual smoke B — `/jared-start` against an issue with no body-level guidance section produces a start-time backstop in the refined shape
- [ ] Manual smoke C — `/jared-wrap` on an in-progress guidance-bearing issue produces the new three-question audit block (advisor() / work-size match / forensic under-dispatch examination), with bolded "no requires why" rule
- [ ] Re-audit at 30 days post-merge per #162's caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)