### PR TITLE
docs(claude-md): tag pushes must be paired with gh release create

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,5 @@ Use `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared <subcommand>`. **Never har
 ## Versioning
 
 Semantic versioning in `.claude-plugin/plugin.json` and mirrored in `pyproject.toml`. Git tag `v<x.y.z>` per release. `pyproject.toml` configures dev tooling and pins venv deps but isn't published as a package — the version field exists for parity, not distribution. Check `.claude-plugin/plugin.json` for the current version rather than relying on this paragraph (which used to hardcode it).
+
+**Every tag push must be accompanied by a GitHub Release.** Use `gh release create v<x.y.z> --title "v<x.y.z> — <short description>" --notes "<body>"` immediately after `git push origin v<x.y.z>`. The release notes follow the v0.13.0+ format: `## What's changed` with `**Features** / **Bug fixes** / **Refactor** / **Doctrine**` sub-headings, each item ending with `(#<PR>)`; followed by `## Backward compatibility` (if relevant), `## Validation` (if relevant), and `## Upgrading` with the `/plugin update jared` + `/reload-plugins` block. A git tag alone is not enough — the GitHub Release is the public-facing artifact.


### PR DESCRIPTION
## Summary

Adds a paragraph to CLAUDE.md's `## Versioning` section codifying that every `git push origin v<x.y.z>` must be followed by `gh release create` so the GitHub Release exists as the public-facing artifact. Names the v0.13.0+ release-notes shape so future sessions emit substantive content.

## Why now

Caught at v0.19.0 (just-shipped) — I tagged but didn't create a GitHub Release; operator had to ask "put it on the releases as well." Looking back, tags v0.14.0 through v0.18.1 also exist without corresponding GitHub Releases (latest Release is v0.13.0). Fixing the convention forward.

## Test plan

- [ ] Next release tag (v0.20.0+) is paired with a `gh release create` invocation
- [ ] Release notes follow the documented `## What's changed` / `## Backward compatibility` / `## Validation` / `## Upgrading` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)