### PR TITLE
docs(bake-sites): #167 formal claim — findajob + trailscribe documented as bake sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ skills/jared/
   assets/                 Templates: issue-body, session-note, project-board.md, plan-conventions
 tests/                    pytest unit + integration suite; conftest has import helpers
 docs/superpowers/         Specs and plans governing this plugin's own work (2026-04-22-jared-levelup)
+docs/bake-sites.md        Projects (beyond jared/jared-testbed) where jared runs in real sessions
 ```
 
 ## Scripts invoked from skill/command context

--- a/docs/bake-sites.md
+++ b/docs/bake-sites.md
@@ -1,0 +1,32 @@
+# Bake sites — projects where jared runs in real sessions
+
+Beyond `jared` itself (`brockamer/jared`) and the integration-test fixture (`brockamer/jared-testbed`), jared is in active steward-mode use against the projects below. Each entry confirms jared operates against the project in real sessions and notes any project-specific quirks future sessions should be aware of.
+
+This file is the formal claim for #167 (v1.0 readiness — verify jared works against ≥1 board besides jared/jared-testbed).
+
+## findajob — `brockamer/findajob`
+
+- **Board:** <https://github.com/users/brockamer/projects/1>
+- **Kind of work:** Self-hosted job-search pipeline (LinkedIn / Indeed / ATS ingestion, LLM scoring, web UI). Mixed feature / fix / docs / tracking issues; high-velocity board with multiple Claude sessions concurrently driving issues to PR.
+- **Project doc location:** `docs/maintainers/project-board.md` — *not* the default `docs/project-board.md`. The jared CLI discovers it via fallback path search; new projects should prefer the default location.
+- **Quirks:**
+  - **High concurrency.** When multiple sessions are active, use `git worktree add` for branching so each session has an isolated working tree. The shared `~/Code/findajob` checkout will routinely be on a feature branch with untracked files from another in-flight session.
+  - **`migration-required` callout.** Issue bodies regularly carry a `migration-required` callout for operator action on deploy. Respect it when filing.
+- **Evidence:** #60 (this repo) measured a complete `/jared`-driven session at 4.40% GraphQL + 0.76% REST `core` saturation on 2026-05-22.
+
+## trailscribe — `brockamer/trailscribe`
+
+- **Board:** <https://github.com/users/brockamer/projects/3>
+- **Kind of work:** Cloudflare Workers project — Garmin inReach SMS-driven assistant. Lower-velocity than findajob; smaller backlog focused on feature work and KV → Durable Object migration.
+- **Project doc location:** `docs/project-board.md` (default).
+- **Quirks:** None observed.
+
+## Adding a bake site
+
+A project qualifies when:
+
+1. It has `docs/project-board.md` (or a documented fallback path under `docs/`) populated per `skills/jared/assets/project-board.md`.
+2. jared CLI subcommands (`summary`, `move`, `comment`, `close`) succeed against it in real sessions.
+3. At least one PR has been driven through the full `/jared` → `/jared-start` → work → wrap cycle against its board.
+
+List newly-qualified projects above with the same fields. Surface any new project-specific quirks so future sessions don't hit them blind.

--- a/docs/bake-sites.md
+++ b/docs/bake-sites.md
@@ -20,6 +20,7 @@ This file is the formal claim for #167 (v1.0 readiness — verify jared works ag
 - **Kind of work:** Cloudflare Workers project — Garmin inReach SMS-driven assistant. Lower-velocity than findajob; smaller backlog focused on feature work and KV → Durable Object migration.
 - **Project doc location:** `docs/project-board.md` (default).
 - **Quirks:** None observed.
+- **Evidence-of-bake:** trailscribe issue [#201](https://github.com/brockamer/trailscribe/issues/201) carries a 2026-05-21 Session-note comment in canonical jared shape, referencing merged PR [#205](https://github.com/brockamer/trailscribe/pull/205) — one complete `/jared` → start → work → wrap cycle. Issue #206 (`adopt jared doc-sync gate`) confirms jared discipline is in active use.
 
 ## Adding a bake site
 


### PR DESCRIPTION
## Summary

- New `docs/bake-sites.md` formally claims **findajob** (project #1) and **trailscribe** (project #3) as jared bake sites with the metadata #167 asks for: board URL, kind-of-work, project-specific quirks.
- `CLAUDE.md` ## Layout gains a one-line pointer so the file is discoverable from the canonical entry point.
- Format includes an "Adding a bake site" section so future qualifying projects land in-shape.

## Why now

The v1.0 readiness gate asked for ≥1 project beyond jared/jared-testbed where jared operates in real sessions. Two sites have been functioning as such already, with full-cycle evidence on each; this PR moves them from undocumented usage to formal claims with quirks captured.

## Evidence-of-bake

- **findajob** — corroborated by #60's 2026-05-22 measurement: a complete `/jared` → start → work → comment cycle on findajob's board consumed 4.40% GraphQL + 0.76% REST `core` saturation (well under both the literal pre-REST-migration target and the post-REST corollary).
- **trailscribe** — trailscribe issue #201 carries a 2026-05-21 Session-note comment in canonical jared shape, referencing merged PR #205. One complete cycle. trailscribe issue #206 (`adopt jared doc-sync gate`) further confirms active discipline adoption.

## Notable quirk surfaced

findajob's project doc lives at `docs/maintainers/project-board.md`, not the default `docs/project-board.md`. The jared CLI discovers it via fallback path search. New projects should prefer the default location — documented here so future bake sites adopt the canonical convention rather than findajob's drift.

## Test plan

- [ ] `docs/bake-sites.md` renders cleanly on GitHub (one-level headings, bullet lists, no broken anchors).
- [ ] `CLAUDE.md` ## Layout table renders with the new line aligned to the existing column shape.
- [ ] No code change → no test-suite impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)