### PR TITLE
feat(close) + doctrine: close-with-comment one atom + audit velocity floor (#184, #183)

### DIFF
--- a/commands/jared-audit.md
+++ b/commands/jared-audit.md
@@ -60,8 +60,12 @@ Flow:
 7. **Mutations — date proposals are aggressive.** When proposing a new milestone due date during reshape, anchor to:
 
    ```
-   default_due_date = today + (velocity.median_pr_duration_days × remaining_open_children)
+   raw_days     = velocity.median_pr_duration_days × remaining_open_children
+   anchor_days  = max(7, raw_days)
+   default_due_date = today + anchor_days
    ```
+
+   The **7-day floor** exists because `median_pr_duration_days` is a tight proxy for "CI duration" on projects that gate merges on green CI, not for "feature-completion duration." On CI-fast-merge cadences (PRs auto-merging within minutes of green) the raw formula collapses to "today + epsilon" — i.e., "tomorrow" — for every reshape, regardless of remaining work. That's not what anchoring to recent shipping cadence is meant to do. The floor keeps proposals aggressive but realistic (#183).
 
    Bias toward the near term. Default cadence is weeks, not quarters. If the proposed date pushes past this anchor, include a one-line written rationale (e.g., "external dependency lands week of X") in the operator approval prompt — parking a milestone 3–6 months out without an explicit reason is a smell.
 

--- a/commands/jared-audit.md
+++ b/commands/jared-audit.md
@@ -76,10 +76,12 @@ Flow:
 9. **Apply approved mutations** using existing atoms:
 
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared close <N> --comment-file <path>
+   ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared close <N> --body-file <path>
    ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared comment <N> --body-file <path>
    ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared set <N> <field> <value>
    ```
+
+   `jared close --body-file` posts the comment before closing, so a close failure leaves the issue open with a stray comment (recoverable by re-running `jared close <N>` without `--body-file`). Closing first then failing to comment would leave a closed issue without a Session note — the discipline this atom exists to enforce.
 
    For body/title edits: `gh api -X PATCH /repos/{owner}/{repo}/issues/{N} -f title=… -f body=…`
    For milestone mutations: `gh api -X PATCH /repos/{owner}/{repo}/milestones/{N} …` (or `DELETE` for `dissolve`).

--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -75,9 +75,12 @@ Flow:
    ```
 
 5. **On approval, apply in order:**
-   - Post Session note comments: for each issue, pipe the note to
+   - For issues being **closed as part of this wrap**, post the Session note and close in one atom — pipe the note to
+     `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared close <N> --body-file -`
+     (the close atom posts the comment before closing, so a close failure leaves the issue open with a recoverable stray comment; closing-then-failing-to-comment would leave a closed issue without a Session note, which is the discipline this atom exists to enforce — see #184).
+   - For issues **staying open** (Session note only, no close), pipe the note to
      `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared comment <N> --body-file -`
-   - Apply reconciliation: `jared close <N>` for completed items, `jared move <N> "Backlog"` (or `"Up Next"`) for abandoned ones, `jared file ...` for newly-filed scope
+   - Apply non-close reconciliation: `jared move <N> "Backlog"` (or `"Up Next"`) for abandoned ones, `jared file ...` for newly-filed scope
    - Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/archive-plan.py --scan --repo <owner>/<repo>` for shippable plans
    - Update `## Current state` on issues where it meaningfully changed this session via `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/capture-context.py`
 

--- a/skills/jared/references/jared-cli.md
+++ b/skills/jared/references/jared-cli.md
@@ -109,7 +109,7 @@ conventional columns are Backlog / Up Next / In Progress / Blocked / Done.
 
 ---
 
-## `jared close <issue_number>`
+## `jared close <issue_number> [--body TEXT | --body-file PATH]`
 
 **Purpose.** Close an issue and verify the board auto-moves it to Done.
 GitHub's project-v2 auto-move is eventually consistent; this subcommand
@@ -117,8 +117,19 @@ polls for up to ~3 attempts, and if the auto-move hasn't fired, forces
 `Status=Done` explicitly. Either way you get a definitive Done state
 before the command returns.
 
+Optionally post a Session note in the same atom — `--body` / `--body-file`
+mirror `jared comment` and `jared file`. When supplied, the comment is
+posted *before* the close, so a close failure leaves the issue open with
+a stray comment (recoverable: re-run `jared close <N>` without `--body*`).
+Closing first then failing to comment would leave a closed issue without
+a Session note — the discipline this flag exists to enforce against the
+audit/wrap doctrine that treats close-with-comment as one atom.
+
 ```
 jared close <issue_number>
+jared close <issue_number> --body "Done — shipped in v0.21."
+jared close <issue_number> --body-file close-note.md
+cat close-note.md | jared close <issue_number> --body-file -
 ```
 
 **Example.**
@@ -126,7 +137,15 @@ jared close <issue_number>
 ```
 $ jared close 12
 OK: closed #12, board auto-moved to Done
+
+$ jared close 12 --body-file close-note.md
+OK: commented on #12 (https://github.com/owner/repo/issues/12#issuecomment-…)
+OK: closed #12, Status=Done
 ```
+
+PII pre-flight (#102) runs on the comment body, same as `jared comment`
+and `jared file`. A redaction-dirty body short-circuits before any gh call —
+neither the comment nor the close runs.
 
 ---
 

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -118,9 +118,22 @@ def build_parser() -> argparse.ArgumentParser:
 
     close_p = sub.add_parser(
         "close",
-        help="Close issue + verify/force auto-move to Done.",
+        help=(
+            "Close issue + verify/force auto-move to Done. "
+            "Optionally post a comment first via --body / --body-file."
+        ),
+        allow_abbrev=False,
     )
     close_p.add_argument("issue_number", type=int)
+    close_body = close_p.add_mutually_exclusive_group()
+    close_body.add_argument(
+        "--body",
+        help="Inline comment body to post on the issue before closing.",
+    )
+    close_body.add_argument(
+        "--body-file",
+        help='Path to markdown comment body, or "-" for stdin. Posted before close.',
+    )
     close_p.set_defaults(func=_cmd_close)
 
     comment = sub.add_parser(
@@ -306,6 +319,37 @@ def _cmd_move(args: argparse.Namespace) -> int:
 
 def _cmd_close(args: argparse.Namespace) -> int:
     board = _load_board(args.board)
+
+    # Optional comment-before-close (#184). Post the Session note first so a
+    # close failure leaves a recoverable state (open issue + stray comment,
+    # user re-runs `jared close <N>` without --body). The opposite order would
+    # close the issue and then fail to post the note — a discipline violation
+    # since the audit/wrap doctrine treats close-with-comment as one atom.
+    has_comment = args.body is not None or args.body_file is not None
+    if has_comment:
+        body = resolve_body(args.body, args.body_file)
+        report = pre_flight_check(body, project_root=_find_project_root(Path.cwd()))
+        if not report.clean:
+            print_redaction_diff(report, file=sys.stderr)
+            return 2
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tf:
+            tf.write(body)
+            tmp_path = tf.name
+        try:
+            comment_url = board.run_gh_raw(
+                [
+                    "issue",
+                    "comment",
+                    str(args.issue_number),
+                    "--repo",
+                    board.repo,
+                    "--body-file",
+                    tmp_path,
+                ]
+            )
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+        print(f"OK: commented on #{args.issue_number} ({comment_url})")
 
     board.run_gh(
         [

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -1,10 +1,12 @@
 import json
+import subprocess as _subprocess
+from io import StringIO
 from pathlib import Path
 from textwrap import dedent
 
 import pytest
 
-from tests.conftest import import_cli, patch_gh_by_arg
+from tests.conftest import FakeGhResult, import_cli, patch_gh_by_arg
 
 
 def _write_board_with_status(tmp_path: Path) -> Path:
@@ -162,3 +164,299 @@ def test_close_targets_correct_project_when_issue_on_multiple_boards(
     # The mutation must reference our board's item-id, never the sibling project's.
     assert "PVTI_ours" in joined
     assert "PVTI_other" not in joined
+
+
+# ---------- close --body / --body-file (#184) ----------
+
+
+def _patch_gh_capture_close_with_body(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    project_number: int = 7,
+    status: str = "In Progress",
+) -> tuple[list[list[str]], list[str | None]]:
+    """Patch subprocess.run for `jared close --body*` tests.
+
+    Routes by argv shape:
+      - `issue comment` → snapshot --body-file content, return comment URL
+      - `issue close`   → empty stdout
+      - `api graphql`   → projectItems response (find_item_id path)
+      - `item-edit`     → "{}"
+
+    Returns (calls, bodies) where `bodies` is the snapshot of the
+    comment's --body-file content at call time (the CLI's `finally`
+    deletes the temp file before the test can read it later).
+    """
+    calls: list[list[str]] = []
+    bodies: list[str | None] = []
+
+    graphql_response = _graphql_item_response(project_number=project_number, status=status)
+    comment_url = "https://github.com/brockamer/findajob/issues/42#issuecomment-9999"
+
+    def fake_run(args: list[str], **_: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        if "issue" in args and "comment" in args:
+            if "--body-file" in args:
+                idx = args.index("--body-file")
+                try:
+                    bodies.append(Path(args[idx + 1]).read_text())
+                except FileNotFoundError:
+                    bodies.append(None)
+            return FakeGhResult(stdout=comment_url)
+        if "issue" in args and "close" in args:
+            return FakeGhResult(stdout="")
+        if "api graphql" in joined:
+            return FakeGhResult(stdout=graphql_response)
+        if "item-edit" in joined:
+            return FakeGhResult(stdout="{}")
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        fake_run,
+    )
+    return calls, bodies
+
+
+def _call_kinds(calls: list[list[str]]) -> list[str]:
+    """Classify each captured argv to its conceptual gh action.
+
+    Used to assert call ORDER (comment must precede close), which is
+    the #184 invariant: a close failure must not leave a closed issue
+    with no Session note.
+    """
+    out: list[str] = []
+    for c in calls:
+        joined = " ".join(c)
+        if "issue" in c and "comment" in c:
+            out.append("comment")
+        elif "issue" in c and "close" in c:
+            out.append("close")
+        elif "api graphql" in joined:
+            out.append("graphql")
+        elif "item-edit" in joined:
+            out.append("item-edit")
+        else:
+            out.append("other")
+    return out
+
+
+def test_close_with_body_file_posts_comment_then_closes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`jared close 42 --body-file note.md` MUST post the comment before the
+    close, and the comment body MUST be what the file contained. Ordering is
+    the #184 invariant — closing first then failing to comment would leave a
+    closed issue without a Session note (the discipline this flag exists to
+    enforce against the audit/wrap doctrine that treats it as one atom).
+    """
+    board_md = _write_board_with_status(tmp_path)
+    note = tmp_path / "session.md"
+    note.write_text("## Session 2026-05-22\n\nClosed as resolved.")
+
+    calls, bodies = _patch_gh_capture_close_with_body(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42", "--body-file", str(note)])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" in kinds, f"expected an issue comment call; got {kinds}"
+    assert "close" in kinds, f"expected an issue close call; got {kinds}"
+    assert kinds.index("comment") < kinds.index("close"), (
+        f"comment must precede close, got order: {kinds}"
+    )
+    assert bodies == ["## Session 2026-05-22\n\nClosed as resolved."]
+    # Defense-in-depth set still runs.
+    assert "item-edit" in kinds
+    # Comment URL surfaced to the user.
+    assert "OK: commented on #42" in captured.out
+    assert "OK: closed #42, Status=Done" in captured.out
+
+
+def test_close_with_inline_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--body <text>` mirrors `jared comment --body`: inline string, no path."""
+    board_md = _write_board_with_status(tmp_path)
+    _calls, bodies = _patch_gh_capture_close_with_body(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(
+        ["--board", str(board_md), "close", "42", "--body", "## Inline close note\n\nDone."]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert bodies == ["## Inline close note\n\nDone."]
+
+
+def test_close_with_body_file_stdin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--body-file -` reads stdin, consistent with `jared comment` / `jared file`."""
+    board_md = _write_board_with_status(tmp_path)
+    _calls, bodies = _patch_gh_capture_close_with_body(monkeypatch)
+    monkeypatch.setattr("sys.stdin", StringIO("piped close comment"))
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42", "--body-file", "-"])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert bodies == ["piped close comment"]
+
+
+def test_close_without_body_does_not_post_comment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Bare `jared close <N>` MUST NOT invoke `issue comment` — preserves the
+    plain-close path for callers that want only the close behavior."""
+    board_md = _write_board_with_status(tmp_path)
+    calls, _bodies = _patch_gh_capture_close_with_body(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42"])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" not in kinds, f"plain close must skip comment; got {kinds}"
+    assert "close" in kinds
+
+
+def test_close_rejects_both_body_and_body_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """argparse mutex group on close mirrors the one on comment/file."""
+    board_md = _write_board_with_status(tmp_path)
+    note = tmp_path / "n.md"
+    note.write_text("x")
+    _patch_gh_capture_close_with_body(monkeypatch)
+
+    mod = import_cli()
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(
+            [
+                "--board",
+                str(board_md),
+                "close",
+                "42",
+                "--body",
+                "inline",
+                "--body-file",
+                str(note),
+            ]
+        )
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    assert "not allowed with" in captured.err or "mutually exclusive" in captured.err, captured.err
+
+
+def _git_init_with_claude_local(tmp_path: Path, claude_local_content: str) -> None:
+    """Mirrors test_cmd_comment.py / test_cmd_file.py — duplicated rather than
+    extracted because the three files don't share a private helper module and
+    adding one for three callers is over-engineering."""
+    _subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    _subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    _subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / "CLAUDE.local.md").write_text(claude_local_content)
+
+
+def test_close_with_body_when_close_fails_after_comment_posts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """If `gh issue close` fails AFTER the comment posts, the comment is
+    durable, the CLI exits non-zero, and the user can re-run `jared close <N>`
+    without `--body*` to retry just the close. This pins the recovery contract
+    documented in `commands/jared-audit.md` step 9 and `references/jared-cli.md`.
+
+    No silent rollback (comments are append-only by GitHub semantics — removing
+    one would be worse than orphaning), but the comment URL MUST be printed
+    BEFORE the error so the operator knows what landed.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    note = tmp_path / "n.md"
+    note.write_text("## Session 2026-05-22\n\nDone — but close will fail.")
+    comment_url = "https://github.com/brockamer/findajob/issues/42#issuecomment-1111"
+
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        if "issue" in args and "comment" in args:
+            return FakeGhResult(stdout=comment_url)
+        if "issue" in args and "close" in args:
+            # gh non-zero exit propagates as GhInvocationError from run_gh.
+            return FakeGhResult(stdout="", returncode=1, stderr="gh: API rate limit")
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        fake_run,
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42", "--body-file", str(note)])
+
+    captured = capsys.readouterr()
+    # main() catches GhInvocationError and returns 1.
+    assert rc == 1, (
+        f"expected non-zero on close failure; stdout={captured.out} stderr={captured.err}"
+    )
+    kinds = _call_kinds(calls)
+    assert kinds.index("comment") < kinds.index("close"), (
+        f"comment must precede close, got: {kinds}"
+    )
+    # No item-edit (defense-in-depth Status=Done) should run when close fails.
+    assert "item-edit" not in kinds, (
+        f"item-edit must not run when close fails; kinds={kinds}"
+    )
+    # Comment URL surfaced — the operator knows what landed before the error.
+    assert "OK: commented on #42" in captured.out
+    assert comment_url in captured.out
+    # Error visible.
+    assert "rate limit" in captured.err or "gh" in captured.err.lower()
+
+
+def test_close_with_body_refuses_on_dirty_pre_flight_report(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Pre-flight redaction (#102) MUST short-circuit before any gh call when
+    --body contains content from a gitignored claude-shaped local file.
+    Neither the comment nor the close should run."""
+    board_md = _write_board_with_status(tmp_path)
+    leaky_phrase = "credentials live at /opt/secrets/foo.json on prod"
+    _git_init_with_claude_local(tmp_path, leaky_phrase + "\n")
+
+    monkeypatch.chdir(tmp_path)
+    from skills.jared.scripts.lib.board import _clear_pre_flight_cache
+
+    _clear_pre_flight_cache()
+
+    calls, _bodies = _patch_gh_capture_close_with_body(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "close",
+            "42",
+            "--body",
+            f"Note: {leaky_phrase}.",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 2, captured.err
+    assert "pre-flight redaction check failed" in captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" not in kinds, f"redactor must short-circuit before gh; calls: {kinds}"
+    assert "close" not in kinds, f"redactor must block close too; calls: {kinds}"


### PR DESCRIPTION
## Summary

- **#184 (CLI + doctrine):** `jared close <N>` grows `--body` / `--body-file` (and `--body-file -` for stdin), posting the comment **before** the close in one atom. Closes the gap where `commands/jared-audit.md` step 9 documented a `--comment-file` flag that never existed and the operator silently fell back to a two-step pattern that wasn't atomic on failure.
- **#183 (doctrine):** Adds a 7-day floor to the audit velocity-anchor date formula. On CI-fast-merge boards `median_pr_duration_days` collapses to ~minutes and the raw formula produced "tomorrow" as the proposed due date for every milestone reshape regardless of remaining work.

Both fixes touched `commands/jared-audit.md`, so the bundle is a tidy combo. Three phase-trail commits per the project's git workflow.

## Why comment-first ordering matters (#184)

If the close ran first and the comment failed, you'd be left with a closed issue and no Session note — exactly the discipline this atom exists to enforce against (the audit and wrap doctrines both treat close-with-comment as one act). Comment-first means a close failure leaves a recoverable state (open issue + stray comment), and the operator retries with `jared close <N>` (no \`--body*\`) to close just the issue. Comments are append-only by GitHub semantics — no silent rollback.

## Surfaces updated

- **CLI** — `skills/jared/scripts/jared`: `--body` / `--body-file` mutex group on close, PII pre-flight on the body, comment-then-close.
- **Tests** — `tests/test_cmd_close.py`: 7 new tests covering ordering, all three body input forms (file / inline / stdin), no-body path (no comment call), mutex rejection, PII short-circuit, and the comment-posts-but-close-fails recovery contract.
- **Audit doctrine** — `commands/jared-audit.md` step 9 (the one-atom shape, doctrine ↔ mechanism now match) and step 7 (#183 floor).
- **Wrap doctrine** — `commands/jared-wrap.md` step 5: collapses the previous two-step post-then-close pattern to one atom for items being closed during the wrap. Items staying open keep using `jared comment`.
- **CLI reference** — `skills/jared/references/jared-cli.md`: documents the new flags, ordering rationale, and PII pre-flight contract.

## Test plan

- [x] \`pytest\` — 466 passed, 1 deselected (integration tests; opt-in)
- [x] \`ruff check .\` — clean
- [x] \`mypy\` strict — clean on 45 source files
- [ ] Live smoke: close #184 itself via \`jared close 184 --body-file <session-note>.md\` — the new flag exercises the new code path on the real issue it filed; verifies AC ("If (B): smoke-verified on at least one live issue")
- [ ] Live smoke (\`#183\`): doctrinal-only change; verified by reading the merged \`commands/jared-audit.md\` step 7 and confirming the floor is applied at the next \`/jared-audit\` run

Closes #184. Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)