### PR TITLE
release: v0.22.1 — GitHub API tool selection investigation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Daniel Brock"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.22.0"
+version = "0.22.1"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## What's changed

**Doctrine**
- GitHub API tool selection — investigation + routing policy. Four-mechanism inventory (gh subcommands / raw REST / graphql / MCP plugin), capability matrix, replicated rate-limit cost attribution, auth deconfliction, per-operation routing recommendation. Establishes that MCP plugin has no ProjectV2 tools (functionally a non-contender for jared's distinctive ops), graphql pressure source is `gh project item-list` (~10 pts/item, can burn the entire hourly bucket on a 500-item board), and the conversational layer has separate doctrine from the CLI (Python can't reach MCP). (#205, investigates #202)

## Backward compatibility

No behavior changes. Docs-only release.

## Validation

Every mechanism invoked at least once against the live `brockamer/jared` projects/4 board, per AC #6 of #202. Small-magnitude calls replicated 3× in a verified-quiet measurement window (graphql freshly reset, other Claude sessions paused, drift verified 0).

## Upgrading

```
/plugin update jared
/reload-plugins
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)