### PR TITLE
perf(batch): migrate capture-context + archive-plan body reads to REST (#208)

### DIFF
--- a/skills/jared/scripts/archive-plan.py
+++ b/skills/jared/scripts/archive-plan.py
@@ -66,7 +66,10 @@ def issue_state(repo: str, number: int) -> tuple[str, str | None]:
 
 
 def fetch_issue_body(repo: str, number: int) -> str:
-    data = board_run_gh(["issue", "view", str(number), "--repo", repo, "--json", "body"])
+    # REST `core` bucket instead of graphql (#208); same pattern as
+    # lib.board.fetch_issue_state_rest. No new wrapper per acceptance criteria —
+    # inline at the call site keeps the seam visible.
+    data = board_run_gh(["api", f"repos/{repo}/issues/{number}"])
     return data.get("body") or ""
 
 

--- a/skills/jared/scripts/capture-context.py
+++ b/skills/jared/scripts/capture-context.py
@@ -54,7 +54,10 @@ SECTION_ORDER = [
 
 
 def fetch_body(repo: str, number: int) -> str:
-    data = board_run_gh(["issue", "view", str(number), "--repo", repo, "--json", "body"])
+    # REST `core` bucket instead of graphql (#208); same pattern as
+    # lib.board.fetch_issue_state_rest. No new wrapper per acceptance criteria —
+    # inline at the call site keeps the seam visible.
+    data = board_run_gh(["api", f"repos/{repo}/issues/{number}"])
     return data.get("body") or ""
 
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1536,7 +1536,7 @@ def test_fetch_recent_closed_prs_with_files_returns_expected_shape(
                 f"expected closed:>= search filter, got {search_value!r}"
             )
             # The date portion after `closed:>=` must be %Y-%m-%d (10 chars: YYYY-MM-DD)
-            date_part = search_value[len("closed:>="):]
+            date_part = search_value[len("closed:>=") :]
             assert len(date_part) == 10 and date_part[4] == "-" and date_part[7] == "-", (
                 f"expected YYYY-MM-DD cutoff, got {date_part!r}"
             )
@@ -1548,9 +1548,7 @@ def test_fetch_recent_closed_prs_with_files_returns_expected_shape(
 
     monkeypatch.setattr(board_mod, "run_gh", fake_run_gh)
 
-    result = board_mod.fetch_recent_closed_prs_with_files(
-        "brockamer/jared", days=7
-    )
+    result = board_mod.fetch_recent_closed_prs_with_files("brockamer/jared", days=7)
     assert result == [
         {"number": 100, "closedAt": "2026-05-20T10:00:00Z", "files": ["src/foo.py", "CLAUDE.md"]},
         {"number": 99, "closedAt": "2026-05-18T10:00:00Z", "files": ["src/bar.py"]},

--- a/tests/test_cmd_audit.py
+++ b/tests/test_cmd_audit.py
@@ -1,4 +1,5 @@
 """Unit tests for /jared-audit — velocity computation + window fetch + CLI."""
+
 from __future__ import annotations
 
 import datetime as dt
@@ -83,12 +84,21 @@ def test_compute_velocity_pr_duration(monkeypatch: pytest.MonkeyPatch) -> None:
     merged_prs = json.dumps(
         [
             # 2 days, 1 day, 4 days → median 2
-            {"number": 100, "createdAt": "2026-05-18T00:00:00Z",
-             "mergedAt": "2026-05-20T00:00:00Z"},
-            {"number": 101, "createdAt": "2026-05-19T00:00:00Z",
-             "mergedAt": "2026-05-20T00:00:00Z"},
-            {"number": 102, "createdAt": "2026-05-15T00:00:00Z",
-             "mergedAt": "2026-05-19T00:00:00Z"},
+            {
+                "number": 100,
+                "createdAt": "2026-05-18T00:00:00Z",
+                "mergedAt": "2026-05-20T00:00:00Z",
+            },
+            {
+                "number": 101,
+                "createdAt": "2026-05-19T00:00:00Z",
+                "mergedAt": "2026-05-20T00:00:00Z",
+            },
+            {
+                "number": 102,
+                "createdAt": "2026-05-15T00:00:00Z",
+                "mergedAt": "2026-05-19T00:00:00Z",
+            },
         ]
     )
     patch_gh_by_arg(
@@ -111,12 +121,30 @@ def test_fetch_audit_window_count_returns_oldest_first(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "old", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 51, "title": "older", "body": "...", "createdAt": "2025-12-15T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 52, "title": "newest", "body": "...", "createdAt": "2026-03-01T00:00:00Z",
-             "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "old",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 51,
+                "title": "older",
+                "body": "...",
+                "createdAt": "2025-12-15T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 52,
+                "title": "newest",
+                "body": "...",
+                "createdAt": "2026-03-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -147,15 +175,30 @@ def test_fetch_audit_window_age_days_filters_by_age(
     now = dt.datetime.now(dt.UTC)
     issues_payload = json.dumps(
         [
-            {"number": 10, "title": "ancient", "body": "...",
-             "createdAt": (now - dt.timedelta(days=120)).isoformat(),
-             "labels": [], "milestone": None},
-            {"number": 11, "title": "stale", "body": "...",
-             "createdAt": (now - dt.timedelta(days=45)).isoformat(),
-             "labels": [], "milestone": None},
-            {"number": 12, "title": "fresh", "body": "...",
-             "createdAt": (now - dt.timedelta(days=5)).isoformat(),
-             "labels": [], "milestone": None},
+            {
+                "number": 10,
+                "title": "ancient",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=120)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 11,
+                "title": "stale",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=45)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 12,
+                "title": "fresh",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=5)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -186,18 +229,31 @@ def test_fetch_audit_window_default_staleness_uses_velocity(
     # Velocity: median age-at-close of 20 → threshold = 2*20 = 40 (within 14..60 band)
     closed_payload = json.dumps(
         [
-            {"number": 1, "createdAt": (now - dt.timedelta(days=20)).isoformat(),
-             "closedAt": now.isoformat()},
+            {
+                "number": 1,
+                "createdAt": (now - dt.timedelta(days=20)).isoformat(),
+                "closedAt": now.isoformat(),
+            },
         ]
     )
     issues_payload = json.dumps(
         [
-            {"number": 10, "title": "older-than-40", "body": "...",
-             "createdAt": (now - dt.timedelta(days=50)).isoformat(),
-             "labels": [], "milestone": None},
-            {"number": 11, "title": "newer-than-40", "body": "...",
-             "createdAt": (now - dt.timedelta(days=30)).isoformat(),
-             "labels": [], "milestone": None},
+            {
+                "number": 10,
+                "title": "older-than-40",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=50)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 11,
+                "title": "newer-than-40",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=30)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -226,12 +282,30 @@ def test_fetch_audit_window_issues_returns_only_listed(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "a", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 51, "title": "b", "body": "...", "createdAt": "2025-12-15T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 52, "title": "c", "body": "...", "createdAt": "2026-03-01T00:00:00Z",
-             "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "a",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 51,
+                "title": "b",
+                "body": "...",
+                "createdAt": "2025-12-15T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 52,
+                "title": "c",
+                "body": "...",
+                "createdAt": "2026-03-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -262,10 +336,22 @@ def test_fetch_audit_window_enriches_open_dependents(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "leaf", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 51, "title": "blocks-leaf", "body": "...",
-             "createdAt": "2026-01-02T00:00:00Z", "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "leaf",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 51,
+                "title": "blocks-leaf",
+                "body": "...",
+                "createdAt": "2026-01-02T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     # GraphQL repo-wide blockedBy edges: #51 is blocked by #50, both open
@@ -316,10 +402,22 @@ def test_fetch_audit_window_milestones_returns_open_milestones(
     write_minimal_board(tmp_path)
     milestones_payload = json.dumps(
         [
-            {"number": 1, "title": "v0.21.0", "due_on": "2026-06-01T00:00:00Z",
-             "open_issues": 5, "closed_issues": 2, "state": "open"},
-            {"number": 2, "title": "v1.0.0", "due_on": None,
-             "open_issues": 12, "closed_issues": 0, "state": "open"},
+            {
+                "number": 1,
+                "title": "v0.21.0",
+                "due_on": "2026-06-01T00:00:00Z",
+                "open_issues": 5,
+                "closed_issues": 2,
+                "state": "open",
+            },
+            {
+                "number": 2,
+                "title": "v1.0.0",
+                "due_on": None,
+                "open_issues": 12,
+                "closed_issues": 0,
+                "state": "open",
+            },
         ]
     )
     patch_gh_by_arg(
@@ -348,8 +446,14 @@ def test_cli_audit_fetch_count_emits_json(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "a", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "a",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -415,9 +415,7 @@ def test_close_with_body_when_close_fails_after_comment_posts(
         f"comment must precede close, got: {kinds}"
     )
     # No item-edit (defense-in-depth Status=Done) should run when close fails.
-    assert "item-edit" not in kinds, (
-        f"item-edit must not run when close fails; kinds={kinds}"
-    )
+    assert "item-edit" not in kinds, f"item-edit must not run when close fails; kinds={kinds}"
     # Comment URL surfaced — the operator knows what landed before the error.
     assert "OK: commented on #42" in captured.out
     assert comment_url in captured.out


### PR DESCRIPTION
## Summary

- `capture-context.py:fetch_body` and `archive-plan.py:fetch_issue_body` now use `gh api repos/<owner>/<repo>/issues/<n>` (REST `core` bucket) instead of `gh issue view --json body` (graphql bucket). Same payload shape — `data["body"]` extracted inline.
- Follows the reference pattern in `lib/board.py:fetch_issue_state_rest` (the #54 / #147 lineage). No new wrapper per #208 acceptance criteria — the seam stays visible at each call site.
- Folded in: ruff format applied to 3 stale test files (`test_board.py`, `test_cmd_audit.py`, `test_cmd_close.py`) that were failing `ruff format --check` on main as of `fde61e9`. Pure formatter expansion, zero behavior change, separate commit.

## Why

Routing recommendation from `docs/github-api-tool-selection.md` § "Full issue-body reads in batch scripts" (#202). Cumulative graphql relief over batch fan-out matters when graphql is the pressured bucket, even though per-call savings are marginal.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean (after stale-file cleanup commit)
- [x] `mypy` strict: 45 source files, no issues
- [x] `pytest -q`: 466 passed
- [x] Smoke: `capture-context.py --issue 208 --repo brockamer/jared --show` succeeds
- [x] Smoke: `archive-plan.py --scan --dry-run --repo brockamer/jared` succeeds
- [x] Direct equivalence check: `gh issue view 208 --json body` and `gh api repos/brockamer/jared/issues/208` return byte-identical body strings (transport-only migration confirmed)

## Notes for reviewer

- The inline migration deliberately skips the ETag/conditional-GET layer that `lib/board.py:fetch_issue_state_rest` wires up via `_fetch_issue_rest_with_etag` (#147). Extending ETag to body reads is a reasonable follow-up but explicitly out of scope here per the "no new wrapper" acceptance criterion. Worth a separate issue if useful.
- Commits are split: `0227b3f` is the actual #208 work (8 lines); `e3688d8` is the unrelated formatter cleanup (204 lines, mechanical).

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)