### PR TITLE
enhancement(diagnostic): mention MCP-token scope in token-scope diagnostic (#210)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -1017,7 +1017,7 @@ def _looks_like_project_mutation(args: list[str]) -> bool:
 
 
 def _format_token_scope_diagnostic() -> str:
-    """Four-part diagnostic block for `Resource not accessible by personal access token`
+    """Diagnostic block for `Resource not accessible by personal access token`
     failures from project mutations. Best-effort — silently skips parts that can't be
     determined.
 
@@ -1025,6 +1025,16 @@ def _format_token_scope_diagnostic() -> str:
     that just failed ran on `gh auth login`'s OAuth session. The realistic remaining
     trigger for this error class is OAuth without `project` scope. Mention the #65
     scrub explicitly so an operator with GH_TOKEN set isn't misled.
+
+    Always appends an MCP note (#210). The GitHub MCP server uses a separate token
+    surface (Claude Code MCP server config), distinct from `gh auth login` and
+    GH_TOKEN. This function is only ever reached from `run_gh_raw`'s failure path —
+    MCP-routed mutations fail inside Claude Code's tool layer and never hit this
+    code. The line is therefore not a detection signal but a UX hint: when the
+    operator is troubleshooting and may also be using MCP, remind them the two
+    auth surfaces are independent so `gh auth refresh -s project` isn't assumed
+    to fix the MCP side. Always-mention is the only viable shape here, since
+    conditional-on-MCP-failure can't be detected from a gh subprocess path.
     """
     lines: list[str] = ["", "Token-scope diagnostic:"]
 
@@ -1044,6 +1054,11 @@ def _format_token_scope_diagnostic() -> str:
 
     lines.append("  Scopes needed: project (write) for project v2 mutations.")
     lines.append("  Suggested fix: gh auth refresh -s project")
+    lines.append(
+        "  MCP note: the GitHub MCP server uses a separate token (Claude Code MCP "
+        "config); its scope requirements are independent of the gh OAuth session "
+        "above, and `gh auth refresh` does not affect it."
+    )
     return "\n".join(lines)
 
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -447,6 +447,53 @@ def test_token_scope_diagnostic_mentions_gh_token_scrub_when_set(
     assert "#65" in str(exc.value)
 
 
+def test_token_scope_diagnostic_includes_mcp_note(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The diagnostic always mentions MCP-token scope as a separate auth surface (#210).
+    MCP-routed mutations never reach this code path (they fail inside Claude Code's tool
+    layer), but operators troubleshooting a gh-OAuth failure may also be using MCP — the
+    line is a UX hint that `gh auth refresh` doesn't fix the MCP side."""
+    from skills.jared.scripts.lib.board import Board, GhInvocationError
+
+    b = Board.from_path(_minimal_board(tmp_path))
+
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "GraphQL: Resource not accessible by personal access token (addProjectV2ItemById)"
+
+    def fake_run(args: list[str], **kw: object) -> FakeResult:
+        if args[:2] == ["gh", "auth"]:
+
+            class AuthResult:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return AuthResult()  # type: ignore[return-value]
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    with pytest.raises(GhInvocationError) as exc:
+        b.run_gh(
+            [
+                "api",
+                "graphql",
+                "-f",
+                'query=mutation { addProjectV2ItemById(input: {projectId: "x", contentId: "y"}) '
+                "{ item { id } } }",
+            ]
+        )
+    msg = str(exc.value)
+    assert "MCP note:" in msg
+    assert "separate token" in msg
+    assert "Claude Code MCP" in msg
+    # The MCP line must not pre-empt the gh fix — gh-OAuth diagnostic stays primary.
+    assert msg.index("Suggested fix: gh auth refresh") < msg.index("MCP note:")
+
+
 def test_find_item_id_finds_match(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     from skills.jared.scripts.lib.board import Board, ItemNotFound
     from tests.conftest import FakeGhResult, graphql_item_response
@@ -1536,7 +1583,7 @@ def test_fetch_recent_closed_prs_with_files_returns_expected_shape(
                 f"expected closed:>= search filter, got {search_value!r}"
             )
             # The date portion after `closed:>=` must be %Y-%m-%d (10 chars: YYYY-MM-DD)
-            date_part = search_value[len("closed:>="):]
+            date_part = search_value[len("closed:>=") :]
             assert len(date_part) == 10 and date_part[4] == "-" and date_part[7] == "-", (
                 f"expected YYYY-MM-DD cutoff, got {date_part!r}"
             )
@@ -1548,9 +1595,7 @@ def test_fetch_recent_closed_prs_with_files_returns_expected_shape(
 
     monkeypatch.setattr(board_mod, "run_gh", fake_run_gh)
 
-    result = board_mod.fetch_recent_closed_prs_with_files(
-        "brockamer/jared", days=7
-    )
+    result = board_mod.fetch_recent_closed_prs_with_files("brockamer/jared", days=7)
     assert result == [
         {"number": 100, "closedAt": "2026-05-20T10:00:00Z", "files": ["src/foo.py", "CLAUDE.md"]},
         {"number": 99, "closedAt": "2026-05-18T10:00:00Z", "files": ["src/bar.py"]},

--- a/tests/test_cmd_audit.py
+++ b/tests/test_cmd_audit.py
@@ -1,4 +1,5 @@
 """Unit tests for /jared-audit — velocity computation + window fetch + CLI."""
+
 from __future__ import annotations
 
 import datetime as dt
@@ -83,12 +84,21 @@ def test_compute_velocity_pr_duration(monkeypatch: pytest.MonkeyPatch) -> None:
     merged_prs = json.dumps(
         [
             # 2 days, 1 day, 4 days → median 2
-            {"number": 100, "createdAt": "2026-05-18T00:00:00Z",
-             "mergedAt": "2026-05-20T00:00:00Z"},
-            {"number": 101, "createdAt": "2026-05-19T00:00:00Z",
-             "mergedAt": "2026-05-20T00:00:00Z"},
-            {"number": 102, "createdAt": "2026-05-15T00:00:00Z",
-             "mergedAt": "2026-05-19T00:00:00Z"},
+            {
+                "number": 100,
+                "createdAt": "2026-05-18T00:00:00Z",
+                "mergedAt": "2026-05-20T00:00:00Z",
+            },
+            {
+                "number": 101,
+                "createdAt": "2026-05-19T00:00:00Z",
+                "mergedAt": "2026-05-20T00:00:00Z",
+            },
+            {
+                "number": 102,
+                "createdAt": "2026-05-15T00:00:00Z",
+                "mergedAt": "2026-05-19T00:00:00Z",
+            },
         ]
     )
     patch_gh_by_arg(
@@ -111,12 +121,30 @@ def test_fetch_audit_window_count_returns_oldest_first(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "old", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 51, "title": "older", "body": "...", "createdAt": "2025-12-15T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 52, "title": "newest", "body": "...", "createdAt": "2026-03-01T00:00:00Z",
-             "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "old",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 51,
+                "title": "older",
+                "body": "...",
+                "createdAt": "2025-12-15T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 52,
+                "title": "newest",
+                "body": "...",
+                "createdAt": "2026-03-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -147,15 +175,30 @@ def test_fetch_audit_window_age_days_filters_by_age(
     now = dt.datetime.now(dt.UTC)
     issues_payload = json.dumps(
         [
-            {"number": 10, "title": "ancient", "body": "...",
-             "createdAt": (now - dt.timedelta(days=120)).isoformat(),
-             "labels": [], "milestone": None},
-            {"number": 11, "title": "stale", "body": "...",
-             "createdAt": (now - dt.timedelta(days=45)).isoformat(),
-             "labels": [], "milestone": None},
-            {"number": 12, "title": "fresh", "body": "...",
-             "createdAt": (now - dt.timedelta(days=5)).isoformat(),
-             "labels": [], "milestone": None},
+            {
+                "number": 10,
+                "title": "ancient",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=120)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 11,
+                "title": "stale",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=45)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 12,
+                "title": "fresh",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=5)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -186,18 +229,31 @@ def test_fetch_audit_window_default_staleness_uses_velocity(
     # Velocity: median age-at-close of 20 → threshold = 2*20 = 40 (within 14..60 band)
     closed_payload = json.dumps(
         [
-            {"number": 1, "createdAt": (now - dt.timedelta(days=20)).isoformat(),
-             "closedAt": now.isoformat()},
+            {
+                "number": 1,
+                "createdAt": (now - dt.timedelta(days=20)).isoformat(),
+                "closedAt": now.isoformat(),
+            },
         ]
     )
     issues_payload = json.dumps(
         [
-            {"number": 10, "title": "older-than-40", "body": "...",
-             "createdAt": (now - dt.timedelta(days=50)).isoformat(),
-             "labels": [], "milestone": None},
-            {"number": 11, "title": "newer-than-40", "body": "...",
-             "createdAt": (now - dt.timedelta(days=30)).isoformat(),
-             "labels": [], "milestone": None},
+            {
+                "number": 10,
+                "title": "older-than-40",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=50)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 11,
+                "title": "newer-than-40",
+                "body": "...",
+                "createdAt": (now - dt.timedelta(days=30)).isoformat(),
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -226,12 +282,30 @@ def test_fetch_audit_window_issues_returns_only_listed(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "a", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 51, "title": "b", "body": "...", "createdAt": "2025-12-15T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 52, "title": "c", "body": "...", "createdAt": "2026-03-01T00:00:00Z",
-             "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "a",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 51,
+                "title": "b",
+                "body": "...",
+                "createdAt": "2025-12-15T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 52,
+                "title": "c",
+                "body": "...",
+                "createdAt": "2026-03-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(
@@ -262,10 +336,22 @@ def test_fetch_audit_window_enriches_open_dependents(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "leaf", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
-            {"number": 51, "title": "blocks-leaf", "body": "...",
-             "createdAt": "2026-01-02T00:00:00Z", "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "leaf",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
+            {
+                "number": 51,
+                "title": "blocks-leaf",
+                "body": "...",
+                "createdAt": "2026-01-02T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     # GraphQL repo-wide blockedBy edges: #51 is blocked by #50, both open
@@ -316,10 +402,22 @@ def test_fetch_audit_window_milestones_returns_open_milestones(
     write_minimal_board(tmp_path)
     milestones_payload = json.dumps(
         [
-            {"number": 1, "title": "v0.21.0", "due_on": "2026-06-01T00:00:00Z",
-             "open_issues": 5, "closed_issues": 2, "state": "open"},
-            {"number": 2, "title": "v1.0.0", "due_on": None,
-             "open_issues": 12, "closed_issues": 0, "state": "open"},
+            {
+                "number": 1,
+                "title": "v0.21.0",
+                "due_on": "2026-06-01T00:00:00Z",
+                "open_issues": 5,
+                "closed_issues": 2,
+                "state": "open",
+            },
+            {
+                "number": 2,
+                "title": "v1.0.0",
+                "due_on": None,
+                "open_issues": 12,
+                "closed_issues": 0,
+                "state": "open",
+            },
         ]
     )
     patch_gh_by_arg(
@@ -348,8 +446,14 @@ def test_cli_audit_fetch_count_emits_json(
     write_minimal_board(tmp_path)
     issues_payload = json.dumps(
         [
-            {"number": 50, "title": "a", "body": "...", "createdAt": "2026-01-01T00:00:00Z",
-             "labels": [], "milestone": None},
+            {
+                "number": 50,
+                "title": "a",
+                "body": "...",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "labels": [],
+                "milestone": None,
+            },
         ]
     )
     patch_gh_by_arg(

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -415,9 +415,7 @@ def test_close_with_body_when_close_fails_after_comment_posts(
         f"comment must precede close, got: {kinds}"
     )
     # No item-edit (defense-in-depth Status=Done) should run when close fails.
-    assert "item-edit" not in kinds, (
-        f"item-edit must not run when close fails; kinds={kinds}"
-    )
+    assert "item-edit" not in kinds, f"item-edit must not run when close fails; kinds={kinds}"
     # Comment URL surfaced — the operator knows what landed before the error.
     assert "OK: commented on #42" in captured.out
     assert comment_url in captured.out


### PR DESCRIPTION
## Summary

- `_format_token_scope_diagnostic` now always appends an MCP note as a fifth line, explaining that the GitHub MCP server uses a separate token surface (Claude Code MCP config) and that `gh auth refresh -s project` does not affect it.
- Ordering preserved: actionable gh fix appears before the MCP UX hint, so an operator triaging the actual gh failure reads the fix first.
- Folded in: same pre-existing ruff-format cleanup as PR #212, idempotent across merge order.

## Design tension resolution

The issue body framed this as a choice between "conditional-on-MCP-failure detection" and "always-mention." Investigation revealed the function is reached only from `run_gh_raw`'s failure path — MCP-routed mutations fail inside Claude Code's tool layer and never hit `lib/board.py` at all. So conditional-mention isn't actually a viable design from this subprocess; the line is fundamentally a UX hint to the operator's mental model, not a detection result.

Always-mention was the only viable shape. Documented in the function docstring with the reasoning.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean (after stale-file cleanup commit)
- [x] `mypy` strict: 45 source files, no issues
- [x] `pytest -q`: 467 passed (one new test added)
- [x] New test `test_token_scope_diagnostic_includes_mcp_note` asserts the MCP line appears AND that ordering puts `Suggested fix:` before `MCP note:`
- [x] Manually rendered the diagnostic to confirm prose reads cleanly:
  ```
  Token-scope diagnostic:
    Token source used: gh auth login OAuth session (jared scrubs GH_TOKEN/GITHUB_TOKEN before invoking gh — see #65).
    Scopes present: 'admin:public_key', 'gist', 'project', 'read:org', 'repo'
    Scopes needed: project (write) for project v2 mutations.
    Suggested fix: gh auth refresh -s project
    MCP note: the GitHub MCP server uses a separate token (Claude Code MCP config); its scope requirements are independent of the gh OAuth session above, and `gh auth refresh` does not affect it.
  ```

## Notes for reviewer

- Commits split: `93cd995` is the actual #210 work + test; `7ec64e9` is the formatter cleanup (same as PR #212's `e3688d8`). Either PR merging first absorbs the formatter change cleanly.
- Diagnostic block is now 5–6 lines depending on whether `_probe_oauth_scopes` returns a value. Operator-facing diagnostics that bloat past 6-7 lines stop being scannable — worth a future watchpoint.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)