### PR TITLE
fix(board): accept bold-wrapped refs in plan ## Issue section list items

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -1173,7 +1173,8 @@ _PLAN_ISSUE_REF_RE = re.compile(
 # only if it's either:
 #   1. a bare line-start ref (`#229 — Metric Layer C.0`, no list marker), or
 #   2. a list item (`- ...`/`* ...`) whose first content is a ref, optionally
-#      preceded by a `PR ` / `Issue ` label (e.g. `- PR #415`).
+#      preceded by a `PR ` / `Issue ` label (e.g. `- PR #415`) and/or wrapped
+#      in bold around the ref token (e.g. `- **#622** — short desc`).
 #
 # Mid-line refs in narrative prose are deliberately ignored — they are the
 # source of #86/#87 false positives. The label is gated behind a list marker
@@ -1181,6 +1182,7 @@ _PLAN_ISSUE_REF_RE = re.compile(
 _PLAN_LINE_REF_RE = re.compile(
     r"^[\s]*"
     r"(?:[-*]\s+(?:(?:PR|Issue)\s+)?)?"  # optional list marker + optional PR/Issue label
+    r"(?:\*\*)?"  # optional bold-open around the ref token (`- **#N**` form)
     r"(?:\[)?"  # optional opening of a markdown link `[#N](...)`
     r"(?:https?://github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d+)"
     r"|(?:[\w.-]+/[\w.-]+)?#(\d+))",

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -168,6 +168,47 @@ def test_parse_referenced_issues_accepts_bare_line_at_column_zero() -> None:
     assert ap.parse_referenced_issues(text) == [229, 230]
 
 
+def test_parse_referenced_issues_accepts_bold_ref_in_list_item() -> None:
+    """#204 — `- **#N** — desc` is a common human-readable form for spec
+    Issue sections. Two findajob specs used this in the 2026-05-22 grooming
+    pass and archive-plan refused to archive them. The carrier position
+    (list marker + bold) is still anchored at line start — mid-line bold
+    refs in prose remain skipped (see negative tests below).
+    """
+    text = (
+        "# Plan\n\n## Issues\n\n"
+        "- **#622** — Investigate cost gate\n"
+        "- **#650** — operator controls\n\n"
+        "## Body\n"
+    )
+    assert ap.parse_referenced_issues(text) == [622, 650]
+
+
+def test_parse_referenced_issues_bold_form_url_variant() -> None:
+    """The bold wrapper accepted at the carrier position also tolerates the
+    URL form inside it. Not strictly required by #204's AC but consistent
+    with how the regex composes."""
+    text = "# Plan\n\n## Issue\n\n- **https://github.com/o/r/issues/42** — desc\n\n## Body\n"
+    assert ap.parse_referenced_issues(text) == [42]
+
+
+def test_parse_referenced_issues_bold_form_does_not_match_mid_line_prose() -> None:
+    """#204 AC negative case — bold refs that aren't at the carrier position
+    (e.g. inside a prose paragraph between bullets and the next heading)
+    must still be skipped. The carrier-position anchoring via `re.match`
+    plus the limited prefix slots is what prevents prose recapture; this
+    test guards that boundary explicitly.
+    """
+    text = (
+        "# Plan\n\n## Issue\n\n"
+        "- #408\n"
+        "- #310\n\n"
+        "As noted in **#42**, this needs follow-up; see also **PR #100**.\n\n"
+        "## Body\n"
+    )
+    assert ap.parse_referenced_issues(text) == [408, 310]
+
+
 def test_parse_shipped_section_returns_pr_numbers() -> None:
     """The `## Shipped` section is the same shape as `## Issue` — list-item
     refs whose meaningful content starts with `#NNN` or a URL.


### PR DESCRIPTION
## Summary

Closes #204.

`_PLAN_LINE_REF_RE` refused list items with bold-wrapped refs (`- **#622** — short desc`), even at the line-start carrier position. Two findajob specs hit this in the 2026-05-22 grooming pass — `archive-plan.py --plan <foo>` skipped them with "no ## Issue section" despite the section being present.

The fix adds one optional `(?:\*\*)?` slot to the regex between the list-marker and the markdown-link `[` slot. The carrier-position anchoring via \`re.match\` is unchanged, so mid-line bold refs in prose remain skipped — preserved by an explicit negative test. \`parse_shipped_section\` benefits from the same change (uses the same regex via \`_parse_plan_section\`).

## Test plan

- [x] New test: `- **#N** — desc` returns `[N]`
- [x] New test: bold-wrapped URL variant in list item
- [x] New negative test: bold refs in prose paragraphs between bullets and the next heading remain skipped
- [x] All existing `parse_referenced_issues` / `parse_shipped_section` tests still pass (28 prior + 3 new = 31 in test_archive_plan.py; 469 total passed)
- [x] \`ruff check .\` — clean
- [x] \`mypy\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)