### PR TITLE
docs(install): document file:// install dev-artifact leakage + cleanup recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,43 @@ For the full contributor setup — Python venv with `uv`, `ruff`,
 `mypy`, the dual-import-path gotcha around the `Board` helper, and the
 testbed configuration — see [`CLAUDE.md`](CLAUDE.md).
 
+### Disk usage for the `file://` install
+
+The `file://` install copies your working tree literally — it does
+**not** honor `.gitignore`. So `.venv/`, `.mypy_cache/`,
+`.pytest_cache/`, `.ruff_cache/`, `jared.egg-info/`, and `tmp/` all
+end up in the install cache alongside the ~1M runtime payload.
+Per-version breakdown on a typical dev checkout:
+
+| Path                  | Size  | Runtime?           |
+|-----------------------|-------|--------------------|
+| `.venv/`              | ~92M  | No (dev tooling)   |
+| `.mypy_cache/`        | ~6.5M | No                 |
+| `docs/`               | ~3.2M | No (source docs)   |
+| `tests/`              | ~1.7M | No                 |
+| Other dev artifacts   | ~1.5M | No                 |
+| **Runtime payload**   | **~1M**   | **Yes**            |
+| **Total per version** | **~105M** |                    |
+
+Each `/plugin update jared` cycle adds another ~105M version to the
+cache. To reclaim disk:
+
+```bash
+rm -rf ~/.claude/plugins/cache/jared-marketplace/jared/
+```
+
+That nukes every cached jared version but leaves other plugins
+untouched. After the wipe, `/plugin update jared` (or a fresh
+`/plugin install jared`) re-creates the current version's cache from
+your working tree — nothing breaks, you've just traded a stack of old
+versions for one fresh ~105M install.
+
+The public install path (`/plugin marketplace add brockamer/jared`)
+clones from GitHub, so it doesn't see your local dev artifacts and
+naturally lands at ~7.3M per version. **This wart is `file://`-only**,
+and a more principled fix would be an upstream plugin-install
+exclusion mechanism — tracked in [#218](https://github.com/brockamer/jared/issues/218).
+
 [pm]: https://code.claude.com/docs/en/plugin-marketplaces.md
 
 ## Testing


### PR DESCRIPTION
## Summary

Closes #198. Carved #218 as a follow-up to track the upstream Claude Code feature request (plugin-install exclusion mechanism, the principled long-term fix).

The `file://` plugin install copies the working tree literally — `.gitignore` is not consulted, so `.venv/` and dev caches land in the install cache alongside the runtime payload. Each `/plugin update jared` cycle adds ~105M; my local cache is currently 1.4G of stacked versions.

Per the issue's "Smart-tier: before committing to a fix path" prescription, I called \`advisor()\` against the three AC options:

- **(a)** docs + cleanup recipe — shipping in this PR
- **(b)** restructure dev to keep `.venv` outside the install root — rejected: forces non-standard venv locations on every contributor for a problem that's "my disk has 1.2G of caches"
- **(c)** Claude Code feature request — split into #218 (don't depend on upstream timing for #198 to close)

## What changed

One new subsection under "Developing" in `README.md`:

- Root cause one-liner (`file://` = literal copy, ignores `.gitignore`)
- Per-component size breakdown table (~92M `.venv`, ~6.5M `.mypy_cache`, … vs ~1M runtime)
- Cleanup recipe: \`rm -rf ~/.claude/plugins/cache/jared-marketplace/jared/\` (path scope verified — `jared-marketplace/` contains only `jared/` on this machine, so the wipe is contained)
- Note that the GitHub-clone install path is naturally lean (~7.3M, no dev artifacts) — this wart is `file://`-only
- Pointer to #218 for the upstream fix

## AC interpretation flag

The body's third AC reads: *"Fresh `file://` install of a clean checkout (no .venv, no caches) verified to produce a cache directory under 5MB."*

That outcome is achievable only on path (b) (restructure dev) or after path (c) ships upstream. Path (a) does not meet it as written. **Interpreting the AC as**: "fresh install + documented cleanup recipe = manageable contributor disk usage, with the 5MB-clean-tree target deferred to #218."

If you disagree with that interpretation, push back and I'll reopen #198 or carve a separate path-(b) issue.

## Verification

- Path scope verified: `ls ~/.claude/plugins/cache/jared-marketplace/` returns only `jared/` — recipe is contained
- Survey of official marketplace cache: zero installed plugins (superpowers, claude-md-management, code-simplifier, …) ship dev artifacts; convention is "keep them out of the source root by hand"
- \`ruff check .\` clean, \`mypy\` clean (no code changed; ran anyway)

## Test plan

- [ ] Operator action — run the cleanup recipe locally; verify `/plugin update jared` re-creates the cache cleanly from a working tree
- [ ] Operator action — sanity-check the README diff renders the table correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)