### PR TITLE
docs(board): backfill ## Jared config section into jared/jared's own project-board doc

### DIFF
--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -166,3 +166,13 @@ This file is the minimum. See the skill's references for:
 - `references/board-sweep.md` — grooming checklist
 - `references/plan-spec-integration.md` — if this project uses plan/spec artifacts
 - `references/session-continuity.md` — Session note format
+
+## Jared config
+
+Project-level knobs that change Jared's behavior on this board. Each bullet is `name: value`. Omit any line to use its default.
+
+- `session-handoff-prompt: ask` — when `/jared-wrap` finishes, ask whether to draft a session handoff prompt for the next session. Values: `ask` (default), `always`, `never`. Used by `/jared-wrap`. The prompt is written to `tmp/next-session-prompt-<TIMESTAMP>.md` and is `.gitignore`d — ephemeral by design.
+
+- `model-guidance: enabled` — controls whether new issues carry a `## Model & execution guidance` section (file-time composition) and whether `/jared-start` evaluates missing guidance lazily (start-time backstop). Values: `enabled` (default), `disabled`. Used by `/jared-file` and `/jared-start`. See SKILL.md § "Model & execution guidance" for the rendered shape.
+
+- `voice: enabled` — controls whether the Jared character voice is rendered in slash-command dialogue (`/jared`, `/jared-start`, `/jared-wrap`, etc.). Values: `enabled` (default), `disabled`. When `disabled`, every slash-command stub renders user-facing output in plain technical prose — same structural content, Jared-isms stripped. Used by every slash-command stub. The voice activation lives entirely in the plugin (no user-local Claude Code settings, no SessionStart hooks, no memory entries required); this bullet is the only way to opt out. See SKILL.md § "Project-level kill switch" (under the voice doctrine) and `references/voice.md` for the full spec.


### PR DESCRIPTION
## Summary

- Backfills the `## Jared config` section into this repo's own `docs/project-board.md` — the convention was introduced in v0.19.0 (model-guidance) and extended in v0.22.0 (voice), but jared/jared's project-board doc predated both and lacked the section entirely.
- Verbatim copy from `assets/project-board.md.template` lines 121–129: intro paragraph plus all three current bullets (`session-handoff-prompt`, `model-guidance`, `voice`).
- Optional `### Current-state operator docs` subsection and `## Session start checks` section intentionally omitted — opting into those features is out of scope for this dogfood backfill.

## Behavior

No behavior change. All three knobs are at their default values — this is discoverability + dogfood-completeness only. Jared's own kill-switch parsers tolerate-and-default when the section is absent, so present-with-defaults is a no-op.

## Test plan

- [x] `pytest -q` — 470 passed, 1 deselected (integration)
- [x] `jared summary` parses docs/project-board.md cleanly with the new section appended
- [x] Visual inspection — section sits at file tail with consistent blank-line spacing

closes #203