### PR TITLE
fix(sweep): replace content.state filters with Project Status — counter and 7 related sites

### DIFF
--- a/skills/jared/references/board-sweep.md
+++ b/skills/jared/references/board-sweep.md
@@ -168,6 +168,12 @@ Approve? (y / cherry-pick / skip)
 
 Wait for sign-off before bulk changes. The sweep is advisory.
 
+## Item-level semantics — "open" means Project status, not GitHub state
+
+The sweep's "Open items on board: N" preamble counts items where the **Project board `status` is not `Done`** — not items where the underlying GitHub issue's `state` is `OPEN`. The two signals usually agree but can diverge (e.g., when the "Item closed → Done" workflow is off, or when the #156-family revert leaves a closed issue with Status≠Done). Sweep is a Project-board audit tool, so the Project-board signal is authoritative for its purposes.
+
+This matters because `gh project item-list --format json` does not populate `content.state` — only the top-level `status` field is reliable across both fetch paths (`Board.open_items()` GraphQL warm path and `gh project item-list` cold path). Filters on `content.state` silently return wrong values on the cold path. See #189.
+
 ## When the sweep finds nothing
 
 Say so. "Swept, all clear" is a valid outcome and the user trusts you more for reporting it honestly than for inventing findings.

--- a/skills/jared/references/board-sweep.md
+++ b/skills/jared/references/board-sweep.md
@@ -170,9 +170,9 @@ Wait for sign-off before bulk changes. The sweep is advisory.
 
 ## Item-level semantics — "open" means Project status, not GitHub state
 
-The sweep's "Open items on board: N" preamble counts items where the **Project board `status` is not `Done`** — not items where the underlying GitHub issue's `state` is `OPEN`. The two signals usually agree but can diverge (e.g., when the "Item closed → Done" workflow is off, or when the #156-family revert leaves a closed issue with Status≠Done). Sweep is a Project-board audit tool, so the Project-board signal is authoritative for its purposes.
+All sweep filters that distinguish open from closed items rely on the **Project board `status`** field (`status == "Done"` for closed), not the GitHub issue `state` field. The two signals usually agree but can diverge (e.g., when the "Item closed → Done" workflow is off, or when the #156-family revert leaves a closed issue with Status≠Done). Sweep is a Project-board audit tool, so the Project-board signal is authoritative.
 
-This matters because `gh project item-list --format json` does not populate `content.state` — only the top-level `status` field is reliable across both fetch paths (`Board.open_items()` GraphQL warm path and `gh project item-list` cold path). Filters on `content.state` silently return wrong values on the cold path. See #189.
+This matters because `gh project item-list --format json` does not populate `content.state` — the field is absent from every item in the cold-path response. Only the top-level `status` field is reliable across both fetch paths (`Board.open_items()` GraphQL warm path and `fetch_items()` cold path via `gh project item-list`). The single exception is `check_native_dependencies`, which inspects `blockedBy` edges from a GraphQL query that does populate `state` — that one site correctly uses `state == "CLOSED"`. See #189.
 
 ## When the sweep finds nothing
 

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -297,14 +297,15 @@ def check_metadata(items: list[dict[str, Any]]) -> list[str]:
     work_stream_in_use = any(
         field(i, "work Stream", "workStream", "workstream")
         for i in items
-        if (i.get("content") or {}).get("state") != "CLOSED"
+        if i.get("status") != "Done"
     )
     missing = []
     for i in items:
         content = i.get("content") or {}
-        # gh project item-list sometimes returns content.state == None for closed
-        # items, so also skip anything the board has already moved to Done.
-        if content.get("state") == "CLOSED" or i.get("status") == "Done":
+        # Skip Done items — no point enforcing metadata on a closed item.
+        # `gh project item-list --format json` does not populate
+        # `content.state`, so filter on the reliable top-level Project Status.
+        if i.get("status") == "Done":
             continue
         n = content.get("number")
         prio = field(i, "priority")
@@ -366,7 +367,7 @@ def check_stale_high_backlog(
     stale = []
     for i in items:
         content = i.get("content") or {}
-        if content.get("state") == "CLOSED":
+        if i.get("status") == "Done":
             continue
         if i.get("status") != "Backlog":
             continue
@@ -393,7 +394,7 @@ def check_in_progress_staleness(
     stale = []
     for i in items:
         content = i.get("content") or {}
-        if content.get("state") == "CLOSED":
+        if i.get("status") == "Done":
             continue
         if i.get("status") != "In Progress":
             continue
@@ -475,8 +476,8 @@ def check_off_board_issues(
 
     Caller passes `issues_by_number` already filtered to repo-open
     issues (see `fetch_open_issues_bulk` which uses `--state open`).
-    A board item with content.state=CLOSED still counts as "on the
-    board" — that's a different drift handled by `check_closed_not_done`.
+    A board item with Status=Done still counts as "on the board" —
+    that's a different drift handled by `check_closed_not_done`.
     """
     on_board = {
         (i.get("content") or {}).get("number")
@@ -564,7 +565,7 @@ def check_session_note_freshness(
     in_progress_numbers: list[int] = []
     for i in items:
         content = i.get("content") or {}
-        if content.get("state") == "CLOSED":
+        if i.get("status") == "Done":
             continue
         if i.get("status") != "In Progress":
             continue

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -213,9 +213,13 @@ def fetch_items_with_closed_cache(board: Board, owner: str, project: str) -> lis
                 return merge_open_with_closed(open_items, cached_closed)
     # Cold-cache fallback: full-board pull (truncation-guarded). Warm the
     # closed-cache from the result so subsequent sweeps take the warm path.
+    # Filter on top-level `status` rather than `content.state`: `gh project
+    # item-list --format json` does not populate `content.state`, so the
+    # earlier `state == "CLOSED"` check was a no-op and the cache never
+    # warmed. `status` is populated by both fetch paths.
     items = fetch_items(owner, project)
     if not no_cache:
-        closed_subset = [i for i in items if (i.get("content") or {}).get("state") == "CLOSED"]
+        closed_subset = [i for i in items if i.get("status") == "Done"]
         board_cache.set_closed_items(project_number=board.project_number, items=closed_subset)
     return items
 
@@ -757,7 +761,11 @@ def main() -> int:
         except (RuntimeError, GhInvocationError) as e:
             print(f"sweep: issue fetch failed: {e}", file=sys.stderr)
 
-    total_open = sum(1 for i in items if (i.get("content") or {}).get("state") != "CLOSED")
+    # Filter on top-level `status` rather than `content.state`: `gh project
+    # item-list --format json` does not populate `content.state`, so the
+    # earlier `state != "CLOSED"` filter was a no-op and the counter equalled
+    # total board size. See #189.
+    total_open = sum(1 for i in items if i.get("status") != "Done")
     print(f"Open items on board: {total_open}")
     if repo:
         print(f"Open issues in {repo}: {len(issues_by_number)}")

--- a/tests/test_sweep_checks.py
+++ b/tests/test_sweep_checks.py
@@ -755,13 +755,15 @@ def test_fetch_items_with_closed_cache_cold_miss_warms_cache(
     full_items = [
         {"content": {"number": 70, "state": "OPEN"}, "status": "In Progress"},
         {"content": {"number": 80, "state": "CLOSED"}, "status": "Done"},
-        {"content": {"number": 81, "state": "CLOSED"}, "status": "In Progress"},
+        {"content": {"number": 81, "state": "CLOSED"}, "status": "Done"},
     ]
     patch_gh(monkeypatch, stdout=json.dumps({"items": full_items}))
 
     items = sweep.fetch_items_with_closed_cache(board, "brockamer", "7")
     assert len(items) == 3
-    # Cache was warmed from the CLOSED subset only — opens go to next live pull.
+    # Cache was warmed from the Done subset only — opens go to next live pull.
+    # (#189: filter on top-level `status`, not `content.state` — the latter
+    # is not populated by `gh project item-list`.)
     warmed = cache.get_closed_items(project_number=7, cache_dir=cache_dir)
     assert warmed is not None
     warmed_numbers: list[int] = sorted(
@@ -872,3 +874,68 @@ def test_fetch_items_with_closed_cache_respects_jared_no_cache(
     # Should reflect the fresh full-pull, not the (ignored) stale closed-cache.
     numbers = [(i.get("content") or {}).get("number") for i in items]
     assert numbers == [1]
+
+
+# ---------- Regression: realistic `gh project item-list` shape (#189) ----------
+
+
+def test_fetch_items_with_closed_cache_filters_by_status_on_realistic_shape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression for #189. `gh project item-list --format json` does NOT
+    populate `content.state` — only top-level `status` is reliable across
+    the cold path. The closed_subset filter must use `status == "Done"`,
+    not `content.state == "CLOSED"`. Fixture uses the realistic shape:
+    content carries body/number/title/url but no `state` key, and `status`
+    sits at the top level of each item.
+    """
+    import os
+
+    from skills.jared.scripts.lib import cache
+    from skills.jared.scripts.lib.board import Board
+
+    sweep = import_sweep()
+
+    cache_dir = Path(os.environ["JARED_CACHE_DIR"])
+    assert cache.get_closed_items(project_number=7, cache_dir=cache_dir) is None
+
+    board_md = tmp_path / "docs" / "project-board.md"
+    board_md.parent.mkdir(parents=True)
+    board_md.write_text(
+        dedent("""\
+        - Project URL: https://github.com/users/brockamer/projects/7
+        - Project number: 7
+        - Project ID: PVT_kwHO_xyz
+        - Owner: brockamer
+        - Repo: brockamer/findajob
+    """)
+    )
+    board = Board.from_path(board_md)
+
+    # Realistic shape: no `content.state` key, `status` at top level.
+    realistic_items = [
+        {"content": {"number": 10, "title": "T10"}, "status": "Backlog"},
+        {"content": {"number": 11, "title": "T11"}, "status": "In Progress"},
+        {"content": {"number": 20, "title": "T20"}, "status": "Done"},
+        {"content": {"number": 21, "title": "T21"}, "status": "Done"},
+    ]
+    patch_gh(monkeypatch, stdout=json.dumps({"items": realistic_items}))
+
+    items = sweep.fetch_items_with_closed_cache(board, "brockamer", "7")
+    assert len(items) == 4
+
+    # The pre-fix filter (`content.state == "CLOSED"`) would warm an empty
+    # cache because `content.state` is absent from every realistic item.
+    # The fix filters on top-level `status` so only the two Done items are
+    # cached.
+    warmed = cache.get_closed_items(project_number=7, cache_dir=cache_dir)
+    assert warmed is not None
+    warmed_numbers: list[int] = sorted(
+        n for i in warmed if isinstance(n := (i.get("content") or {}).get("number"), int)
+    )
+    assert warmed_numbers == [20, 21]
+
+    # Counter math derived from the same fixture: items with status != Done.
+    # This is the "Open items on board: N" preamble logic in main().
+    total_open = sum(1 for i in realistic_items if i.get("status") != "Done")
+    assert total_open == 2  # #10 Backlog + #11 In Progress; #20 / #21 Done are excluded


### PR DESCRIPTION
## Summary

- Fixes #189 — the `Open items on board: N` counter at `sweep.py:760` was a silent no-op because `gh project item-list --format json` does not populate `content.state`, so the filter `state != "CLOSED"` evaluated `None != "CLOSED"` → True for every item, making the counter equal total board size.
- Empirically on project #4: counter pre-fix read 117 (total); post-fix reads 20 (= 18 Backlog + 2 In Progress, matches `gh project item-list` ground truth filtered by `status != "Done"`).
- Replaces the same broken `content.state`-based filter across all 7 related sites in `sweep.py` with `Project Status`-based filters (`status == "Done"` / `status != "Done"`), which is reliable across both fetch paths (`Board.open_items()` warm GraphQL path and `fetch_items()` cold `gh` path).
- One site **intentionally left as-is**: `check_native_dependencies` (line 452) inspects `blockedBy` edges from a GraphQL query that directly selects `state`. Status-based filtering would be wrong there — the question is GitHub-issue-closed, not Project-Done.

## Why it shipped despite test coverage

Existing fixtures populated `content.state` in synthetic items (`"state": "OPEN"`, `"state": "CLOSED"`), but the real `gh project item-list` output omits `content.state` entirely. The tests passed while production was broken because the fixtures invented a field that the live API doesn't return.

This PR adds a regression test that uses the **realistic** `gh` shape (no `content.state`, only top-level `status`) so the same bug shape will be caught immediately if it ever recurs. The broader lying-fixture cleanup across existing test files is the narrowed remaining scope of #223.

## Phasing

Two commits, preserving the phase trail per project convention:
- **Phase 1** (`614dde0`): the targeted #189 fix — counter at line 760 + the structurally-identical `closed_subset` filter at line 218 (same root cause, splitting would leave the closed cache permanently empty post-#186). New regression test. `references/board-sweep.md` semantics note.
- **Phase 2** (`ce236e5`): the broader sweep across the remaining 5 code sites + 1 narrative docstring update + expanded `board-sweep.md` note. Triggered by maintainer scope expansion mid-PR after the phase-1 narrow fix.

## Behavior change

- **Visible:** `Open items on board: N` now reflects actual open count (Status ≠ Done), not total board size.
- **Invisible-in-the-output but real:** every sweep check now correctly excludes Done items even on the cold path. Previously they were leaking through because `state == "CLOSED"` was a cold-path no-op.
- **Performance:** `fetch_items_with_closed_cache` will now actually warm the closed cache (it never did post-#186 because the seeding filter matched nothing). Future sweeps on mature boards take the warm path, which was #186's design intent.

## Files changed

- `skills/jared/scripts/sweep.py` — 8 sites updated (5 active filters, 1 docstring, 2 from phase 1 already)
- `skills/jared/references/board-sweep.md` — new "Item-level semantics" subsection
- `tests/test_sweep_checks.py` — new realistic-shape regression test; one existing fixture adjusted to remain consistent with the new filter (item #81 in cold-miss test)

## Test plan

- [x] `pytest -q` — 471 passed (was 470 + 1 new), 1 deselected
- [x] `ruff check` / `ruff format --check` / `mypy --strict` — all clean
- [x] Empirical: `sweep.py` against project #4 reports `Open items on board: 20`, matches `gh project item-list` ground truth
- [x] No false flags in any sweep check section (Metadata, WIP, Stale, etc.)

## Related

- #223 — follow-up issue filed during the phase-1 investigation. Its first two ACs (call-site audit + per-site fixes) are now satisfied by this PR; only the lying-fixture cleanup remains as #223's narrowed scope. Will update #223 after merge.
- #186 — closed-cache merge path. This PR is what makes #186's optimization actually trigger on mature boards.
- #156 — Status revert family. The state-vs-status divergence this PR codifies is the same gap #156 documented from a different angle.

closes #189