### PR TITLE
fix(stage): bullet-style error restates <details> wrapper requirement

### DIFF
--- a/skills/jared/scripts/stage.py
+++ b/skills/jared/scripts/stage.py
@@ -218,7 +218,8 @@ def not_pullable_reason(item: dict[str, Any]) -> str:
     if _ACCEPTANCE_SECTION.search(body):
         return (
             "not pullable — acceptance section has no `-`-prefixed bullets "
-            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
+            "(numbered list, prose, or `- Criterion N` placeholders all fail); "
+            "keep the `<details><summary>Expand</summary>` wrapper around the bullets"
         )
 
     if _ACCEPTANCE_HEADING_ANY.search(body):

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -184,7 +184,8 @@ class TestNotPullableReason:
         assert (
             stage.not_pullable_reason(item)
             == "not pullable — acceptance section has no `-`-prefixed bullets "
-            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
+            "(numbered list, prose, or `- Criterion N` placeholders all fail); "
+            "keep the `<details><summary>Expand</summary>` wrapper around the bullets"
         )
 
     def test_numbered_list_bullets_fail(self) -> None:
@@ -204,7 +205,8 @@ class TestNotPullableReason:
         assert (
             stage.not_pullable_reason(item)
             == "not pullable — acceptance section has no `-`-prefixed bullets "
-            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
+            "(numbered list, prose, or `- Criterion N` placeholders all fail); "
+            "keep the `<details><summary>Expand</summary>` wrapper around the bullets"
         )
 
     def test_prose_only_acceptance_fails(self) -> None:
@@ -223,8 +225,30 @@ class TestNotPullableReason:
         assert (
             stage.not_pullable_reason(item)
             == "not pullable — acceptance section has no `-`-prefixed bullets "
-            "(numbered list, prose, or `- Criterion N` placeholders all fail)"
+            "(numbered list, prose, or `- Criterion N` placeholders all fail); "
+            "keep the `<details><summary>Expand</summary>` wrapper around the bullets"
         )
+
+    def test_bullet_style_message_restates_wrapper_requirement(self) -> None:
+        """#195: when bullets are wrong-style but the `<details>` wrapper is
+        present, the error message must explicitly restate that the wrapper
+        should be preserved. Otherwise a fixer reading only this message
+        could drop the wrapper while fixing the bullets, landing in the
+        non-canonical-wrapper-missing failure mode on the next stage."""
+        stage = import_stage()
+        item = {
+            "body": (
+                "Real summary.\n\n"
+                "## Acceptance criteria\n\n"
+                "<details>\n<summary>Expand</summary>\n\n"
+                "1. First criterion\n"
+                "2. Second criterion\n\n"
+                "</details>"
+            )
+        }
+        reason = stage.not_pullable_reason(item)
+        assert "<details><summary>Expand</summary>" in reason
+        assert "wrapper" in reason
 
     def test_non_canonical_heading_short_form(self) -> None:
         """`## Acceptance` (no `criteria` suffix), no <details> wrapper."""


### PR DESCRIPTION
## Summary

- Fixes #195. `not_pullable_reason()` had two messages for malformed acceptance sections that each described a different failure mode but didn't agree on the canonical target shape. A fixer triaging message 1 (wrong bullet style) could land in message 2 (wrapper missing) on the next pass without ever seeing the canonical shape — wording-only regression, but real.
- Repro on findajob #219/#228/#230/#231 reshape pass (2026-05-22). Caught only by a re-stage; without the re-run the bodies would have shipped broken.
- Fix: append the canonical-shape hint to message 1 so both messages converge on `<details><summary>Expand</summary>` + `-`-prefixed bullets. Message 2 unchanged.

## Files

- `skills/jared/scripts/stage.py` — one error message extended by one clause
- `tests/test_stage.py` — three existing equality assertions updated; one new substring test for the wrapper-preservation hint

## Test plan

- [x] `pytest -q` — 472 passed (was 471 + 1 new), 1 deselected
- [x] `ruff check` / `ruff format --check` — clean
- [x] Test-driven: new `test_bullet_style_message_restates_wrapper_requirement` checks the hint phrase is present
- [x] No behavior change to message 2 (wrapper-missing path)

closes #195