### PR TITLE
chore(docs): archive multi-session-shape spec (#232 shipped)

### DIFF
--- a/docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-shape.md
+++ b/docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-shape.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #232 on 2026-05-23. Final decisions captured in issue body.**
+---
+
 # Spec: multi-session — stage/start/git hygiene for parallel Claude sessions
 
 **Issue:** #232


### PR DESCRIPTION
## Summary

- Archives `docs/superpowers/specs/2026-05-23-multi-session-shape.md` to `archived/2026-05/` — the only issue it referenced (#232) shipped in PR #234.
- Surfaced by `/jared-groom` on 2026-05-23. `archive-plan.py` performed the move and updated #232's `## Planning` section.

## Test plan

- [x] Sweep confirms zero plan/spec drift remaining
- [x] Archive lives at the conventional `archived/<YYYY-MM>/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)