### PR TITLE
feat(file): require --milestone or --no-milestone (#238)

### DIFF
--- a/skills/jared/references/jared-cli.md
+++ b/skills/jared/references/jared-cli.md
@@ -164,7 +164,7 @@ cat session-note.md | jared comment <issue_number> --body-file -
 
 ---
 
-## `jared file --title ... (--body ... | --body-file ...) --priority ...`
+## `jared file --title ... (--body ... | --body-file ...) --priority ... (--milestone NAME | --no-milestone)`
 
 **Purpose.** Atomic create-issue + add-to-board + set-Priority + set-Status
 + post-create verification. Kills the `gh issue create` / `gh project
@@ -178,10 +178,12 @@ jared file \
   --priority High \
   --status "Up Next" \
   --label enhancement \
-  --field "Work Stream=Planning"
+  --field "Work Stream=Planning" \
+  --milestone "v1.0 — public install"
 
-# Or inline body, parity with `gh issue create --body`:
-jared file --title "Quick fix" --body "One-line summary of the bug." --priority Low
+# Or inline body + explicit no-milestone for big-idea/wishlist filings:
+jared file --title "Quick fix" --body "One-line summary of the bug." \
+  --priority Low --no-milestone
 ```
 
 **Arguments:**
@@ -191,9 +193,16 @@ jared file --title "Quick fix" --body "One-line summary of the bug." --priority 
 | `--title` | yes | Issue title; keep ≤ 70 chars, verb-first. |
 | `--body` / `--body-file` | yes (exactly one) | `--body "<text>"` for inline content; `--body-file <path>` for a markdown file; `--body-file -` reads stdin. Mutually exclusive. |
 | `--priority {High,Medium,Low}` | yes | Enforced to avoid filing with null Priority. |
+| `--milestone NAME` / `--no-milestone` | yes (exactly one) | Either assign a milestone by title (validated against the repo's open milestones) or opt out explicitly. Filing without either flag is refused with a listing of open milestones — closes the orphan-issue stream that eight consecutive findajob structural reviews had to bulk-absorb. Mutually exclusive. |
 | `--status` | no | Any Status column. Default: `Backlog`. |
 | `--label` | no | Repeatable. |
 | `--field` | no | Repeatable `NAME=VALUE` for additional single-select fields (e.g. `Work Stream=Planning`). |
+
+**Milestone resolution.** `--milestone NAME` is matched by exact title
+against `gh api repos/<owner>/<repo>/milestones?state=open`. An unmatched
+name produces a clear error listing the open milestones — no silent
+fallback, no auto-create. Use `--no-milestone` for filings where assignment
+doesn't make sense yet (wishlist, big-idea items).
 
 **Invariant.** On success, stdout reports `OK: filed #N → <status>,
 Priority=<prio>` and the URL. Any step failing — board add fails, verification

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -182,6 +182,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="NAME=VALUE for additional single-select fields "
         '(e.g. "Work Stream=Planning"). Repeatable.',
     )
+    # --milestone NAME / --no-milestone — exactly one must be supplied (#238).
+    # Enforcement lives in _cmd_file (not the argparse group's required=True)
+    # so we can produce a listing of open milestones in the error path; argparse's
+    # default message would just say "one of the arguments is required" without
+    # the listing. The mutually-exclusive group still prevents both at once.
+    file_milestone = file_p.add_mutually_exclusive_group(required=False)
+    file_milestone.add_argument(
+        "--milestone",
+        help='Open milestone title to assign (e.g. "v1.0 — public install"). '
+        "Validated against repo's open milestones; unmatched names are refused.",
+    )
+    file_milestone.add_argument(
+        "--no-milestone",
+        action="store_true",
+        help="Explicit opt-out: file without a milestone (wishlist/big-idea items).",
+    )
     file_p.set_defaults(func=_cmd_file)
 
     add_p = sub.add_parser(
@@ -407,6 +423,57 @@ def _cmd_file(args: argparse.Namespace) -> int:
         board.option_id(name, value)
         extra_specs.append((name, value))
 
+    # Milestone resolution (#238). Every filing must declare intent: either
+    # --milestone NAME (validated against open milestones) or --no-milestone
+    # (explicit opt-out). Missing both → refuse with a listing. Eight
+    # consecutive findajob structural reviews bulk-absorbed orphan filings
+    # before this gate landed; making the omission impossible at the source
+    # is cheaper than catching it in every sweep.
+    milestone_title: str | None = None
+    if not args.no_milestone:
+        milestones = board.run_gh(
+            ["api", f"repos/{board.repo}/milestones", "-f", "state=open", "-f", "per_page=100"]
+        )
+        # Defensive: REST returns a list; an empty/missing payload is treated
+        # as "no open milestones" rather than crashing on attribute access.
+        open_titles = [
+            m.get("title", "") for m in (milestones if isinstance(milestones, list) else [])
+        ]
+        if args.milestone is None:
+            print(
+                "error: --milestone NAME or --no-milestone is required (see #238).",
+                file=sys.stderr,
+            )
+            if open_titles:
+                print("  open milestones on this board:", file=sys.stderr)
+                for t in open_titles:
+                    print(f"    - {t}", file=sys.stderr)
+                print(
+                    '  pass --milestone "<title>" to assign, or --no-milestone to opt out.',
+                    file=sys.stderr,
+                )
+            else:
+                print("  no open milestones on this board.", file=sys.stderr)
+                print(
+                    f"  create one via `gh api repos/{board.repo}/milestones -f title=...` "
+                    "or pass --no-milestone to opt out.",
+                    file=sys.stderr,
+                )
+            return 2
+        if args.milestone not in open_titles:
+            print(
+                f"error: --milestone {args.milestone!r} does not match any open milestone.",
+                file=sys.stderr,
+            )
+            if open_titles:
+                print("  open milestones on this board:", file=sys.stderr)
+                for t in open_titles:
+                    print(f"    - {t}", file=sys.stderr)
+            else:
+                print("  no open milestones on this board.", file=sys.stderr)
+            return 2
+        milestone_title = args.milestone
+
     # Resolve body before any gh call: inline --body, --body-file path, or
     # --body-file - (stdin). gh issue create still wants a path, so we round-
     # trip through a temp file. Single resolution seam keeps #97's redactor
@@ -455,6 +522,8 @@ def _cmd_file(args: argparse.Namespace) -> int:
     ]
     for label in args.label or []:
         create_args.extend(["--label", label])
+    if milestone_title is not None:
+        create_args.extend(["--milestone", milestone_title])
     # Preserve the staged temp file on any create-step failure so the user can
     # retry without re-typing the body. #100: closes the fallback loop where
     # an opaque `jared file` failure → Claude shells out to plain `gh issue

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -1,3 +1,4 @@
+import json as _json
 import subprocess as _subprocess
 from io import StringIO
 from pathlib import Path
@@ -100,6 +101,7 @@ def test_file_sequences_create_add_status_priority(
             str(body_file),
             "--priority",
             "High",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -148,6 +150,7 @@ def test_file_with_custom_status_and_extra_field(
             "Up Next",
             "--field",
             "Work Stream=Planning",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -207,6 +210,7 @@ def test_file_preserves_staged_body_on_create_failure(
             inline_body,
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -265,6 +269,7 @@ def test_file_unlinks_staged_body_on_success(
             "OK body",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -318,6 +323,7 @@ def test_file_inline_body_staging_round_trip_mismatch_errors(
             "Real body content that will not survive the round-trip.",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -385,6 +391,7 @@ def test_file_emits_recovery_command_on_post_create_failure(
             "Up Next",
             "--field",
             "Work Stream=Planning",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -453,6 +460,7 @@ def test_file_emits_recovery_command_on_field_mutation_failure(
             str(body_file),
             "--priority",
             "Medium",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -522,6 +530,7 @@ def test_file_with_inline_body(
             "## Hello\n\nLiteral inline markdown.",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -549,6 +558,7 @@ def test_file_with_body_file_dash_stdin(
             "-",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -580,6 +590,7 @@ def test_file_rejects_both_body_and_body_file(
                 str(body_file),
                 "--priority",
                 "Low",
+                "--no-milestone",
             ]
         )
     assert excinfo.value.code != 0
@@ -615,6 +626,7 @@ def test_file_rejects_body_prefix_abbrev(
                 "hello world",
                 "--priority",
                 "Low",
+                "--no-milestone",
             ]
         )
     assert excinfo.value.code != 0
@@ -666,6 +678,7 @@ def test_file_makes_no_item_list_calls(
             str(body_file),
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
 
@@ -733,6 +746,7 @@ def test_cmd_file_refuses_on_dirty_pre_flight_report(
             f"While testing I noticed {leaky_phrase} stops responding under load.",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -771,6 +785,7 @@ def test_cmd_file_proceeds_on_clean_pre_flight_report(
             "Wholly unrelated body about the public weather service.",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -812,6 +827,7 @@ def test_cmd_file_clean_when_no_claude_local(
             "Some content with no special meaning.",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -855,6 +871,7 @@ def test_cmd_file_refuses_when_run_from_subdir(
             f"Note: {leaky_phrase} is flaky.",
             "--priority",
             "Low",
+            "--no-milestone",
         ]
     )
     captured = capsys.readouterr()
@@ -862,4 +879,261 @@ def test_cmd_file_refuses_when_run_from_subdir(
     assert "pre-flight redaction check failed" in captured.err
     assert not any("issue" in c and "create" in c for c in calls), (
         f"redactor must short-circuit before gh; calls: {calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# --milestone / --no-milestone enforcement (#238)
+#
+# Every issue filed via `jared file` must declare its milestone intent — either
+# `--milestone NAME` (validated against the repo's open milestones) or
+# `--no-milestone` (explicit opt-out). Filing with neither flag is refused
+# with a listing of open milestones. This closes the orphan-issue stream that
+# eight consecutive findajob structural reviews (Decisions 17, 19, 22, 23, 24,
+# 27, 28, 29) had to absorb as bulk-fix work.
+# ---------------------------------------------------------------------------
+
+
+def _open_milestones_json(titles: list[str]) -> str:
+    """Mock body for `gh api repos/<owner>/<repo>/milestones?state=open`.
+
+    GitHub returns a top-level JSON list; we synthesize the minimum shape
+    `_cmd_file` needs (title + number). Real responses include more fields
+    but the milestone lookup only cares about title-match.
+    """
+    return _json.dumps(
+        [{"title": t, "number": i + 1, "state": "open"} for i, t in enumerate(titles)]
+    )
+
+
+def _routed_fake_with_milestones(
+    monkeypatch: pytest.MonkeyPatch,
+    open_milestones: list[str],
+    *,
+    verify_number: int = 42,
+) -> list[list[str]]:
+    """Like `_routed_fake` but also routes the milestone-list REST lookup.
+
+    The `gh api repos/.../milestones` call is matched by substring 'milestones'
+    in argv (it appears in the path); response shape is the list-form
+    `_open_milestones_json` produces.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        calls.append(args)
+        joined = " ".join(args)
+        if "milestones" in joined and "api" in joined:
+            return FakeGhResult(stdout=_open_milestones_json(open_milestones))
+        if "issue create" in joined:
+            return FakeGhResult(
+                stdout=f"https://github.com/brockamer/findajob/issues/{verify_number}\n"
+            )
+        if "item-add" in joined:
+            return FakeGhResult(stdout='{"id": "PVTI_new"}')
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        fake_run,
+    )
+    return calls
+
+
+def test_file_with_milestone_assigns_via_gh_create(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Happy path: `--milestone "v1.0 — public install"` looks up open milestones,
+    finds a title match, and passes `--milestone "<title>"` to `gh issue create`.
+
+    The title-match strategy (vs. number-resolution) keeps the surface small —
+    gh accepts the title directly, so we don't need to translate to a milestone
+    number, just validate it exists in the open set first.
+    """
+    board_md = _write_full_board(tmp_path)
+    target = "v1.0 — public install"
+    calls = _routed_fake_with_milestones(monkeypatch, [target, "v1.1 — first public showcase"])
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "Body.",
+            "--priority",
+            "Medium",
+            "--milestone",
+            target,
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+
+    # Milestone lookup happened (single REST call).
+    milestone_lookups = [c for c in calls if "milestones" in " ".join(c) and "api" in c]
+    assert len(milestone_lookups) == 1, (
+        f"expected exactly one milestone lookup; got {len(milestone_lookups)}: {milestone_lookups}"
+    )
+
+    # gh issue create was invoked with --milestone "<title>".
+    create_calls = [c for c in calls if "issue" in c and "create" in c]
+    assert len(create_calls) == 1, f"expected one issue create; got {create_calls}"
+    create_argv = create_calls[0]
+    assert "--milestone" in create_argv, (
+        f"--milestone must be passed to gh issue create; argv: {create_argv}"
+    )
+    idx = create_argv.index("--milestone")
+    assert create_argv[idx + 1] == target, (
+        f"milestone title must be passed verbatim; got {create_argv[idx + 1]!r}"
+    )
+
+
+def test_file_with_no_milestone_skips_lookup_and_create_without_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--no-milestone` is the explicit opt-out path: no REST lookup, no
+    --milestone argv to gh. Mostly serves wishlist/big-idea filings where
+    milestone assignment doesn't make sense yet.
+
+    The 'skips lookup' assertion matters because the lookup costs one REST
+    call per filing; the opt-out path must be free."""
+    board_md = _write_full_board(tmp_path)
+    # Pass open_milestones so that *if* the lookup fired despite --no-milestone,
+    # the call would route to the milestones branch (not return {}); the
+    # assertion below would catch it either way.
+    calls = _routed_fake_with_milestones(monkeypatch, ["v1.0 — public install"])
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "Body.",
+            "--priority",
+            "Low",
+            "--no-milestone",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+
+    # No milestone lookup should have happened.
+    milestone_lookups = [c for c in calls if "milestones" in " ".join(c) and "api" in c]
+    assert milestone_lookups == [], (
+        f"--no-milestone must skip the milestone REST lookup; got {milestone_lookups}"
+    )
+
+    # gh issue create must NOT have been passed --milestone.
+    create_calls = [c for c in calls if "issue" in c and "create" in c]
+    assert len(create_calls) == 1
+    assert "--milestone" not in create_calls[0], (
+        f"--no-milestone must not pass --milestone to gh; argv: {create_calls[0]}"
+    )
+
+
+def test_file_rejects_neither_milestone_flag_with_listing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Filing without --milestone or --no-milestone is refused with a stderr
+    message that lists the open milestones on the board.
+
+    The whole point of the issue (Option a — enforce at file time): make the
+    omission impossible at the source instead of catching it in every
+    subsequent structural review. The listing in stderr keeps the recovery
+    one paste-back away.
+    """
+    board_md = _write_full_board(tmp_path)
+    open_titles = ["v1.0 — public install", "v1.1 — first public showcase"]
+    calls = _routed_fake_with_milestones(monkeypatch, open_titles)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "Body.",
+            "--priority",
+            "Low",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    # Non-zero exit so callers know the filing did not complete.
+    assert rc != 0, captured.err
+
+    # Both open milestones must appear in the listing.
+    for title in open_titles:
+        assert title in captured.err, (
+            f"open milestone {title!r} must be listed in stderr; got:\n{captured.err}"
+        )
+
+    # The error must signpost both flags so the user knows the two valid recoveries.
+    assert "--milestone" in captured.err, captured.err
+    assert "--no-milestone" in captured.err, captured.err
+
+    # Critical: gh issue create must NOT have been invoked. Refusal happens
+    # before any write. (The milestone lookup itself is allowed; it's a read.)
+    assert not any("issue" in c and "create" in c for c in calls), (
+        f"refusal must short-circuit before gh issue create; calls: {calls}"
+    )
+
+
+def test_file_rejects_unmatched_milestone_with_listing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--milestone "Nonexistent"` is refused with a clear error that names the
+    requested title and lists the open milestones the user could have meant.
+
+    No silent fallback (would land an orphan), no auto-create (silently
+    creating milestones from typos is worse than failing loudly).
+    """
+    board_md = _write_full_board(tmp_path)
+    open_titles = ["v1.0 — public install", "v1.1 — first public showcase"]
+    calls = _routed_fake_with_milestones(monkeypatch, open_titles)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "Body.",
+            "--priority",
+            "Low",
+            "--milestone",
+            "Nonexistent v9.9",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc != 0, captured.err
+
+    # The requested-but-unmatched name appears in the error so the user can
+    # spot the typo immediately.
+    assert "Nonexistent v9.9" in captured.err, captured.err
+
+    # Every open milestone is listed so the user can pick from them.
+    for title in open_titles:
+        assert title in captured.err, (
+            f"open milestone {title!r} must be listed; got:\n{captured.err}"
+        )
+
+    # No silent fallback: gh issue create must not have been invoked.
+    assert not any("issue" in c and "create" in c for c in calls), (
+        f"unmatched milestone must short-circuit; calls: {calls}"
     )


### PR DESCRIPTION
## Summary

Closes #238. `jared file` now requires every filing to declare milestone intent explicitly — either `--milestone "<title>"` (validated against the repo's open milestones) or `--no-milestone` (explicit opt-out). Filing with neither flag is refused with a stderr listing of the open milestones and both flag names in the recovery message.

This stops the orphan stream at the source: eight consecutive findajob structural reviews (Decisions 17, 19, 22, 23, 24, 27, 28, 29) bulk-absorbed CLI-filed orphans, with Decision 29 alone catching 9 such filings inside ~24 hours.

## Implementation

- `file_p` subparser gains a mutually-exclusive group: `--milestone NAME` / `--no-milestone`. The group is `required=False` at the argparse level so that `_cmd_file` can produce the listing-shaped error itself — argparse's default `one of arguments is required` message would lose the listing.
- `_cmd_file` resolves milestones via `gh api repos/<owner>/<repo>/milestones?state=open&per_page=100` (one REST call per filing on the assign or no-flag paths; zero calls on `--no-milestone`).
- Unmatched-name and missing-flag error paths both produce the open-milestones listing; an empty-milestones board produces a separate message pointing at `gh api ... -f title=...` or `--no-milestone`.
- `gh issue create --milestone "<title>"` is appended to the create args when assigning; gh accepts the title directly, so no number translation is needed.

## Test plan

- [x] TDD: four failing tests up front in tests/test_cmd_file.py (assign-by-name, no-milestone opt-out, missing-flag listing, unmatched-name listing). All four pass after impl.
- [x] All 14 existing jared file tests updated to include --no-milestone (the contract change is intentional; this is the point of the issue).
- [x] pytest: 476 passed, 1 deselected (integration tests opt-in, unchanged).
- [x] ruff check clean.
- [x] ruff format --check clean.
- [x] mypy clean (Success: no issues found in 45 source files).

## Out of scope (per issue body)

- Auto-assigning to a default "active anchor" milestone — would require a notion of "active anchor" that lives outside the CLI.
- Backfilling existing orphans — covered by routine sweep absorption.

Generated with Claude Code (https://claude.com/claude-code).