### PR TITLE
docs(doctrine): consolidate memory→doctrine, add parallel-sessions reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,23 @@ docs/bake-sites.md        Projects (beyond jared/jared-testbed) where jared runs
 
 Use `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared <subcommand>`. **Never hardcode `~/.claude/skills/...` paths** — the plugin cache location is an implementation detail of Claude Code's install system.
 
+## Evolving Jared's discipline
+
+When adding a new Jared rule (kill switch, project-level toggle, body-shape convention, naming rule), default to **doctrine** — SKILL.md, slash-command stubs, or a `references/` doc. Claude reads the doc when composing or evaluating and follows the rule.
+
+Reach for Python parsing in `lib/board.py` **only when a CLI surface gates on the value programmatically.** If no subcommand refuses, accepts, or branches based on the field, parsing it creates dead code: the field exists, the test passes, and nothing reads it. The #114 model-guidance feature shipped a parsed field with a four-case unit test in Phase 4 that Phase 6 reverted — the consumers were slash-command surfaces that read the doc directly.
+
+Corollary: when investigation (audit, bake test, code review, sweep, reshape) produces findings, default to NOT filing follow-up issues. See `skills/jared/SKILL.md` § "Discovered scope" for the discipline.
+
+## Branch + PR workflow
+
+Main is protected — every substantive change lands via a PR (`gh pr create` → `gh pr merge --merge --delete-branch`). Direct `git push origin main` is reserved for post-merge hotfixes or release-tag pushes the operator explicitly requested.
+
+- **Feature branches** are disposable and pre-authorized. Pattern: `feature/<issue>-<slug>` (or `chore/...`, `fix/...`). WIP-style commits are fine — the PR is the review surface.
+- **Phase-numbered commits.** When implementing from a plan with explicit phases, prefix commits with `(Phase N.M)`: e.g., `feat(jared): wire next-session-prompt CLI (Phase 3.2)`. Preserves the phase trail when squashing isn't used.
+- **Merge strategy is `--merge`, not squash or rebase.** Preserves the phase-by-phase commit trail on main — git archaeology depends on it (e.g., v0.2.0's merge commit walks back through 33 phase commits).
+- **Parallel sessions must use git worktrees**, not `git checkout -b` in the shared repo — the shared `.git/HEAD` is the trap. See `skills/jared/references/parallel-sessions.md`.
+
 ## Versioning
 
 Semantic versioning in `.claude-plugin/plugin.json` and mirrored in `pyproject.toml`. Git tag `v<x.y.z>` per release. `pyproject.toml` configures dev tooling and pins venv deps but isn't published as a package — the version field exists for parity, not distribution. Check `.claude-plugin/plugin.json` for the current version rather than relying on this paragraph (which used to hardcode it).

--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -44,6 +44,8 @@ Flow:
    - Any plan or spec linked from `## Planning` — read and summarize
    - Git state: current branch, uncommitted changes, last 5 commits touching related files
 
+   **Drift check (issues filed >7d ago).** When the body cites specific file paths, function names, or call sites, verify they still exist before acting — refactors silently invalidate filed plans. Surface any drift in the announce as a "Drift since filing" note so the operator decides between refile / update body / accept-and-call-out.
+
 6. **Model guidance backstop.** Scan the issue body for an `## Model & execution guidance` H2.
 
    - If present: load it as part of context; surface its content in step 8's announce so the user can confirm or amend.

--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -155,6 +155,8 @@ Before writing code, editing docs, or making any change with durable effect, con
 
 Move the item to In Progress. WIP caps at the project's configured limit (default: 3). If the cap is hit, the user decides what moves out or pauses — Jared does not silently exceed WIP.
 
+**Cross-session check.** If In Progress shows another `session-N` label that isn't yours, that's another Claude session actively touching code in this repo — check file-surface overlap before pulling adjacent work. See `references/parallel-sessions.md` for the worktree pattern and surface-overlap discipline.
+
 Before writing code, load the full context for this issue:
 
 - Issue body (including `## Current state` and `## Decisions` sections)
@@ -169,6 +171,8 @@ Announce the plan for the session in a short preamble. This primes you *and* cre
 Two kinds of things happen mid-work, and both need to land somewhere:
 
 **Discovered scope.** You notice tech debt, a missing feature, a gap in documentation, or anything actionable beyond the current issue's boundary. File it immediately as a new issue (see "Before substantive work"). Do not park it in a comment on the current issue. Do not inflate the current issue's scope. Do not write a TODO.
+
+**Post-investigation findings — different reflex.** When an investigation pass (bake test, audit, code review, sweep, structural reshape) *produces* a list of findings, the discipline above inverts: default to NOT filing. The writeup is the durable artifact; tracked issues are for work that actually gates. For each finding, ask: would a real user file this themselves? If not, fold it into the writeup and skip the issue. Sprawl from reflexive post-investigation filings is more expensive than the gaps that go un-tracked — every future sweep/audit/groom touches the issue, and that cost has to be paid back by either fixing it or carrying it productively.
 
 **Evolving understanding.** Design decisions made while implementing, gotchas discovered, assumptions that turned out to be wrong, sub-items intentionally deferred. This is the content that otherwise disappears. It goes on the *current* issue in structured form:
 

--- a/skills/jared/references/operations.md
+++ b/skills/jared/references/operations.md
@@ -85,6 +85,8 @@ When the graphql bucket is pressured (`graphql_budget()` reports < 1000 remainin
 
 When graphql is healthy, either path is fine; the choice becomes a UX call (gh's CLI conventions vs MCP's typed-tool ergonomics). ProjectV2 operations stay on graphql via `jared` regardless — there is no MCP alternative.
 
+**Rate-limit recovery — direct REST for comments and edits.** When GraphQL is exhausted (0/5000 remaining), `gh issue comment` itself fails with "GraphQL: API rate limit already exceeded" — `gh` does a GraphQL preflight to resolve the issue → node ID even though the POST is REST. Fallback: post directly via `gh api -X POST /repos/<owner>/<repo>/issues/<N>/comments --input -` with a `{"body": "..."}` payload. The same pattern applies to `gh issue edit --milestone <name>` (broken by the same preflight); use `gh api PATCH /repos/<o>/<r>/issues/<N> -f milestone=<n>` direct. When GraphQL is dry but REST is healthy, the REST endpoint is the escape hatch.
+
 Full investigation, capability matrix, per-call costs, and auth-surface details: [`docs/github-api-tool-selection.md`](../../../docs/github-api-tool-selection.md).
 
 ## Raw `gh` fallback — the minimum escape-hatch set

--- a/skills/jared/references/parallel-sessions.md
+++ b/skills/jared/references/parallel-sessions.md
@@ -1,0 +1,76 @@
+# Parallel sessions — coordination, label semantics, worktree pattern
+
+When two Claude Code sessions work concurrently in the same Jared-stewarded
+repo, the board is the coordination surface and the worktree is the
+isolation surface. Both are required — neither alone is sufficient.
+
+## The `session-N` label is a durable claim
+
+When the board shows an issue In Progress with a `session-N` label (N = 1,
+2, …), that label means session N is actively touching that code right now.
+The label outlives the conversation; it's the durable claim that survives
+the next session-start.
+
+**Before pulling a new issue:**
+
+1. Scan In Progress for items labeled `session-M` where M ≠ your session
+   number.
+2. For each, check whether its surface (the files / functions / dependencies
+   it modifies) overlaps your candidate's surface.
+3. **Soft conflict** (same file, different functions, well-separated): note
+   it, proceed if safe, plan to rebase if the other lands first.
+4. **Hard conflict** (same function, same imports, shared helpers): stop,
+   surface options to the operator, defer the decision.
+
+Labels run both ways. Your own work should carry your `session-N` label so
+the other session sees you. Unlabeled In Progress work is invisible to the
+coordination discipline — flag the gap rather than silently grabbing
+adjacent items.
+
+## The worktree pattern — never checkout-b in a shared repo
+
+`git checkout -b <new-branch>` in a shared checkout moves the shared
+`.git/HEAD`. The other session's next `git status` will report the wrong
+branch, and a commit from either side risks stealing the other's WIP.
+
+**Correct pattern:**
+
+```bash
+git fetch origin
+git worktree add ~/Code/<repo>-<issue> -b feature/<issue>-<slug> origin/main
+cd ~/Code/<repo>-<issue>
+```
+
+Each session gets its own working directory with its own HEAD while sharing
+`.git`. After the PR merges:
+
+```bash
+git worktree remove ~/Code/<repo>-<issue>
+git branch -d feature/<issue>-<slug>
+```
+
+Each worktree needs its own `.venv` — `uv sync` or `uv pip install -e .`
+inside the new worktree before running tests.
+
+## Triggers for the worktree default
+
+- Operator explicitly says "the other session is working #X, you start #Y."
+- The board shows a `session-N` label that's not yours on an In Progress
+  item.
+- You spot a `feature/<issue>-...` branch you didn't create on the current
+  checkout (likely the other session's WIP).
+
+## Don't
+
+- `git checkout -b` in the shared checkout when another session is active.
+- Stash, commit, or `git checkout --` over a dirty working tree another
+  session is driving.
+- Pull from another session's `session-N` queue silently — the label is the
+  durable claim.
+
+## When in doubt
+
+Surface the conflict to the operator. The cost of pausing to ask is low;
+the cost of clobbering the other session's branch is high. Cross-session
+coordination is the one place where defaulting to *more communication* is
+the right move — see `references/voice.md` for the surfacing style.


### PR DESCRIPTION
## Summary

Surfaced via the #177 doctrine audit (2026-05-23 session): 8 memory entries
were doing the work of doctrine, 3 multi-session memories spanning jared +
findajob duplicated each other, and a couple of doctrine surfaces were
genuinely missing. This PR is the doctrine half of the consolidation.

The memory half (11 file deletions in `~/.claude/projects/.../memory/`)
happens in user space, not tracked here.

## What changes

**New reference** — `skills/jared/references/parallel-sessions.md` (78 lines):
session-N label semantics, surface-overlap check, worktree pattern.
Synthesizes three memory entries that were independently rediscovering the
same multi-session discipline. The natural doctrine fold from #232's spec.

**SKILL.md additions** (4 lines):
- "Discovered scope" gains a paragraph on post-investigation findings —
  default to NOT filing when an investigation pass produces a finding-list.
- "When starting work" gains a cross-session-check pointer to the new
  reference.

**commands/jared-start.md step 5** (2 lines): drift-check sentence for
issues filed >7d ago — verify paths/symbols cited in the body still exist
before acting. Doctrine only; no automated check filed as feature work.

**references/operations.md** (2 lines): rate-limit recovery section.
`gh issue comment` and `gh issue edit --milestone` use GraphQL preflight
even though the underlying mutation is REST. Direct REST endpoints
(`gh api -X POST .../comments`, `gh api PATCH .../issues/N`) are the
escape hatch when GraphQL is exhausted. Surfaced live in the #177 session.

**CLAUDE.md** (17 lines, two new sections):
- "Evolving Jared's discipline" — doctrine-first when adding rules; Python
  parsing in `lib/board.py` only when a CLI surface gates on the value.
  References the #114 Phase 4→6 add+revert as the failure-mode case.
- "Branch + PR workflow" — main lands via PR, feature/* pre-authorized,
  phase-numbered commits, --merge strategy, worktrees for parallel
  sessions.

## Net scope

25 lines added across 4 existing files + 1 new 78-line reference. Modest by
design — the discipline that produced this PR (default to NOT adding
doctrine) was applied to the doctrine consolidation itself.

## Test plan

- [ ] No code changes — markdown only. ruff / mypy / pytest unaffected.
- [ ] Cross-references resolve: `skills/jared/references/parallel-sessions.md`
      is referenced from SKILL.md, CLAUDE.md, and itself references voice.md.
- [ ] Operator sanity check: does the consolidated doctrine read as a
      coherent set of rules for an external installer?

🤖 Generated with [Claude Code](https://claude.com/claude-code)