### PR TITLE
feat(caps): raise default WIP caps to 8 Up Next / 4 In Progress

### DIFF
--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -153,7 +153,7 @@ Before writing code, editing docs, or making any change with durable effect, con
 
 ### When starting work — move to In Progress, load context
 
-Move the item to In Progress. WIP caps at the project's configured limit (default: 3). If the cap is hit, the user decides what moves out or pauses — Jared does not silently exceed WIP.
+Move the item to In Progress. WIP caps at the project's configured limit (default: 4). If the cap is hit, the user decides what moves out or pauses — Jared does not silently exceed WIP.
 
 **Cross-session check.** If In Progress shows another `session-N` label that isn't yours, that's another Claude session actively touching code in this repo — check file-surface overlap before pulling adjacent work. See `references/parallel-sessions.md` for the worktree pattern and surface-overlap discipline.
 
@@ -262,7 +262,7 @@ See `references/session-continuity.md` for details.
 
 ## WIP, blocked, pullable — the lean core
 
-**WIP limits.** In Progress caps at the project's configured limit (default 3). Up Next caps at 3 — more than that is overstocking, since only the top gets pulled anyway.
+**WIP limits.** In Progress caps at the project's configured limit (default 4). Up Next caps at 8 — more than that is overstocking, since only the top gets pulled anyway.
 
 **Blocked is a state, not a vibe.** When an issue is blocked, it gets the `blocked` label AND a `## Blocked by` section in the body naming the blocker and the owner of unblocking. Blocked items stay in their current column but visually flag. "Waiting for so-and-so" without an owner and a specific expected outcome is not blocked, it's abandoned.
 

--- a/skills/jared/scripts/stage.py
+++ b/skills/jared/scripts/stage.py
@@ -329,7 +329,7 @@ def _count_status(items: list[dict[str, Any]], status: str) -> int:
 def stage_proposals(
     items: list[dict[str, Any]],
     *,
-    up_next_cap: int = 3,
+    up_next_cap: int = 8,
     today: date,
 ) -> StageProposals:
     """Compute one /jared-stage evaluation pass over the given items.
@@ -453,8 +453,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--up-next-cap",
         type=int,
-        default=3,
-        help="Maximum items allowed in Up Next column (default: 3).",
+        default=8,
+        help="Maximum items allowed in Up Next column (default: 8).",
     )
     args = parser.parse_args(argv)
 

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -28,7 +28,7 @@ Usage:
   sweep.py --owner X --project N       # explicit owner/project
   sweep.py --repo owner/repo           # explicit repo for issue-level queries
   sweep.py --plan-dir path             # plan/spec directory (default: docs/superpowers/plans)
-  sweep.py --wip-limit N               # override WIP limit (default: 3)
+  sweep.py --wip-limit N               # override WIP limit (default: 4)
   sweep.py --staleness-days N          # aging threshold for High Backlog (default: 14)
 
 Output: prose findings, grouped by check. Exit 0 regardless of findings.
@@ -350,7 +350,7 @@ def check_wip(items: list[dict[str, Any]], limit: int) -> list[str]:
     return findings
 
 
-def check_up_next_size(items: list[dict[str, Any]], limit: int = 3) -> list[str]:
+def check_up_next_size(items: list[dict[str, Any]], limit: int = 8) -> list[str]:
     up_next = [i for i in items if i.get("status") == "Up Next"]
     if len(up_next) > limit:
         return [
@@ -665,7 +665,7 @@ def main() -> int:
         help="Plan/spec directory to scan (can pass multiple times). "
         "Default: docs/superpowers/plans and docs/superpowers/specs if they exist.",
     )
-    parser.add_argument("--wip-limit", type=int, default=3, help="In Progress cap")
+    parser.add_argument("--wip-limit", type=int, default=4, help="In Progress cap")
     parser.add_argument("--staleness-days", type=int, default=14, help="High Backlog age threshold")
     parser.add_argument(
         "--blocked-aging-days",


### PR DESCRIPTION
## Summary
- `stage.py` `--up-next-cap` default `3 → 8`
- `sweep.py` `--wip-limit` default `3 → 4`; `check_up_next_size()` default `3 → 8`
- `SKILL.md` updated to describe the new defaults

Operator-set limits matching findajob's `docs/maintainers/project-board.md` doctrine (synced in https://github.com/brockamer/findajob/commit/09f04f0). Projects that prefer the older 3/3 shape can pass `--up-next-cap 3` and `--wip-limit 3` explicitly.

## Test plan
- [x] `/jared-stage` (no flags) on findajob fills Up Next to 8 instead of 3
- [x] `sweep.py` (no flags) treats `In Progress > 4` as out-of-cap and `Up Next > 8` as overstocked
- [ ] Manual smoke on a non-findajob project would re-verify portability, but operator has no other active jared-managed boards

🤖 Generated with [Claude Code](https://claude.com/claude-code)