### PR TITLE
docs(install): document stale GH_TOKEN env-var confusion in README prereqs (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,15 @@ Archive? [Y/n] y
 
     Without `project` scope, board mutations fail silently or with
     confusing 404s.
+- **Heads up — stale `GH_TOKEN` / `GITHUB_TOKEN`.** If either env var
+  is exported from another tool (a CI helper, an old script, whatever),
+  `gh auth status` will show a confusing split: a *failed* token-auth
+  line **and** a *successful* keyring-auth line side-by-side. Jared
+  scrubs both env vars before calling `gh` (see
+  [#65](https://github.com/brockamer/jared/issues/65)), so the keyring
+  is what actually gets used — but the `gh auth status` output stays
+  misleading. Either `unset GH_TOKEN GITHUB_TOKEN` to clean up the
+  output, or ignore the token-failure line.
 - **A GitHub Projects v2 board.** Either an existing one you want to
   steward, or a fresh empty project at
   `https://github.com/users/<you>/projects`. Jared works with any


### PR DESCRIPTION
## Summary

- Adds a Prerequisites callout in `README.md` covering the `GH_TOKEN` / `GITHUB_TOKEN` shadow scenario surfaced by #177's autonomous bake (F12 in the writeup, folded into #138 via #240's first-principles closure).
- Names the confusing `gh auth status` output a user sees when either env var is stale alongside a healthy keyring login, explains the #65 scrub behavior, and gives the two clean fixes (`unset` or ignore the failure line).
- Live PAT-reduction verify slice (other half of #138's original AC) is formally deferred in the issue body — synthetic regression coverage at `tests/test_board.py:406` and `:733` is deemed sufficient for v1.0, and the live slice naturally bundles with the next external-user bake.

## Context — why this is the right shape

#138 was filed and immediately deferred 2026-05-16 pending the #110 bake-in surfacing concrete failure messages. The autonomous bake (#177) on 2026-05-23 surfaced 14 findings; the operator's first-principles re-eval of #240 (the install-path bundle) folded the diagnostic-surface gap into this issue. The bake's own recommendation for the scenario was *"README prereqs should mention this failure mode"* — which is exactly what this PR delivers.

`_format_token_scope_diagnostic` in `lib/board.py:1019` already names the scrub behavior reactively (when a project mutation fails). The remaining gap was the **pre-failure confusion** — a user reads `gh auth status`, sees the split output, and bounces off the install path before ever running a jared command. Reactive diagnostic can't help there; proactive docs can.

## Closes

Closes #138

## Test plan

- [ ] Render the new README section locally and confirm formatting is clean
- [ ] Verify no existing regression tests broke: `pytest -q tests/test_board.py::test_token_scope_diagnostic_mentions_gh_token_scrub_when_set tests/test_board.py::test_run_gh_strips_github_token_envs` (ran clean pre-push)
- [ ] Lint clean: `ruff check .` (ran clean pre-push)
- [ ] Type-check clean: `mypy` (ran clean pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)