### PR TITLE
chore(archive): multi-session impl spec + plan → archived/2026-05/

### DIFF
--- a/docs/superpowers/plans/archived/2026-05/2026-05-23-multi-session-impl.md
+++ b/docs/superpowers/plans/archived/2026-05/2026-05-23-multi-session-impl.md
@@ -1,6 +1,15 @@
+---
+**Shipped in #231, #236 on 2026-05-23. Final decisions captured in issue body.**
+---
+
 # Multi-Session Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Issue
+
+- #231 — feat(sessions): worktree-by-default for parallel Claude sessions
+- #236 — feat(multi-session): /jared-start --session flag + sibling-detection prompt
 
 **Goal:** Ship the opt-in worktree-based isolation for parallel Claude sessions on a jared-stewarded repo, with unconditional session-presence locking that makes the B-leg refusal real. Closes #231 (worktree-by-default) + #236 (`/jared-start --session` flag) in one PR.
 

--- a/docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-impl-design.md
+++ b/docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-impl-design.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #231, #236 on 2026-05-23. Final decisions captured in issue body.**
+---
+
 # Spec: multi-session implementation — opt-in worktree + session-presence locking
 
 **Issues:** #231 (worktree-by-default) + #236 (`/jared-start --session` flag), bundled


### PR DESCRIPTION
## Summary

- Archive the multi-session impl spec and plan now that #231 + #236 have shipped (PR #247, merged as d895d29).
- Add the missing \`## Issue\` section to the plan — archive-plan.py refused to archive it without that section (plan-conventions require it).

## What's in this PR

\`\`\`
R  docs/superpowers/plans/2026-05-23-multi-session-impl.md → docs/superpowers/plans/archived/2026-05/...
R  docs/superpowers/specs/2026-05-23-multi-session-impl-design.md → docs/superpowers/specs/archived/2026-05/...
\`\`\`

Both moves done by \`archive-plan.py --scan --repo brockamer/jared --yes\`. The script also updated #231 and #236's \`## Planning\` sections to point at the new archived paths.

## Test plan

- [x] \`archive-plan.py\` reported both files as shippable (all referenced issues closed)
- [x] Both files moved to \`archived/2026-05/\` with rename detected (>99% similarity)
- [x] Issue body \`## Planning\` sections updated automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)