### PR TITLE
fix(ties): native blocked-by edges now tagged [blocker], not [cross-ref]

### DIFF
--- a/docs/github-api-tool-selection.md
+++ b/docs/github-api-tool-selection.md
@@ -119,7 +119,7 @@ All values measured during the 2026-05-22 quiet window. `(3×)` indicates the va
 | Call | Bucket | Per-call cost |
 |---|---|---|
 | `gh project item-list <N> --owner <O> --limit 2000` | graphql | **~10 points per project item.** 203 measured on jared/projects/4 (~50 items); ~5000 observed by operator on findajob/projects/1 (~500 items) — a single call burned the entire hourly bucket. Cost is the chief graphql pressure source. |
-| `Board.fetch_open_issues_for_ties()` (paginated, body + labels + milestone + projectItems + trackedInIssues) | graphql | ~20-50 per page (estimated from board.py docstring; not directly measured this window) |
+| `Board.fetch_open_issues_for_ties()` (paginated, body + labels + milestone + projectItems + blockedBy) | graphql | ~20-50 per page (estimated from board.py docstring; not directly measured this window) |
 | `gh issue view N --json <any-fields>` | graphql | **1 point (3×)** — regardless of field count (minimal `number,title,state` and jared-realistic `body,comments,labels,milestone,title,number,state` both consumed 1 point) |
 | `mcp__github__issue_read` (method=get) | REST core | **1-2 points** (3× consecutive: 2, 2, 1 — subsequent calls on the same issue appear to be MCP-server-side cached, dropping to 1 point. Budget 2 conservatively.) |
 | `gh api repos/.../issues/N` | REST core | **1 point (3×)** — or 0 with ETag 304 (`fetch_issue_state_rest` path) |
@@ -224,7 +224,7 @@ Revisit if a future migration introduces 3+ additional REST callsites (e.g., the
 
 - **MCP scope diagnostic**: `_format_token_scope_diagnostic` in `board.py` only knows about `gh`'s token. If a future MCP-routed mutation fails with the same `Resource not accessible by personal access token` signature, the diagnostic won't fire. Likely a one-line addition if the doctrine of "MCP for conversational issue CRUD" takes hold.
 - **Search bucket exposure**: `gh issue list --search` may eventually pressure the tight `search` bucket on larger projects. Not a current concern; flag if pre-flight checks ever surface it.
-- **blocked-by via REST**: `trackedInIssues` is exposed via GraphQL but the equivalent REST endpoint (issue dependencies) may have different shape/scope. Not investigated — `fetch_blocked_by_edges` stays graphql for now.
+- **blocked-by via REST**: the native GraphQL `blockedBy` connection (GitHub's issue-dependency feature) is what `fetch_blocked_by_edges` and `fetch_open_issues_for_ties` both read. The equivalent REST endpoint (issue dependencies) may have different shape/scope. Not investigated — both functions stay graphql for now. Note: `blockedBy` is distinct from `trackedInIssues` (the task-list parent/child connection); the two were briefly conflated in `fetch_open_issues_for_ties` until #230.
 
 ## Validation log
 

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -756,7 +756,7 @@ class Board:
                     }}
                   }}
                 }}
-                trackedInIssues(first: 10) {{ nodes {{ number }} }}
+                blockedBy(first: 20) {{ nodes {{ number }} }}
               }}
               pageInfo {{ hasNextPage endCursor }}
             }}
@@ -780,7 +780,7 @@ class Board:
                 status_field = project_item.get("fieldValueByName") or {}
                 priority_field = project_item.get("priority") or {}
                 milestone_obj = node.get("milestone") or {}
-                tracked_in = node.get("trackedInIssues", {}).get("nodes") or []
+                blocked_by_nodes = node.get("blockedBy", {}).get("nodes") or []
                 all_records.append(
                     OpenIssueForTies(
                         number=int(node["number"]),
@@ -792,7 +792,7 @@ class Board:
                         milestone=milestone_obj.get("title"),
                         status=str(status_field.get("name") or "Backlog"),
                         priority=priority_field.get("name"),
-                        blocked_by=tuple(int(t["number"]) for t in tracked_in),
+                        blocked_by=tuple(int(t["number"]) for t in blocked_by_nodes),
                     )
                 )
             if not page["pageInfo"]["hasNextPage"]:

--- a/skills/jared/scripts/lib/ties.py
+++ b/skills/jared/scripts/lib/ties.py
@@ -49,6 +49,21 @@ MAX_TIES_DISPLAYED = 8
 # deterministic hits — neither is bullet-proof, both deserve operator attention.
 CONFIDENCE_WEIGHT: dict[Confidence, int] = {"strong": 3, "medium": 2, "weak": 1, "llm": 2}
 
+# Tiebreaker when multiple signals fire at the same confidence for one related_n.
+# Structured-edge signals beat text-scrape signals — native blocked-by is a
+# deterministic GraphQL edge, cross-ref is a regex match on issue-body prose.
+# Lower number = higher precedence (sorted ascending as secondary key in combine()).
+_SIGNAL_PRIORITY: dict[SignalName, int] = {
+    "blocked_by": 0,
+    "file_paths": 1,
+    "cross_ref": 2,
+    "milestone": 3,
+    "title_tokens": 4,
+    "labels": 5,
+    "possibly_already_done": 6,
+    "semantic_overlap": 7,
+}
+
 # Score cap so a single candidate firing every signal doesn't dominate sorting.
 MAX_COMBINED_SCORE = 5
 
@@ -453,8 +468,13 @@ def combine(
             continue
 
         # Sort hits strong → weak so primary is the strongest signal.
-        # Within same confidence, keep stable order.
-        sorted_hits = sorted(related_hits, key=lambda h: -CONFIDENCE_WEIGHT[h.confidence])
+        # Within same confidence, break ties by _SIGNAL_PRIORITY so structured
+        # edges (blocked_by) beat text-scrape signals (cross_ref) deterministically,
+        # not by analyzer call order.
+        sorted_hits = sorted(
+            related_hits,
+            key=lambda h: (-CONFIDENCE_WEIGHT[h.confidence], _SIGNAL_PRIORITY[h.name]),
+        )
         primary_signal = sorted_hits[0].name
         primary_label = _RELATIONSHIP_LABELS[primary_signal]
         secondary_labels: list[str] = []

--- a/tests/test_board_fetch_for_ties.py
+++ b/tests/test_board_fetch_for_ties.py
@@ -43,7 +43,7 @@ _GRAPHQL_RESPONSE_FULL: dict[str, Any] = {
                                 }
                             ]
                         },
-                        "trackedInIssues": {"nodes": []},
+                        "blockedBy": {"nodes": []},
                     },
                     {
                         "number": 20,
@@ -59,7 +59,7 @@ _GRAPHQL_RESPONSE_FULL: dict[str, Any] = {
                                 }
                             ]
                         },
-                        "trackedInIssues": {"nodes": [{"number": 10}]},
+                        "blockedBy": {"nodes": [{"number": 10}]},
                     },
                 ],
                 "pageInfo": {"hasNextPage": False, "endCursor": None},
@@ -109,7 +109,7 @@ def test_fetch_partial_mode_omits_body(tmp_path: Path) -> None:
                                     }
                                 ]
                             },
-                            "trackedInIssues": {"nodes": []},
+                            "blockedBy": {"nodes": []},
                         }
                     ],
                     "pageInfo": {"hasNextPage": False, "endCursor": None},

--- a/tests/test_ties_combine.py
+++ b/tests/test_ties_combine.py
@@ -182,3 +182,70 @@ class TestCombineEdgeCases:
         hits = [_hit(99, "milestone", "strong")]
         ties = combine(hits, "weak", _target(), _open_issues())
         assert ties == []
+
+
+class TestCombineSignalPriority:
+    """When multiple signals fire at the same confidence for one related_n,
+    _SIGNAL_PRIORITY picks the primary — not analyzer call order. Structured-
+    edge signals beat text-scrape signals."""
+
+    def test_blocked_by_beats_cross_ref_when_both_strong(self) -> None:
+        """Native blocked-by edge wins the primary tag over body cross-ref,
+        regardless of which analyzer ran first. This is the canonical
+        bug-#230 case: an issue with both a native blockedBy edge AND a
+        body mention of the same blocker."""
+        target = OpenIssueForTies(
+            number=1,
+            title="t",
+            body="references #2",
+            labels=(),
+            milestone=None,
+            status="In Progress",
+            priority="High",
+            blocked_by=(2,),
+        )
+        # Insert cross_ref FIRST to prove insertion order doesn't bind.
+        hits = [
+            _hit(2, "cross_ref", "strong", evidence="target #1 body mentions #2"),
+            _hit(2, "blocked_by", "strong", evidence="target #1 is blocked by #2"),
+        ]
+        ties = combine(hits, "medium", target, _open_issues((2, "B")))
+        assert ties[0].primary_relationship == "blocker"
+        assert "cross-ref" in ties[0].secondary_relationships
+        # Suggested action is blocker-flavored, not cross-ref-flavored.
+        assert "sequence" in ties[0].suggested_action.lower()
+
+    def test_blocked_by_beats_cross_ref_reverse_insertion_order(self) -> None:
+        """Same as above but with blocked_by inserted FIRST — the result
+        must still be blocked-by-primary. Guards against a regression where
+        only stable-sort happens to put it first."""
+        target = OpenIssueForTies(
+            number=1,
+            title="t",
+            body="references #2",
+            labels=(),
+            milestone=None,
+            status="In Progress",
+            priority="High",
+            blocked_by=(2,),
+        )
+        hits = [
+            _hit(2, "blocked_by", "strong", evidence="target #1 is blocked by #2"),
+            _hit(2, "cross_ref", "strong", evidence="target #1 body mentions #2"),
+        ]
+        ties = combine(hits, "medium", target, _open_issues((2, "B")))
+        assert ties[0].primary_relationship == "blocker"
+
+    def test_title_tokens_beats_labels_when_both_weak(self) -> None:
+        """Priority axis is independent of confidence: when two weak signals
+        fire for the same related_n, title_tokens (priority 4) beats labels
+        (priority 5)."""
+        hits = [
+            _hit(2, "labels", "weak"),
+            _hit(2, "title_tokens", "weak"),
+        ]
+        ties = combine(hits, "weak", _target(), _open_issues((2, "B")))
+        assert ties[0].primary_relationship == "adjacent"
+        # Both labels and title_tokens map to "adjacent"; primary's source
+        # hit is the first sorted element, which should be title_tokens.
+        assert ties[0].hits[0].name == "title_tokens"


### PR DESCRIPTION
## Summary

- **Root cause**: `lib/board.py`'s `fetch_open_issues_for_ties` queried `trackedInIssues` (GitHub's task-list parent/child connection — the checkbox lists in issue bodies) and stuffed the result into a Python field literally named `blocked_by`. The sister function `fetch_blocked_by_edges` correctly uses the native `blockedBy` connection (the issue-dependency feature). Two parallel reader functions had quietly drifted apart, so `analyze_blocked_by` never saw any native edges and the ties block always emitted `[strong, cross-ref]` for every blocker.
- **Fix**: swap `trackedInIssues` → `blockedBy(first:20)` in the OpenIssuesForTies GraphQL query, rename the parser local, and update doc references.
- **Tiebreaker**: added `_SIGNAL_PRIORITY` map in `combine()` so when both `blocked_by` and `cross_ref` fire at strong confidence for the same `related_n`, the structured edge wins the bracket and cross-ref demotes to `(also cross-ref)` — deterministic, no longer dependent on analyzer call order. Closes #230 AC #3 by demote, not suppress (both signals stay visible).

## Test plan

- [x] `pytest` — 516 pass, 1 deselected (integration)
- [x] `ruff check .` — clean
- [x] `mypy` — clean (50 source files)
- [x] **End-to-end: `jared ties 190`** — `#192 [strong, blocker]   unblocked by target — flag in PR  (also cross-ref, milestone-mate, adjacent)` ✓
- [x] **End-to-end: `jared ties 192`** — `#190 [strong, blocker]   blocking — sequence #190 first  (also cross-ref, milestone-mate, adjacent)` ✓
- [x] **Bonus**: previously-invisible native edges between `#190↔#229` and `#192↔#191` now surface correctly.

## Discovered but not filed

- `jared worktree-add` derived the branch name `feature/230-worktree` (literal word) — slug derivation looks broken. Renamed the branch locally before pushing. Per the operator's "no sprawl" preference (`feedback_first_principles_before_filing`), surfacing here rather than filing a separate issue; happy to file if you'd like a tracker for it, or roll into a fast-follow PR.
- AC #3's "don't double-emit" wording was interpreted as **demote, not suppress**. The cross-ref signal still appears in `secondary_relationships` (rendered as `(also cross-ref)`). Lets reviewers see both signals are present. If you meant *suppress entirely when blocked-by fires*, easy follow-up patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)