### PR TITLE
feat(multi-session): per-session WIP arithmetic + session-N doctrine (#235)

### DIFF
--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -73,7 +73,12 @@ Flow:
 
    Solo sessions (`--session` absent) still write a lock with `session=null, worktree_path=null`. This is load-bearing: it lets a later sibling session detect the solo one and refuse with guidance, rather than silently sharing `.git/HEAD`.
 
-2. **Check WIP.** Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared summary` and read the `In Progress (N)` header — that `N` is the current count. If it's already at the project's configured cap (default 3), STOP and ask what moves out or pauses. Do NOT silently exceed WIP.
+2. **Check WIP.** Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared summary`. The In Progress header has two shapes (per #235):
+
+   - `In Progress (N):` — no `session-N` labels in play. `N` is the workstream count, equal to the item count.
+   - `In Progress (M workstreams · N items):` — `session-N` labels collapse same-session items into one workstream. `M` (the leading number) is what to compare against the cap. `N` (the item count) is for operator orientation only.
+
+   Compare `M` (or `N` in the no-collapse case) against the project's configured cap (default 3). If it's at the cap, STOP and ask what moves out or pauses. Do NOT silently exceed WIP.
 
 3. **Check pullable state.** Read the target issue's body and verify:
    - First paragraph is a clear summary

--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -78,7 +78,7 @@ Flow:
    - `In Progress (N):` — no `session-N` labels in play. `N` is the workstream count, equal to the item count.
    - `In Progress (M workstreams · N items):` — `session-N` labels collapse same-session items into one workstream. `M` (the leading number) is what to compare against the cap. `N` (the item count) is for operator orientation only.
 
-   Compare `M` (or `N` in the no-collapse case) against the project's configured cap (default 3). If it's at the cap, STOP and ask what moves out or pauses. Do NOT silently exceed WIP.
+   Compare `M` (or `N` in the no-collapse case) against the project's configured cap (default 4, per #245). If it's at the cap, STOP and ask what moves out or pauses. Do NOT silently exceed WIP.
 
 3. **Check pullable state.** Read the target issue's body and verify:
    - First paragraph is a clear summary

--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -153,9 +153,9 @@ Before writing code, editing docs, or making any change with durable effect, con
 
 ### When starting work — move to In Progress, load context
 
-Move the item to In Progress. WIP caps at the project's configured limit (default: 4). If the cap is hit, the user decides what moves out or pauses — Jared does not silently exceed WIP.
+Move the item to In Progress. WIP caps at the project's configured limit (default: 4) — counted in *workstreams*, not items: In Progress issues sharing a `session-N` label collapse into one workstream (per #235). If the cap is hit, the user decides what moves out or pauses — Jared does not silently exceed WIP.
 
-**Cross-session check.** If In Progress shows another `session-N` label that isn't yours, that's another Claude session actively touching code in this repo — check file-surface overlap before pulling adjacent work. See `references/parallel-sessions.md` for the worktree pattern and surface-overlap discipline.
+**Cross-session check.** If In Progress shows another `session-N` label that isn't yours, that's another Claude session actively touching code in this repo — check file-surface overlap before pulling adjacent work. See `references/parallel-sessions.md` for the worktree pattern, the `session-N` label semantics, the pre-parallel-session operator ritual, and how `jared summary` renders the per-session collapse.
 
 Before writing code, load the full context for this issue:
 
@@ -262,7 +262,7 @@ See `references/session-continuity.md` for details.
 
 ## WIP, blocked, pullable — the lean core
 
-**WIP limits.** In Progress caps at the project's configured limit (default 4). Up Next caps at 8 — more than that is overstocking, since only the top gets pulled anyway.
+**WIP limits.** In Progress caps at the project's configured limit (default 4), counted in *workstreams* — In Progress items sharing a `session-N` label collapse into one workstream count, so two `session-1`-labeled issues + one `session-2`-labeled issue = 2 workstreams against the cap. Up Next caps at 8 — more than that is overstocking, since only the top gets pulled anyway.
 
 **Blocked is a state, not a vibe.** When an issue is blocked, it gets the `blocked` label AND a `## Blocked by` section in the body naming the blocker and the owner of unblocking. Blocked items stay in their current column but visually flag. "Waiting for so-and-so" without an owner and a specific expected outcome is not blocked, it's abandoned.
 

--- a/skills/jared/references/parallel-sessions.md
+++ b/skills/jared/references/parallel-sessions.md
@@ -11,6 +11,56 @@ When the board shows an issue In Progress with a `session-N` label (N = 1,
 The label outlives the conversation; it's the durable claim that survives
 the next session-start.
 
+**Exact format.** `session-<positive-integer>` — `session-1`, `session-2`,
+…. The parser is a strict regex (`^session-(\d+)$`); `session-a`,
+`Session-1`, `sess-1` don't count. Peer labels (`enhancement`, `bug`, …)
+sit alongside without interfering — the per-session arithmetic only
+considers labels matching the strict shape.
+
+**Who applies and when.** The *operator* applies `session-N` labels at
+parallel-session start (option 1a from the v1.1 multi-session shape spec).
+Not Jared, not `/jared-stage`, not `/jared-start`. Auto-application was
+considered and deferred — see `docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-shape.md` § "Workstream 1".
+
+## Pre-parallel-session operator ritual
+
+Before launching two or more Claude sessions against the same repo:
+
+1. Glance at Up Next + In Progress and partition the next pull candidates
+   by *surface overlap* — which issues touch the same files, modules, or
+   shared helpers.
+2. Apply `session-1` to the group session 1 will own, `session-2` to the
+   group session 2 will own, etc. Items with no surface overlap stay
+   unlabeled and act as floats either session can claim.
+3. Start the sessions with `/jared-start <issue> --session N`. The flag
+   tells the session-presence resolver which claim it represents.
+
+The discipline is operator vigilance, not mechanism. The mechanism that
+*does* land per #235: `jared summary`'s WIP arithmetic collapses items
+sharing a `session-N` label into a single workstream count, so two
+session-1 issues + one session-2 issue render as "2 workstreams · 3 items"
+rather than three independent items pressuring the WIP cap.
+
+## How per-session WIP arithmetic renders
+
+`jared summary` and `jared next-session-prompt` show the collapse when it
+applies:
+
+- **No `session-N` labels in play** (common case): `In Progress (N):` —
+  unchanged, no parenthetical, no per-item suffix.
+- **`session-N` labels present**: `In Progress (M workstreams · N items):`
+  with each item suffixed by its session tag, e.g.
+  `#235 [High] Per-session WIP (session-1)`.
+
+The leading number is the workstream count — that's what `/jared-start`'s
+WIP-cap check compares against the project's configured cap. Two
+session-1 items + one session-2 item read as 2 workstreams, not 3 items.
+
+An item carrying both `session-1` and `session-2` is malformed (the
+discipline exists to prevent exactly that collision) but the set-union
+arithmetic handles it without special-casing: both labels contribute to
+the workstream set, the item contributes zero to the unlabeled count.
+
 **Before pulling a new issue:**
 
 1. Scan In Progress for items labeled `session-M` where M ≠ your session

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import tempfile
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -845,6 +846,39 @@ def _cmd_set(args: argparse.Namespace) -> int:
     return 0
 
 
+_SESSION_LABEL_RE = re.compile(r"^session-(\d+)$")
+
+
+def _session_labels(labels: Sequence[str]) -> list[str]:
+    """Extract `session-N` labels from an item's label set, sorted by N.
+
+    Any label not matching `session-<digits>` is ignored — peer labels
+    (enhancement, bug, etc.) don't participate in per-session arithmetic.
+    """
+    matched = [name for name in labels if _SESSION_LABEL_RE.match(name)]
+    return sorted(matched, key=lambda s: int(s.split("-", 1)[1]))
+
+
+def _count_workstreams(items: list[dict[str, Any]]) -> int:
+    """Per-session WIP arithmetic for In Progress items (#235).
+
+    Workstream count = |distinct session-N labels seen| + |items with no
+    session-N label|. An unlabeled item is its own workstream; same-session
+    items collapse into one. An item carrying both session-1 and session-2
+    (operator-error case the discipline exists to prevent) adds both
+    labels to the workstream set — set-union, no special case.
+    """
+    distinct_sessions: set[str] = set()
+    unlabeled = 0
+    for item in items:
+        sessions = _session_labels(item.get("labels") or ())
+        if sessions:
+            distinct_sessions.update(sessions)
+        else:
+            unlabeled += 1
+    return len(distinct_sessions) + unlabeled
+
+
 def _cmd_summary(args: argparse.Namespace) -> int:
     board = _load_board(args.board)
     if getattr(args, "fresh", False):
@@ -863,6 +897,17 @@ def _cmd_summary(args: argparse.Namespace) -> int:
             return f"  #{num} [{prio}] {title}"
         return f"  #{num} {title}"
 
+    def render_in_progress_item(item: dict[str, Any]) -> str:
+        # Suffix any session-N labels so the collapse rendering is legible.
+        # Dual-session labels on one item shouldn't happen — that's the
+        # collision the discipline exists to prevent — but if they do,
+        # show both rather than silently picking one.
+        sessions = _session_labels(item.get("labels") or ())
+        base = render_item(item)
+        if sessions:
+            return f"{base} ({', '.join(sessions)})"
+        return base
+
     # Stuck-closed items: closed issues whose Status never auto-moved to
     # Done (typical drift path: PR-merge auto-close on a project where
     # the built-in "Item closed → Done" workflow is off). open_items()
@@ -875,11 +920,19 @@ def _cmd_summary(args: argparse.Namespace) -> int:
     up_next = up_next_all[:3]
     blocked = by_status("Blocked")
 
+    workstreams = _count_workstreams(in_progress)
+    if workstreams < len(in_progress):
+        in_progress_header = (
+            f"In Progress ({workstreams} workstreams · {len(in_progress)} items):"
+        )
+    else:
+        in_progress_header = f"In Progress ({len(in_progress)}):"
+
     print(f"Board: {board.project_url}")
     print()
-    print(f"In Progress ({len(in_progress)}):")
+    print(in_progress_header)
     for it in in_progress:
-        print(render_item(it))
+        print(render_in_progress_item(it))
     if stuck_closed:
         print()
         print(f"Stuck closed ({len(stuck_closed)}) — closed issues not on Done:")
@@ -1085,12 +1138,18 @@ def _latest_session_note_oneliner(comments: list[dict[str, Any]]) -> str | None:
 
 
 def _render_in_flight(item: dict[str, Any], note_one_liner: str | None) -> None:
-    """Print one bullet for an In Progress item with optional last Session-note one-liner."""
+    """Print one bullet for an In Progress item with optional last Session-note one-liner.
+
+    Suffixes any `session-N` labels so the handoff carries the same
+    grouping signal `jared summary` shows (#235).
+    """
     content = item.get("content") or {}
     num = content.get("number")
     prio = item.get("priority") or "-"
     title = content.get("title", "")
-    print(f"- #{num} [{prio}] {title}")
+    sessions = _session_labels(item.get("labels") or ())
+    suffix = f" ({', '.join(sessions)})" if sessions else ""
+    print(f"- #{num} [{prio}] {title}{suffix}")
     if note_one_liner is not None:
         print(f'  Last session: "{note_one_liner}"')
 

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -462,6 +462,7 @@ class Board:
             number
             title
             state
+            labels(first: 20) { nodes { name } }
             projectItems(first: 10) {
               nodes {
                 id
@@ -522,6 +523,10 @@ class Board:
             flat = _flatten_project_item_for_project(issue.get("projectItems"), self.project_number)
             if flat is None:
                 continue
+            labels_node = issue.get("labels") or {}
+            label_names = tuple(
+                n["name"] for n in (labels_node.get("nodes") or []) if "name" in n
+            )
             items.append(
                 {
                     "content": {
@@ -531,6 +536,7 @@ class Board:
                     },
                     "status": flat.get("status"),
                     "priority": flat.get("priority"),
+                    "labels": label_names,
                 }
             )
         return items

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,6 +222,7 @@ def patch_gh_multi(
     closed_issues: list[dict[str, object]] | None = None,
     closed_statuses: dict[int, tuple[str, str]] | None = None,
     comments_batch_json: str | None = None,
+    labels_by_number: dict[int, list[str]] | None = None,
 ) -> None:
     """Patch the multi-gh-call shape produced by the batched open-only path (#185).
 
@@ -245,6 +246,7 @@ def patch_gh_multi(
     open_issues = open_issues or []
     statuses = statuses or {}
     closed_statuses = closed_statuses or {}
+    labels_by_number = labels_by_number or {}
     empty_comments_json = '{"data": {"repository": {}}}'
 
     def _open_items_batched_response() -> str:
@@ -256,11 +258,13 @@ def patch_gh_multi(
             if number in statuses:
                 status, priority = statuses[number]
                 project_items = {"nodes": [_projectitems_node(status, priority)]}
+            label_nodes = [{"name": name} for name in labels_by_number.get(number, [])]
             nodes.append(
                 {
                     "number": number,
                     "title": issue.get("title", ""),
                     "state": issue.get("state", "OPEN"),
+                    "labels": {"nodes": label_nodes},
                     "projectItems": project_items,
                 }
             )

--- a/tests/test_board_open_items.py
+++ b/tests/test_board_open_items.py
@@ -141,6 +141,7 @@ def test_open_items_single_issue_shape_matches_board_items(
             "content": {"number": 42, "title": "Thing to do", "state": "OPEN"},
             "status": "Up Next",
             "priority": "Medium",
+            "labels": (),
         }
     ]
 
@@ -180,6 +181,89 @@ def test_open_items_excludes_issues_not_on_project_board(
     patch_gh(monkeypatch, stdout=batched_response)
 
     assert board.open_items() == []
+
+
+def test_open_items_includes_labels_per_item(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Per-session WIP arithmetic (#235) needs each item's label set
+    available at the summary layer. open_items() projects labels as a
+    tuple of name strings on each dict; empty when the issue has none.
+    """
+    from skills.jared.scripts.lib.board import Board
+
+    board_md = write_minimal_board(tmp_path)
+    board = Board.from_path(board_md)
+
+    batched_response = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "issues": {
+                        "pageInfo": {"hasNextPage": False},
+                        "nodes": [
+                            {
+                                "number": 1,
+                                "title": "Labeled",
+                                "state": "OPEN",
+                                "labels": {
+                                    "nodes": [
+                                        {"name": "session-1"},
+                                        {"name": "enhancement"},
+                                    ]
+                                },
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "id": "PVTI_a",
+                                            "project": {"number": 7},
+                                            "fieldValues": {
+                                                "nodes": [
+                                                    {
+                                                        "name": "In Progress",
+                                                        "field": {"name": "Status"},
+                                                    }
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            },
+                            {
+                                "number": 2,
+                                "title": "Unlabeled",
+                                "state": "OPEN",
+                                "labels": {"nodes": []},
+                                "projectItems": {
+                                    "nodes": [
+                                        {
+                                            "id": "PVTI_b",
+                                            "project": {"number": 7},
+                                            "fieldValues": {
+                                                "nodes": [
+                                                    {
+                                                        "name": "In Progress",
+                                                        "field": {"name": "Status"},
+                                                    }
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            },
+                        ],
+                    }
+                }
+            }
+        }
+    )
+    patch_gh(monkeypatch, stdout=batched_response)
+
+    result = board.open_items()
+
+    by_num = {entry["content"]["number"]: entry for entry in result}
+    assert by_num[1]["labels"] == ("session-1", "enhancement")
+    assert by_num[2]["labels"] == ()
 
 
 def test_open_items_raises_when_pagination_required(

--- a/tests/test_cmd_next_session_prompt.py
+++ b/tests/test_cmd_next_session_prompt.py
@@ -82,6 +82,34 @@ def test_next_session_prompt_renders_basic_sections(
     assert "[Medium]" in out
 
 
+def test_next_session_prompt_renders_session_label_inline_for_in_flight(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Per-session WIP arithmetic symmetry (#235): an In Progress item
+    with a `session-N` label shows that tag inline in the handoff's
+    "In flight" section, so the next session reading the handoff sees
+    the same grouping signal `jared summary` shows."""
+    board_md = write_minimal_board(tmp_path)
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {"number": 235, "title": "Per-session WIP", "state": "OPEN"},
+        ],
+        statuses={235: ("In Progress", "High")},
+        labels_by_number={235: ["session-1", "enhancement"]},
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "next-session-prompt"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "#235" in out and "Per-session WIP" in out
+    assert "(session-1)" in out
+
+
 def test_extract_next_action_handles_empty_body() -> None:
     """When the **Next action:** field has empty/whitespace body and is
     followed by another bold paragraph, the extractor returns None rather

--- a/tests/test_cmd_summary.py
+++ b/tests/test_cmd_summary.py
@@ -139,6 +139,113 @@ def test_summary_no_stuck_closed_section_when_clean(
     assert "Stuck closed" not in out
 
 
+def test_summary_collapses_same_session_in_progress_into_one_workstream(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Per-session WIP arithmetic (#235): two In Progress items sharing
+    `session-1` plus one with `session-2` render as 2 workstreams · 3 items,
+    not as a flat count of 3. The leading number is what /jared-start's
+    WIP-cap check reads; the parenthetical item count keeps the operator
+    oriented on what they're actually looking at.
+    """
+    board_md = write_minimal_board(tmp_path)
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {"number": 1, "title": "A in session-1", "state": "OPEN"},
+            {"number": 2, "title": "B in session-1", "state": "OPEN"},
+            {"number": 3, "title": "C in session-2", "state": "OPEN"},
+        ],
+        statuses={
+            1: ("In Progress", "High"),
+            2: ("In Progress", "High"),
+            3: ("In Progress", "Medium"),
+        },
+        labels_by_number={
+            1: ["session-1", "enhancement"],
+            2: ["session-1"],
+            3: ["session-2"],
+        },
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "summary"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "In Progress (2 workstreams · 3 items)" in out
+    # Each item renders its session tag so the grouping is legible.
+    assert "(session-1)" in out
+    assert "(session-2)" in out
+
+
+def test_summary_unlabeled_in_progress_counts_as_own_workstream(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An In Progress item with no `session-N` label is its own workstream.
+    Two session-1 items + one unlabeled = 2 workstreams · 3 items.
+    """
+    board_md = write_minimal_board(tmp_path)
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {"number": 1, "title": "A in session-1", "state": "OPEN"},
+            {"number": 2, "title": "B in session-1", "state": "OPEN"},
+            {"number": 3, "title": "C solo", "state": "OPEN"},
+        ],
+        statuses={
+            1: ("In Progress", "High"),
+            2: ("In Progress", "High"),
+            3: ("In Progress", "Medium"),
+        },
+        labels_by_number={
+            1: ["session-1"],
+            2: ["session-1"],
+            # #3 has no labels → its own workstream
+        },
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "summary"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "In Progress (2 workstreams · 3 items)" in out
+
+
+def test_summary_no_collapse_when_no_session_labels_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Common case — no parallel-session labels in play. Header stays as
+    `In Progress (N):`. Workstream-count parenthetical is the *changed*
+    shape; it must not leak into the no-collapse path."""
+    board_md = write_minimal_board(tmp_path)
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {"number": 1, "title": "Alone", "state": "OPEN"},
+            {"number": 2, "title": "Also alone", "state": "OPEN"},
+        ],
+        statuses={
+            1: ("In Progress", "High"),
+            2: ("In Progress", "High"),
+        },
+        labels_by_number={
+            1: ["enhancement"],
+            # #2 has no labels at all
+        },
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "summary"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "In Progress (2):" in out
+    assert "workstreams" not in out
+    assert "(session-" not in out
+
+
 def test_summary_up_next_truncates_to_three(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

- `jared summary` and `jared next-session-prompt` collapse In Progress items sharing a `session-N` label into one workstream count. Header renders as `In Progress (M workstreams · N items):` when collapse applies; unchanged `In Progress (N):` when no `session-N` labels are in play. Each in-progress item gets a `(session-N)` suffix when labeled.
- Doctrine in `references/parallel-sessions.md` now documents the exact `session-N` format, the pre-parallel-session operator ritual (operator partitions Up Next by surface overlap and applies labels), and how the per-session WIP arithmetic renders. SKILL.md's WIP-cap doctrine and the `/jared-start` command stub teach the next session to read the leading number as workstreams against the cap.
- Subsumes #217: option 1 ("relax the cap for explicitly-labeled session-N groups") delivered.

## Implementation

**Lower layer.** `_OPEN_ITEMS_QUERY` adds `labels(first: 20) { nodes { name } }`; `open_items()` projects labels as a tuple of name strings on each item dict. No cost change — labels travel in the same single GraphQL round-trip.

**Higher layer.** `_cmd_summary` computes `|distinct session-N labels| + |unlabeled items|` for the In Progress section. When the workstream count is less than the item count, the header renders with both numbers and each item gets its session-N suffix. `_render_in_flight` in next-session-prompt mirrors the suffix so the handoff carries the same grouping signal. The dual-label edge case (one item with both `session-1` and `session-2`) is handled by natural set-union — no special-case branch — and surfaces both labels in the suffix as a signal to the operator.

**Test fixture.** `patch_gh_multi` gains a `labels_by_number: dict[int, list[str]]` kwarg that threads per-issue labels into the synthesized OPEN-issues batched response. Three summary tests cover the collapse case, the unlabeled-as-own-workstream case, and the no-collapse common case. One next-session-prompt test covers in-flight symmetry. One open_items test covers label projection at the lower layer.

## Test plan

- [x] `pytest` — 518 passed, 1 deselected (integration), 0 regressions
- [x] `ruff check` + `mypy` clean
- [x] Smoke against real board: moved #230 (+session-1) and #227 (+session-2) to In Progress alongside #235 (session-1). `jared summary` rendered `In Progress (2 workstreams · 3 items):` with each item's session tag visible. Dual-label case surfaced organically (#230 carried both labels) and rendered correctly. Reverted: board back to single-In-Progress baseline.

## Backward compatibility

- The single-issue-per-session-N case (or no session-N labels) keeps the existing `In Progress (N):` shape — operators not running parallel sessions see no visual change.
- The leading number in both shapes is the count to compare against the WIP cap; reading discipline preserved.
- `open_items()` dict now includes a `labels` key; callers that consumed the prior dict shape via key iteration are unaffected (additive change), and the one test asserting exact equality is updated.

Closes #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)