### PR TITLE
fix(file): --milestone fetch must use URL query, not -f form body

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -508,8 +508,10 @@ def _cmd_file(args: argparse.Namespace) -> int:
     # is cheaper than catching it in every sweep.
     milestone_title: str | None = None
     if not args.no_milestone:
+        # Query params on the URL — `gh api -f key=value` is a request body
+        # field, and on /milestones a body flips GET-list into POST-create.
         milestones = board.run_gh(
-            ["api", f"repos/{board.repo}/milestones", "-f", "state=open", "-f", "per_page=100"]
+            ["api", f"repos/{board.repo}/milestones?state=open&per_page=100"]
         )
         # Defensive: REST returns a list; an empty/missing payload is treated
         # as "no open milestones" rather than crashing on attribute access.

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -1137,3 +1137,84 @@ def test_file_rejects_unmatched_milestone_with_listing(
     assert not any("issue" in c and "create" in c for c in calls), (
         f"unmatched milestone must short-circuit; calls: {calls}"
     )
+
+
+def test_file_milestone_lookup_uses_get_query_string_not_form_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Regression for #254 — argv-shape assertion the #238 tests missed.
+
+    `gh api -f key=value` sends `key=value` as a **form field in the request
+    body**, which on the `/repos/{owner}/{repo}/milestones` endpoint flips
+    GET-list into POST-create. The buggy form (`-f state=open -f per_page=100`)
+    therefore 422s with `"title" wasn't supplied`. The fix is to put filters
+    on the URL query string (or pass `--method GET`).
+
+    This test asserts the *call shape*, not just the return value the previous
+    milestone tests relied on. The previous routing mock matched any argv
+    containing the substring `milestones` and returned a synthetic list,
+    so it green-lit the malformed form. Argv-level assertion is the
+    discipline that catches this class of regression.
+    """
+    board_md = _write_full_board(tmp_path)
+    target = "v1.0 — public install"
+    calls = _routed_fake_with_milestones(monkeypatch, [target])
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Test",
+            "--body",
+            "Body.",
+            "--priority",
+            "Medium",
+            "--milestone",
+            target,
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+
+    milestone_lookups = [c for c in calls if "milestones" in " ".join(c) and "api" in c]
+    assert len(milestone_lookups) == 1, (
+        f"expected exactly one milestone-lookup call; got {milestone_lookups}"
+    )
+    argv = milestone_lookups[0]
+
+    # Acceptable shape A: state filter on the URL query string.
+    url_arg = next((a for a in argv if "milestones" in a), "")
+    has_url_query = "state=open" in url_arg
+
+    # Acceptable shape B: explicit GET with -f filters (gh routes -f to query
+    # when --method GET is set).
+    has_method_get = (
+        "--method" in argv
+        and argv.index("--method") + 1 < len(argv)
+        and argv[argv.index("--method") + 1].upper() == "GET"
+    )
+
+    assert has_url_query or has_method_get, (
+        "milestone-lookup argv must either carry filters on the URL query string "
+        "(e.g. `repos/<owner>/<repo>/milestones?state=open`) OR pass `--method GET` "
+        "alongside `-f` filters. Without one of these, gh treats `-f state=open` as a "
+        "POST body field, hitting the create-milestone endpoint and 422-ing.\n"
+        f"  url fragment: {url_arg!r}\n"
+        f"  full argv: {argv}"
+    )
+
+    # Belt-and-braces: no bare `-f state=...` or `-f per_page=...` without
+    # `--method GET`. Catches the next author who copies the buggy pattern.
+    if not has_method_get:
+        f_field_values = [
+            argv[i + 1] for i, tok in enumerate(argv) if tok == "-f" and i + 1 < len(argv)
+        ]
+        for field in f_field_values:
+            assert not field.startswith(("state=", "per_page=")), (
+                f"`-f {field}` without `--method GET` sends a request body; "
+                f"on /milestones that hits the create-milestone POST. "
+                f"argv: {argv}"
+            )


### PR DESCRIPTION
## Summary

- `jared file --milestone NAME` was broken since #238 shipped: `gh api -f state=open -f per_page=100` sent filters as request body, hitting the create-milestone POST and 422-ing with `"title" wasn't supplied`.
- Move filters to the URL query string. One-line fix.
- Add an argv-shape regression test that catches this class of bug (the previous tests routed by substring + synthetic return, green-lighting the malformed call).

## Why this slipped past #238's tests

`_routed_fake_with_milestones` in `tests/test_cmd_file.py` matched any argv containing `"milestones"` + `"api"` and returned a synthetic list. The actual `gh` call shape was never asserted — so the buggy `-f state=open -f per_page=100` argv produced the mocked list at test time, but produced HTTP 422 at runtime. Argv-level assertion (capture-and-inspect, not stub-and-return) is the discipline that prevents the recurrence.

## Audit

`grep -nE '"api",.*"-f"' skills/jared/scripts/**/*.py` returns one other site: `lib/board.py:1545` — `["api", "graphql", "-f", f"query={query}"]`. That's correct usage: `gh api graphql` genuinely POSTs the query as body. No other GET endpoints in the tree abuse `-f`.

## Test plan

- [x] Failing regression test added before the fix — verified RED on current code
- [x] Fix applied; test goes GREEN
- [x] Full suite: 522 passed, 1 deselected
- [x] `ruff check` clean, `mypy --strict` clean
- [x] Live smoke against real `gh`: `jared file --milestone "v0.21 — engineering hardening" ...` filed #255 successfully end-to-end (closed as smoke artifact)

Closes #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)