### PR TITLE
chore(release): v0.23.1 — fix jared file --milestone argv shape

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "author": {
     "name": "Daniel Brock"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: each entry starts with `## v<x.y.z> — YYYY-MM-DD`, followed by terse b
 
 Convention is documented in [CLAUDE.md](CLAUDE.md) § Versioning. Pre-`v0.2.0` history is omitted — `v0.2.0` is the level-up release that established the current Jared shape.
 
+## v0.23.1 — 2026-05-24
+
+**Bug fixes**
+- `jared file --milestone NAME` failed with HTTP 422 (`"title" wasn't supplied`) since v0.23.0 — the open-milestones fetch passed `-f state=open -f per_page=100` to `gh api`, which sends those as a POST body and hits the create-milestone endpoint instead of listing. Filters moved to the URL query string. Argv-shape regression test added (the previous tests routed by substring match on `"milestones"` and returned a synthetic list, green-lighting the malformed call). (#256, closes #254)
+
 ## v0.23.0 — 2026-05-23
 
 **Features**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.23.0"
+version = "0.23.1"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- One-bug patch release. v0.23.0's milestone-required filing landed with a bad `gh api` invocation that broke every `jared file --milestone NAME` call.
- Ships #256 (fix + argv-shape regression test).
- Bumps version 0.23.0 → 0.23.1 in `.claude-plugin/plugin.json` + `pyproject.toml`; adds CHANGELOG entry; release notes follow on the v0.23.1 GitHub Release.

## What's in v0.23.1

**Bug fixes**
- `jared file --milestone NAME` failed with HTTP 422 (`"title" wasn't supplied`) since v0.23.0 — `gh api -f state=open -f per_page=100` sent filters as request body, hitting the create-milestone endpoint instead of listing open milestones. Filters moved to URL query. Argv-shape regression test added. (#256, closes #254)

## Test plan

- [x] Full suite green (522 passed) on the fix commit
- [x] Live smoke against real `gh` confirmed end-to-end (filed + closed #255 with `--milestone "v0.21 — engineering hardening"`)
- [x] Version strings consistent across `.claude-plugin/plugin.json` and `pyproject.toml`
- [ ] Post-merge: tag `v0.23.1`, push tag, create GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)