### PR TITLE
feat(close): audit-emission rail — require ## Guidance audit or --no-audit (closes #227, #226)

### DIFF
--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -32,7 +32,7 @@ Flow:
 
    - Smart-tier decisions: routed through `advisor()`?                                                  [yes / no / N/A]
    - Were your session's model and dispatch choices well-matched to the work size?                       [yes / no / N/A]
-   - Looking back, did any cheap-tier or surface-mapping work run inline that would have been better dispatched? [yes / no / N/A]
+   - Looking back, did any cheap-tier or surface-mapping work run inline that would have been better dispatched? [yes / no / N/A — if no, name the closest call you considered]
    ```
 
    **A `no` or surfaced regret on any line REQUIRES a one-line "why" appended beneath that bullet.** Not optional. Examples:
@@ -45,6 +45,8 @@ Flow:
    **Skip the audit append when:**
    - `docs/project-board.md`'s `## Jared config` contains `- model-guidance: disabled`, OR
    - The touched issue has no `## Model & execution guidance` H2 anywhere (no body section, no start-time backstop comment).
+
+   **Audit-emission rail (#227).** `jared close <N>` enforces this contract at the CLI: when the issue carries `## Model & execution guidance` and the kill switch is off, the close refuses unless either the close body (`--body` / `--body-file`) contains `## Guidance audit (#N)`, OR `--no-audit <reason>` is passed. The escape posts a `_Audit-exempt close: <reason>_` marker comment so the closure is countable as exempt. Acceptable reasons name the shape of the legitimate skip — `epic-rollup`, `scope-question`, `no-work-session`, `docs-trivia`. The rail closes the silent-skip path that left ~37% of post-v0.19.0 closures audit-less, and forces every close on a guidance-bearing issue into one of three buckets: audit-emitted, `--no-audit`-exempt, or refused.
 
    **The audit evaluates judgment, not compliance.** The original 2026-05-13 findajob#150 surfacing concern (Claude proceeded at parent-session model without dispatching for cheap-tier work) is preserved by question 3, which names the failure-mode work types explicitly to force forensic examination rather than relying on the operator to surface a feeling. The over-prescription pattern from the 2026-05-20 #162 audit is surfaced by question 2 ("well-matched to the work size"). The decision-point discipline that works at 95% (`advisor()`) is preserved by question 1. The audit's value is the trigger — asking the question at wrap-time removes the dependency on the operator noticing the gap. See SKILL.md § "Model & execution guidance" for the file-time framing the audit reflects against.
 

--- a/skills/jared/SKILL.md
+++ b/skills/jared/SKILL.md
@@ -102,7 +102,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared file --title "..." (--body "...
 # --priority accepts High/Medium/Low (canonical) or high/medium/low/med (normalized by CLI)
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared move <N> "In Progress"
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared set <N> <FieldName> <OptionName>
-${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared close <N>
+${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared close <N> [(--body "..." | --body-file <path or ->) | --no-audit <reason>]
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared comment <N> (--body "..." | --body-file <path or ->)
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared blocked-by <dependent> <blocker> [--remove]
 ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared get-item <N>     # JSON lookup helper
@@ -184,6 +184,8 @@ See `references/context-capture.md` for the trigger patterns and the helper scri
 ### When completing work — close and verify
 
 Close via `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared close <N>` — the CLI closes the issue and polls for the board's auto-move to Done, falling back to an explicit `Status=Done` set if the auto-move hasn't fired. A PR merge closes the issue too; same verification applies, so re-run `jared close` (idempotent) or `jared summary` to confirm the item landed in Done.
+
+**Audit-emission rail (#227).** When the issue body carries `## Model & execution guidance` and the project kill switch is off, `jared close` refuses unless either the close body (`--body` / `--body-file`) contains `## Guidance audit (#N)`, OR `--no-audit <reason>` is passed (e.g., `epic-rollup`, `scope-question`, `no-work-session`, `docs-trivia`, `already-emitted`). The typical wrap path is `jared close <N> --body-file -` piping a Session note + audit; the typical exempt path is `jared close <N> --no-audit no-work-session` for closures that don't warrant an audit. See `commands/jared-wrap.md` § "Audit-emission rail" for the full doctrine.
 
 After close, Jared asks two questions:
 

--- a/skills/jared/references/jared-cli.md
+++ b/skills/jared/references/jared-cli.md
@@ -120,16 +120,29 @@ before the command returns.
 Optionally post a Session note in the same atom — `--body` / `--body-file`
 mirror `jared comment` and `jared file`. When supplied, the comment is
 posted *before* the close, so a close failure leaves the issue open with
-a stray comment (recoverable: re-run `jared close <N>` without `--body*`).
+a stray comment. Recovery: re-run with `--no-audit already-emitted` so
+the rail (#227) treats the prior audit as the durable artifact and a
+duplicate audit isn't posted.
 Closing first then failing to comment would leave a closed issue without
 a Session note — the discipline this flag exists to enforce against the
 audit/wrap doctrine that treats close-with-comment as one atom.
 
+**Audit-emission rail (#227).** When the issue body carries
+`## Model & execution guidance` and the project's
+`docs/project-board.md` § `## Jared config` does NOT set
+`- model-guidance: disabled`, `jared close` refuses unless either the
+body (`--body` / `--body-file`) contains `## Guidance audit (#N)` OR
+`--no-audit <reason>` is passed. The escape posts a tiny
+`_Audit-exempt close: <reason>_` marker comment for measurement.
+Acceptable reasons: `epic-rollup`, `scope-question`, `no-work-session`,
+`docs-trivia`, `already-emitted` (recovery path above).
+
 ```
-jared close <issue_number>
+jared close <issue_number>                                # OK when issue lacks model guidance
 jared close <issue_number> --body "Done — shipped in v0.21."
-jared close <issue_number> --body-file close-note.md
+jared close <issue_number> --body-file close-note.md      # body must contain ## Guidance audit (#N)
 cat close-note.md | jared close <issue_number> --body-file -
+jared close <issue_number> --no-audit scope-question      # explicit exempt close
 ```
 
 **Example.**

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -448,19 +448,18 @@ def _print_audit_required_error(issue_number: int) -> None:
     print(f"      ## Guidance audit (#{issue_number})", file=sys.stderr)
     print("", file=sys.stderr)
     print(
-        "      - Smart-tier decisions: routed through `advisor()`?                [yes / no / N/A]",
+        "      - Smart-tier decisions: routed through `advisor()`? [yes / no / N/A]",
         file=sys.stderr,
     )
     print(
-        "      - Were your session's model and dispatch choices well-matched"
-        " to the work size?                                                 "
-        "  [yes / no / N/A]",
+        "      - Were your session's model and dispatch choices well-matched "
+        "to the work size? [yes / no / N/A]",
         file=sys.stderr,
     )
     print(
-        "      - Looking back, did any cheap-tier or surface-mapping work run"
-        " inline that would have been better dispatched? [yes / no / N/A —"
-        ' if no, name the closest call you considered]',
+        "      - Looking back, did any cheap-tier or surface-mapping work run "
+        "inline that would have been better dispatched? "
+        "[yes / no / N/A — if no, name the closest call you considered]",
         file=sys.stderr,
     )
     print("", file=sys.stderr)
@@ -469,7 +468,8 @@ def _print_audit_required_error(issue_number: int) -> None:
         file=sys.stderr,
     )
     print(
-        "    (e.g., 'epic-rollup', 'scope-question', 'no-work-session', 'docs-trivia').",
+        "    (e.g., 'epic-rollup', 'scope-question', 'no-work-session', "
+        "'docs-trivia', 'already-emitted').",
         file=sys.stderr,
     )
 
@@ -487,6 +487,17 @@ def _cmd_close(args: argparse.Namespace) -> int:
         if not report.clean:
             print_redaction_diff(report, file=sys.stderr)
             return 2
+
+    # Reject empty-string --no-audit before the rail check — keeps the marker
+    # comment from rendering as an unhelpful `_Audit-exempt close: _` line.
+    if args.no_audit is not None and not args.no_audit.strip():
+        print(
+            "error: --no-audit requires a non-empty reason "
+            "(e.g., 'epic-rollup', 'scope-question', 'no-work-session', "
+            "'docs-trivia', 'already-emitted').",
+            file=sys.stderr,
+        )
+        return 2
 
     # Audit-emission rail (#227). When the issue carries `## Model & execution
     # guidance` AND the project-level kill switch is off, the close must

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -142,6 +142,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--body-file",
         help='Path to markdown comment body, or "-" for stdin. Posted before close.',
     )
+    # --no-audit REASON (#227). For issues that carry `## Model & execution
+    # guidance`, `_cmd_close` requires either a body with `## Guidance audit
+    # (#N)` OR an explicit `--no-audit <reason>` acknowledging the skip.
+    # Posts a `_Audit-exempt close: <reason>_` marker comment before close
+    # so future emission-rate measurements can subtract these from the
+    # denominator. Naming mirrors `--no-milestone` from #238.
+    close_p.add_argument(
+        "--no-audit",
+        metavar="REASON",
+        help=(
+            "Acknowledge intentional skip of the wrap-time guidance audit "
+            "(e.g., 'epic-rollup', 'scope-question', 'no-work-session'). "
+            "Posts a marker comment so the closure is countable as exempt."
+        ),
+    )
     close_p.set_defaults(func=_cmd_close)
 
     comment = sub.add_parser(
@@ -410,21 +425,91 @@ def _cmd_move(args: argparse.Namespace) -> int:
     return _cmd_set(args)
 
 
+_GUIDANCE_AUDIT_H2_RE = re.compile(r"^## Guidance audit \(#", re.MULTILINE)
+
+
+def _print_audit_required_error(issue_number: int) -> None:
+    """Stderr diagnostic for the audit-emission rail's refusal paths (#227).
+
+    Printed when a close on an issue that carries `## Model & execution
+    guidance` is attempted without an audit-bearing body and without the
+    `--no-audit <reason>` escape. The message names the two paths so the
+    operator can choose between completing the audit or acknowledging the
+    intentional skip.
+    """
+    print(
+        f"error: #{issue_number} carries ## Model & execution guidance, but the "
+        "close has no ## Guidance audit (#N) (see #227).",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print("  Either include the audit template in --body-file:", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(f"      ## Guidance audit (#{issue_number})", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "      - Smart-tier decisions: routed through `advisor()`?                [yes / no / N/A]",
+        file=sys.stderr,
+    )
+    print(
+        "      - Were your session's model and dispatch choices well-matched"
+        " to the work size?                                                 "
+        "  [yes / no / N/A]",
+        file=sys.stderr,
+    )
+    print(
+        "      - Looking back, did any cheap-tier or surface-mapping work run"
+        " inline that would have been better dispatched? [yes / no / N/A —"
+        ' if no, name the closest call you considered]',
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print(
+        "  OR pass --no-audit <reason> to acknowledge intentional skip",
+        file=sys.stderr,
+    )
+    print(
+        "    (e.g., 'epic-rollup', 'scope-question', 'no-work-session', 'docs-trivia').",
+        file=sys.stderr,
+    )
+
+
 def _cmd_close(args: argparse.Namespace) -> int:
     board = _load_board(args.board)
+
+    # Resolve --body / --body-file once upfront so the audit-emission rail
+    # (#227) can inspect it AND the comment-post step can reuse it without
+    # double-consuming stdin (--body-file - is one-shot).
+    body: str | None = None
+    if args.body is not None or args.body_file is not None:
+        body = resolve_body(args.body, args.body_file)
+        report = pre_flight_check(body, project_root=_find_project_root(Path.cwd()))
+        if not report.clean:
+            print_redaction_diff(report, file=sys.stderr)
+            return 2
+
+    # Audit-emission rail (#227). When the issue carries `## Model & execution
+    # guidance` AND the project-level kill switch is off, the close must
+    # either include `## Guidance audit (#N)` in its body OR pass
+    # --no-audit <reason> acknowledging the skip. Closes the silent-skip path
+    # that left ~37% of post-v0.19.0 closures audit-less.
+    if not board.model_guidance_disabled and args.no_audit is None:
+        issue_body = board.fetch_issue_body(args.issue_number)
+        has_guidance = "## Model & execution guidance" in issue_body
+        if has_guidance:
+            if body is None:
+                _print_audit_required_error(args.issue_number)
+                return 2
+            if not _GUIDANCE_AUDIT_H2_RE.search(body):
+                _print_audit_required_error(args.issue_number)
+                return 2
 
     # Optional comment-before-close (#184). Post the Session note first so a
     # close failure leaves a recoverable state (open issue + stray comment,
     # user re-runs `jared close <N>` without --body). The opposite order would
     # close the issue and then fail to post the note — a discipline violation
     # since the audit/wrap doctrine treats close-with-comment as one atom.
-    has_comment = args.body is not None or args.body_file is not None
-    if has_comment:
-        body = resolve_body(args.body, args.body_file)
-        report = pre_flight_check(body, project_root=_find_project_root(Path.cwd()))
-        if not report.clean:
-            print_redaction_diff(report, file=sys.stderr)
-            return 2
+    if body is not None:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tf:
             tf.write(body)
             tmp_path = tf.name
@@ -443,6 +528,24 @@ def _cmd_close(args: argparse.Namespace) -> int:
         finally:
             Path(tmp_path).unlink(missing_ok=True)
         print(f"OK: commented on #{args.issue_number} ({comment_url})")
+
+    # --no-audit marker (#227). Posted as a small standalone italic comment so
+    # the audit-rate measurement can subtract acknowledged-exempt closures
+    # from the denominator: `(audits + explicit --no-audits) / closures`.
+    if args.no_audit is not None:
+        marker = f"_Audit-exempt close: {args.no_audit}_"
+        marker_url = board.run_gh_raw(
+            [
+                "issue",
+                "comment",
+                str(args.issue_number),
+                "--repo",
+                board.repo,
+                "--body",
+                marker,
+            ]
+        )
+        print(f"OK: marked exempt on #{args.issue_number} ({marker_url})")
 
     board.run_gh(
         [

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -69,6 +69,10 @@ class Board:
     # defaults to ['src/**']. See sweep.check_doc_sync_gate (#163).
     operator_docs: list[str] = field(default_factory=list)
     code_surface: list[str] = field(default_factory=list)
+    # Project-level kill switch for the wrap-time guidance audit (#227).
+    # Set in `## Jared config` as `- model-guidance: disabled`. When True,
+    # `_cmd_close` skips the audit-emission rail entirely. False = rail active.
+    model_guidance_disabled: bool = False
     # Cached `gh project item-list` result, populated on first board_items()
     # call and reused for the lifetime of this instance. None means uncached.
     _items: list[dict[str, Any]] | None = field(default=None, repr=False)
@@ -184,7 +188,9 @@ class Board:
         assert repo is not None
 
         field_ids, field_options = cls._parse_field_blocks(text)
-        session_handoff_prompt = cls._parse_jared_config(text).get("session-handoff-prompt", "ask")
+        jared_config = cls._parse_jared_config(text)
+        session_handoff_prompt = jared_config.get("session-handoff-prompt", "ask")
+        model_guidance_disabled = jared_config.get("model-guidance", "").strip() == "disabled"
         session_start_checks = cls._parse_session_start_checks(text)
         operator_docs, code_surface = cls._parse_operator_docs(text)
 
@@ -200,6 +206,7 @@ class Board:
             session_start_checks=session_start_checks,
             operator_docs=operator_docs,
             code_surface=code_surface,
+            model_guidance_disabled=model_guidance_disabled,
             _raw_doc=text,
         )
 
@@ -524,9 +531,7 @@ class Board:
             if flat is None:
                 continue
             labels_node = issue.get("labels") or {}
-            label_names = tuple(
-                n["name"] for n in (labels_node.get("nodes") or []) if "name" in n
-            )
+            label_names = tuple(n["name"] for n in (labels_node.get("nodes") or []) if "name" in n)
             items.append(
                 {
                     "content": {
@@ -598,6 +603,28 @@ class Board:
             f"No project item for issue #{issue_number} in project "
             f"{self.project_number}. Is the issue added to the board?"
         )
+
+    def fetch_issue_body(self, issue_number: int) -> str:
+        """Return the issue body text via `gh issue view --json body`.
+
+        REST-bucket call (not GraphQL), so safe under GraphQL budget pressure.
+        Returns "" when the body is null or missing — callers treat that as
+        "no guidance section present," which is the correct safe default for
+        the audit-emission rail in `_cmd_close` (#227).
+        """
+        data = self.run_gh(
+            [
+                "issue",
+                "view",
+                str(issue_number),
+                "--repo",
+                self.repo,
+                "--json",
+                "body",
+            ]
+        )
+        body = data.get("body") if isinstance(data, dict) else None
+        return body if isinstance(body, str) else ""
 
     def _add_to_board(self, issue_number: int) -> str:
         """Call `gh project item-add` for `issue_number` and return the new item-id.

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -717,6 +717,28 @@ def test_close_rail_skipped_when_issue_body_lacks_guidance_h2(
     assert "close" in kinds, f"expected close to run on guidance-free issue; got {kinds}"
 
 
+def test_close_rejects_empty_no_audit_reason(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--no-audit ""` is technically allowed by argparse but would post an
+    unhelpful `_Audit-exempt close: _` marker. The CLI rejects empty / whitespace-
+    only reasons with a clear error and an example-reason hint.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    calls, _bodies = _patch_gh_capture_close_with_body(
+        monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42", "--no-audit", ""])
+
+    captured = capsys.readouterr()
+    assert rc == 2, captured.err
+    assert "non-empty reason" in captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" not in kinds and "close" not in kinds
+
+
 def test_audit_required_error_message_includes_template_and_escape(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_cmd_close.py
+++ b/tests/test_cmd_close.py
@@ -174,28 +174,36 @@ def _patch_gh_capture_close_with_body(
     *,
     project_number: int = 7,
     status: str = "In Progress",
+    issue_body: str = "",
 ) -> tuple[list[list[str]], list[str | None]]:
     """Patch subprocess.run for `jared close --body*` tests.
 
     Routes by argv shape:
-      - `issue comment` → snapshot --body-file content, return comment URL
+      - `issue view --json body` → `{"body": <issue_body>}` for the
+        audit-emission rail's `fetch_issue_body` lookup (#227). Default
+        body is "" so existing tests don't trip the rail.
+      - `issue comment` → snapshot --body / --body-file content, return URL
       - `issue close`   → empty stdout
       - `api graphql`   → projectItems response (find_item_id path)
       - `item-edit`     → "{}"
 
-    Returns (calls, bodies) where `bodies` is the snapshot of the
-    comment's --body-file content at call time (the CLI's `finally`
-    deletes the temp file before the test can read it later).
+    Returns (calls, bodies) where `bodies` is the snapshot of every
+    comment's body content (either --body inline or --body-file path
+    contents) in call order. The CLI's `finally` deletes the temp file
+    before the test can read it later, so snapshots happen at call time.
     """
     calls: list[list[str]] = []
     bodies: list[str | None] = []
 
     graphql_response = _graphql_item_response(project_number=project_number, status=status)
     comment_url = "https://github.com/brockamer/findajob/issues/42#issuecomment-9999"
+    issue_view_response = json.dumps({"body": issue_body})
 
     def fake_run(args: list[str], **_: object) -> FakeGhResult:
         calls.append(args)
         joined = " ".join(args)
+        if "issue" in args and "view" in args and "--json" in args:
+            return FakeGhResult(stdout=issue_view_response)
         if "issue" in args and "comment" in args:
             if "--body-file" in args:
                 idx = args.index("--body-file")
@@ -203,6 +211,9 @@ def _patch_gh_capture_close_with_body(
                     bodies.append(Path(args[idx + 1]).read_text())
                 except FileNotFoundError:
                     bodies.append(None)
+            elif "--body" in args:
+                idx = args.index("--body")
+                bodies.append(args[idx + 1])
             return FakeGhResult(stdout=comment_url)
         if "issue" in args and "close" in args:
             return FakeGhResult(stdout="")
@@ -458,3 +469,275 @@ def test_close_with_body_refuses_on_dirty_pre_flight_report(
     kinds = _call_kinds(calls)
     assert "comment" not in kinds, f"redactor must short-circuit before gh; calls: {kinds}"
     assert "close" not in kinds, f"redactor must block close too; calls: {kinds}"
+
+
+# ---------- audit-emission rail (#227) ----------
+
+_ISSUE_BODY_WITH_GUIDANCE = (
+    "Summary paragraph here.\n\n"
+    "## Acceptance criteria\n\n"
+    "- [ ] thing one\n\n"
+    "## Model & execution guidance\n\n"
+    "*Tiers below classify the work — they do not prescribe dispatch.*\n\n"
+    "**Cheap-tier work:**\n"
+    "- the cheap stuff\n"
+)
+
+_SESSION_NOTE_WITH_AUDIT = (
+    "## Session 2026-05-24 — closed\n\n"
+    "**Outcome:** shipped, tested, merged.\n\n"
+    "## Guidance audit (#42)\n\n"
+    "- Smart-tier decisions: routed through `advisor()`? yes — pre-fix design call\n"
+    "- Were your session's model and dispatch choices well-matched to the work size? yes\n"
+    "- Looking back, did any cheap-tier or surface-mapping work run inline that "
+    "would have been better dispatched? no — single-file edit, dispatch overhead "
+    "would have exceeded the work.\n"
+)
+
+_SESSION_NOTE_WITHOUT_AUDIT = (
+    "## Session 2026-05-24 — closed\n\n"
+    "**Outcome:** shipped, tested, merged.\n\n"
+    "Closing without ceremony — the change was a one-line config tweak.\n"
+)
+
+
+def _write_board_with_status_and_killswitch(tmp_path: Path) -> Path:
+    """Like _write_board_with_status, but with `model-guidance: disabled` set."""
+    board_md = tmp_path / "docs" / "project-board.md"
+    board_md.parent.mkdir(parents=True)
+    board_md.write_text(
+        dedent("""\
+        - Project URL: https://github.com/users/brockamer/projects/7
+        - Project number: 7
+        - Project ID: PVT_kwHO_xyz
+        - Owner: brockamer
+        - Repo: brockamer/findajob
+
+        ## Jared config
+        - model-guidance: disabled
+
+        ### Status
+        - Field ID: PVTSSF_status
+        - Backlog: OPTION_backlog
+        - In Progress: OPTION_in_progress
+        - Done: OPTION_done
+    """)
+    )
+    return board_md
+
+
+def test_close_refuses_when_guidance_present_and_no_body_no_escape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Bare `jared close <N>` on a guidance-bearing issue MUST refuse (#227 rail).
+    No comment, no close, no item-edit. Stderr names both escape paths.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    calls, _bodies = _patch_gh_capture_close_with_body(
+        monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42"])
+
+    captured = capsys.readouterr()
+    assert rc == 2, captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" not in kinds, f"rail must short-circuit before any comment; got {kinds}"
+    assert "close" not in kinds, f"rail must short-circuit before close; got {kinds}"
+    assert "item-edit" not in kinds, f"rail must short-circuit before item-edit; got {kinds}"
+    # Stderr message names both escape paths so the operator can choose.
+    assert "## Guidance audit" in captured.err
+    assert "--no-audit" in captured.err
+    assert "#227" in captured.err
+
+
+def test_close_refuses_when_body_lacks_audit_h2(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Body has a Session note but no `## Guidance audit (#N)` H2 → refuse.
+    Common drift mode in the #176 data: operator posts the Session note via
+    `jared close --body-file` but forgets to append the audit (10 of 24
+    direct-with-session-note closures fell into this shape).
+    """
+    board_md = _write_board_with_status(tmp_path)
+    note = tmp_path / "session.md"
+    note.write_text(_SESSION_NOTE_WITHOUT_AUDIT)
+    calls, _bodies = _patch_gh_capture_close_with_body(
+        monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42", "--body-file", str(note)])
+
+    captured = capsys.readouterr()
+    assert rc == 2, captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" not in kinds, f"rail must refuse before posting; got {kinds}"
+    assert "close" not in kinds, f"rail must refuse before close; got {kinds}"
+
+
+def test_close_passes_when_body_has_audit_h2(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Body containing both `## Session ...` and `## Guidance audit (#N)`
+    passes the rail — comment posts, close runs. The happy path.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    note = tmp_path / "session.md"
+    note.write_text(_SESSION_NOTE_WITH_AUDIT)
+    calls, bodies = _patch_gh_capture_close_with_body(
+        monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42", "--body-file", str(note)])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" in kinds and "close" in kinds
+    assert kinds.index("comment") < kinds.index("close")
+    # The posted body is the one we provided (with audit).
+    assert any(b == _SESSION_NOTE_WITH_AUDIT for b in bodies)
+
+
+def test_close_no_audit_escape_posts_marker_no_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--no-audit <reason>` without --body-file posts a single italic marker
+    comment, then closes. Used for legitimately exempt closures (epic-rollup,
+    scope-question, no-work-session). Marker is grep-able for future
+    `(audits + explicit --no-audits) / closures` measurement.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    calls, bodies = _patch_gh_capture_close_with_body(
+        monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42", "--no-audit", "scope-question"])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    kinds = _call_kinds(calls)
+    assert "comment" in kinds and "close" in kinds
+    assert kinds.index("comment") < kinds.index("close")
+    # Exactly one comment posted, body is the marker.
+    assert kinds.count("comment") == 1
+    assert bodies == ["_Audit-exempt close: scope-question_"]
+    assert "OK: marked exempt on #42" in captured.out
+
+
+def test_close_no_audit_with_body_posts_session_then_marker_then_closes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--body-file` + `--no-audit` together: post Session note FIRST, then
+    marker, then close. Order matters — if close fails mid-flow, the Session
+    note is durable (per #184 invariant) and the marker is durable too.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    note = tmp_path / "session.md"
+    note.write_text(_SESSION_NOTE_WITHOUT_AUDIT)
+    calls, bodies = _patch_gh_capture_close_with_body(
+        monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE
+    )
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "close",
+            "42",
+            "--body-file",
+            str(note),
+            "--no-audit",
+            "epic-rollup",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    kinds = _call_kinds(calls)
+    # Two comments precede the close.
+    assert kinds.count("comment") == 2
+    assert "close" in kinds
+    first_comment = kinds.index("comment")
+    second_comment = kinds.index("comment", first_comment + 1)
+    close_idx = kinds.index("close")
+    assert first_comment < second_comment < close_idx, (
+        f"expected session-note → marker → close, got {kinds}"
+    )
+    # Body order: session note first, then marker.
+    assert bodies == [
+        _SESSION_NOTE_WITHOUT_AUDIT,
+        "_Audit-exempt close: epic-rollup_",
+    ]
+
+
+def test_close_rail_skipped_when_model_guidance_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`docs/project-board.md` § `## Jared config` contains `- model-guidance:
+    disabled` → rail is bypassed. Bare close on a guidance-bearing issue runs
+    to completion. The kill switch is what lets opt-out projects coexist.
+    """
+    board_md = _write_board_with_status_and_killswitch(tmp_path)
+    calls, _bodies = _patch_gh_capture_close_with_body(
+        monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42"])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    kinds = _call_kinds(calls)
+    assert "close" in kinds, f"expected close to run with kill switch on; got {kinds}"
+
+
+def test_close_rail_skipped_when_issue_body_lacks_guidance_h2(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue body without `## Model & execution guidance` → rail doesn't fire.
+    Pre-existing closes on guidance-free issues continue to work unchanged,
+    which is critical for the backward-compatibility contract.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    # Default fixture issue_body="" → no guidance H2 → rail passes.
+    calls, _bodies = _patch_gh_capture_close_with_body(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42"])
+
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    kinds = _call_kinds(calls)
+    assert "close" in kinds, f"expected close to run on guidance-free issue; got {kinds}"
+
+
+def test_audit_required_error_message_includes_template_and_escape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The refusal stderr must include the audit template and the --no-audit
+    hint so the operator can pick a path without consulting docs. This is a
+    UX-pinning test — the message text matters because it's shown at the
+    moment of frustration.
+    """
+    board_md = _write_board_with_status(tmp_path)
+    _patch_gh_capture_close_with_body(monkeypatch, issue_body=_ISSUE_BODY_WITH_GUIDANCE)
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "close", "42"])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    err = captured.err
+    # Template signature.
+    assert "## Guidance audit (#42)" in err
+    assert "advisor()" in err
+    assert "closest call you considered" in err  # bundles #226's Q3 reword
+    # Escape with example reasons.
+    assert "--no-audit" in err
+    assert "scope-question" in err


### PR DESCRIPTION
## Summary

- Closes #227 (the 63% audit-emission gap) by adding a CLI rail to `jared close`: when the issue body carries `## Model & execution guidance` AND the project kill switch is off, the close refuses unless the body contains `## Guidance audit (#N)` OR `--no-audit <reason>` is passed (posts a `_Audit-exempt close: <reason>_` marker).
- Bundles #226 (Q3 reword) into the same wrap doctrine surface — Q3 prompt now reads `[yes / no / N/A — if no, name the closest call you considered]` per #176's surgical refinement.

## Diagnosis (n=100, post-v0.19.0 window, jared + findajob)

Combined emission rate: 63.0% (63/100), consistent with #176's 63.6%. Split by closure trigger + Session-note presence reveals two uniform gap modes:

| Mode | Cases | Emission |
|---|---|---|
| Session note exists, no audit H2 | 20 | 41% |
| No Session note at all | 15 | 0% |
| Residual (commit-message direct) | 2 | — |

**Hypothesis 2 (PR-merge bypass) from #227's body is empirically refuted.** PR-merge as a category emits at 76% — *above* the 63% baseline. Operators run `/jared-wrap` before merging in most cases; the gap was in wrap-comment shape, not in close-trigger.

## Fix design (refined by advisor consult)

Single CLI validation in `_cmd_close`:

- Required arg: `--body` / `--body-file` *when* issue has `## Model & execution guidance` AND kill switch off.
- Body must contain `^## Guidance audit \(#` (matches the doctrine template at `commands/jared-wrap.md`).
- Escape: `--no-audit REASON` (mirrors `--no-milestone` from #238). Posts a marker comment so the closure is countable as exempt.
- Bypass: `- model-guidance: disabled` in `docs/project-board.md` § `## Jared config` skips the rail entirely.

Refusal stderr renders the audit template + both escape paths so operator can pick at the moment of refusal.

## Doctrine propagation (second commit)

After landing the rail, doc-sync follow-up across the surfaces Claude / operators read when composing closes:

- `SKILL.md` command listing now shows close variants (`--body` / `--body-file` / `--no-audit`).
- `SKILL.md` "When completing work" narrative names the typical wrap path (`--body-file -`) and the typical exempt path (`--no-audit no-work-session`).
- `references/jared-cli.md` recovery doc: post-rail recovery uses `--no-audit already-emitted` rather than "re-run bare close" (which the rail would now refuse).
- Five exempt-reason vocabulary terms standardized across SKILL.md / jared-cli.md / jared-wrap.md / CLI error text: `epic-rollup`, `scope-question`, `no-work-session`, `docs-trivia`, `already-emitted`.

UX fixes in the same commit:
- `_print_audit_required_error` had awkward column alignment on Q2; replaced with brackets-immediately-after-question form so the rendered template stays scannable.
- `--no-audit ""` (empty reason) is now refused; was previously accepted by argparse and would render an unhelpful marker.

## Projected post-fix emission

**~85–95%**, depending on operator path mix:

- **Provably caught (≥21 of 37 audit-less paths):** all direct-close audit-less cases (11 no-Session + 10 with-Session-but-no-audit) — the rail fires on every direct `jared close` invocation against guidance-bearing issues.
- **Conditionally caught (10 of 14 PR-merge audit-less):** the PR-merge audit-less cases that had Session notes — these were posted *somehow*. If via `jared close --body-file` (then close fired again on PR merge), the rail caught them next time. If via `jared comment` + bare `gh pr merge`, the rail doesn't fire — `jared close` isn't in the close path. The split between these two operator-habit paths is unknown from the data.
- **Not caught (≤4 cases):** pure PR auto-close without any prior `jared close` call (the 4 no-Session pr-merge audit-less cases). These bypass the CLI entirely.

So 21 cases are firmly closed and 10 more depend on operator path. Future-metric formula becomes `(audits + explicit --no-audits) / closures ≥ 85%`.

## What this does NOT do

- **No PR-close-detection in `/jared-wrap`** — hypothesis 2 was refuted by data; PR-merge category emits above average already.
- **No change to `jared comment`** — mid-session notes don't carry audit obligation; only `_cmd_close` is the wrap-time signature.
- **No re-measurement script change** — the marker-comment shape is forward-compatible, but the audit-rate query update is post-merge follow-up work (4-week window).

## Test plan

- [x] 531 unit tests pass (9 new tests in `test_cmd_close.py` cover refusal paths, escapes, kill-switch bypass, guidance-free passthrough, error UX, empty-reason rejection)
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --strict` clean
- [x] Eyeball-render of `_print_audit_required_error` confirms scannable layout
- [ ] Live smoke: close an issue on jared-testbed with the rail active (deferred — unit coverage is comprehensive; rail short-circuits before any gh call on refusal)
- [ ] Re-measure emission rate 4 weeks post-merge (filed as follow-up; AC #4 of #227)

🤖 Generated with [Claude Code](https://claude.com/claude-code)