### PR TITLE
fix(session-lock) + doctrine(wrap): issue-keyed locks + worktree-removal (#259 + #260)

### DIFF
--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -92,13 +92,19 @@ Flow:
    - Apply non-close reconciliation: `jared move <N> "Backlog"` (or `"Up Next"`) for abandoned ones, `jared file ...` for newly-filed scope
    - Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/archive-plan.py --scan --repo <owner>/<repo>` for shippable plans
    - Update `## Current state` on issues where it meaningfully changed this session via `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/capture-context.py`
-   - Clear this session's presence lock:
+   - Clear this session's presence lock. The lock is keyed by the issue this session was started against (`<N>` = the `/jared-start` argument), not by PID — PID-keyed locks were stale-on-arrival because the writing CLI subprocess exits immediately (#259):
      ```bash
      GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
      REPO_ROOT=$(dirname "$GIT_COMMON_DIR")
-     ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared session-lock-clear --repo-root "$REPO_ROOT"
+     ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared session-lock-clear --repo-root "$REPO_ROOT" --issue <N>
      ```
-     Removes `<repo>/.jared/session-<pid>.lock` so the next `/jared-start` doesn't see this session as a live sibling. Sibling sessions' locks are left untouched (the clear is PID-keyed).
+     Removes `<repo>/.jared/session-<N>.lock` so the next `/jared-start` doesn't see this session as a live sibling. Sibling sessions' locks (other issues) are left untouched.
+   - **Worktree removal (multi-session only).** When this session worked from a worktree (created by `/jared-start <N> --session N` — non-null `worktree_path` on the lock) AND the corresponding `feature/<N>-worktree` branch has merged into main, remove the worktree and delete the branch from the main checkout:
+     ```bash
+     git -C "$REPO_ROOT" worktree remove "<worktree-path>"
+     git -C "$REPO_ROOT" branch -d feature/<N>-worktree
+     ```
+     The cleanup is **scoped to this session's issue**, not lockdir-wide — sibling worktrees from other parallel sessions are not touched. Skip the bullet entirely for solo sessions (worktree_path is null) and for sessions whose branch hasn't merged yet (the operator decides whether to keep the unmerged worktree around). The rule comes from operator feedback after the 2026-05-24 wrap of #227's session-1 left an orphan `~/Code/jared-227/` on disk — see the `[[feedback-wrap-remove-merged-worktree]]` user-memory note for the original framing.
 
 6. **Confirm and close out.** Render the closing line in voice:
 

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -352,7 +352,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     slw = sub.add_parser(
         "session-lock-write",
-        help="Write a lock file for this PID into <repo-root>/.jared/.",
+        help="Write a lock file for this issue into <repo-root>/.jared/.",
     )
     slw.add_argument("--repo-root", required=True, help="Path to the main checkout.")
     slw.add_argument("--issue", type=int, required=True, help="Issue number being worked.")
@@ -371,9 +371,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     slc = sub.add_parser(
         "session-lock-clear",
-        help="Remove the lock file for this PID (called by /jared-wrap).",
+        help="Remove the lock file for this issue (called by /jared-wrap).",
     )
     slc.add_argument("--repo-root", required=True, help="Path to the main checkout.")
+    slc.add_argument(
+        "--issue",
+        type=int,
+        required=True,
+        help="Issue number whose lock to clear.",
+    )
     slc.set_defaults(func=_cmd_session_lock_clear)
 
     wa = sub.add_parser(
@@ -1535,8 +1541,8 @@ def _cmd_session_lock_write(args: argparse.Namespace) -> int:
 
 
 def _cmd_session_lock_clear(args: argparse.Namespace) -> int:
-    """Clear this PID's lock file."""
-    session_lock.clear_lock(repo_root=Path(args.repo_root), pid=os.getpid())
+    """Clear this issue's lock file."""
+    session_lock.clear_lock(repo_root=Path(args.repo_root), issue=args.issue)
     return 0
 
 

--- a/skills/jared/scripts/lib/session_lock.py
+++ b/skills/jared/scripts/lib/session_lock.py
@@ -1,12 +1,20 @@
-"""Session-presence locking for parallel jared sessions (#231, #236).
+"""Session-presence locking for parallel jared sessions (#231, #236, #259).
 
-Every active `/jared-start` writes a JSON lock file at `<repo>/.jared/session-<pid>.lock`
-recording the session's PID, start time, and (if multi-session) the `--session N` value
-plus worktree path. This makes the B-leg refusal real: a later `/jared-start` reads
-existing locks, checks PID-liveness, and refuses-with-guidance when a sibling is
-detected and the operator hasn't opted into multi-session.
+Every active `/jared-start` writes a JSON lock file at `<repo>/.jared/session-<issue>.lock`
+recording the issue, start time, optional `--session N` value, worktree path, and the
+writing process's PID (diagnostic only). The lock is keyed by issue, not PID: the
+CLI subprocess that writes the lock exits immediately, so a PID-keyed file would be
+dead-on-arrival and the B-leg refusal would never fire (the original #231/#236
+implementation had this defect — #259 fixes it).
 
-See docs/superpowers/specs/2026-05-23-multi-session-impl-design.md for design.
+Locks live until explicitly cleared by `/jared-wrap` (or `jared session-lock-clear
+--issue N`). A crashed session leaves its lock on disk; the next `/jared-start` will
+detect it and refuse with guidance, including the recorded PID so the operator can
+verify and force-clear if appropriate.
+
+See docs/superpowers/specs/2026-05-23-multi-session-impl-design.md for original design;
+this module's identity model was reworked in #259 after empirical evidence that
+PID-keyed locks were stale-on-arrival.
 """
 
 from __future__ import annotations
@@ -15,7 +23,6 @@ import contextlib
 import enum
 import json
 import os
-import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -35,15 +42,15 @@ def _lock_dir(repo_root: Path) -> Path:
     return repo_root / ".jared"
 
 
-def _lock_path(repo_root: Path, pid: int) -> Path:
-    return _lock_dir(repo_root) / f"session-{pid}.lock"
+def _lock_path(repo_root: Path, issue: int) -> Path:
+    return _lock_dir(repo_root) / f"session-{issue}.lock"
 
 
 def write_lock(repo_root: Path, lock: Lock) -> Path:
     """Atomically write a lock file for this session. Returns the path."""
     lockdir = _lock_dir(repo_root)
     lockdir.mkdir(parents=True, exist_ok=True)
-    path = _lock_path(repo_root, lock.pid)
+    path = _lock_path(repo_root, lock.issue)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(asdict(lock)))
     os.replace(tmp, path)
@@ -89,20 +96,28 @@ def is_alive(pid: int) -> bool:
     return True
 
 
-def clear_lock(repo_root: Path, pid: int) -> None:
-    """Remove the lock file for this PID. No-op if absent."""
-    path = _lock_path(repo_root, pid)
+def clear_lock(repo_root: Path, issue: int) -> None:
+    """Remove the lock file for this issue. No-op if absent."""
+    path = _lock_path(repo_root, issue)
     with contextlib.suppress(FileNotFoundError):
         path.unlink()
 
 
 def list_active_locks(repo_root: Path) -> list[Lock]:
-    """Enumerate all live session locks for this repo. Clears stale entries.
+    """Enumerate all session locks on disk for this repo.
 
-    Walks `<repo>/.jared/session-*.lock`, reads each, drops any with a dead
-    PID (deleting the stale file and emitting a one-line stderr warning).
-    Malformed lock files are silently skipped — they may be partial writes
-    from a crashed write that didn't reach os.replace.
+    Walks `<repo>/.jared/session-*.lock` and reads each. Malformed lock files
+    are silently skipped — they may be partial writes from a crashed write
+    that didn't reach os.replace. Old-style locks left over from the pre-#259
+    PID-keyed naming (filename number ≠ recorded `issue` field) are removed
+    opportunistically — this is the only automatic migration path for in-place
+    upgrades from pre-#259 installs.
+
+    No PID-liveness sweep is performed: the CLI subprocess's PID (only recorded
+    diagnostically) is always dead by the time anything reads the file. A
+    crashed session leaves its lock on disk; the operator clears it explicitly
+    with `jared session-lock-clear --issue N` when the next `/jared-start`
+    surfaces the orphan.
     """
     lockdir = _lock_dir(repo_root)
     if not lockdir.exists():
@@ -112,15 +127,18 @@ def list_active_locks(repo_root: Path) -> list[Lock]:
         lock = read_lock(path)
         if lock is None:
             continue
-        if is_alive(lock.pid):
-            active.append(lock)
-        else:
+        # Migration: pre-#259 lock filenames were session-<pid>.lock; their
+        # filename number won't match the lock's `issue` field. Issue-keyed
+        # writes (#259 onward) always satisfy filename_number == lock.issue.
+        try:
+            filename_number = int(path.stem.removeprefix("session-"))
+        except ValueError:
+            filename_number = -1
+        if filename_number != lock.issue:
             with contextlib.suppress(OSError):
                 path.unlink()
-            print(
-                f"warning: cleared stale lock for PID {lock.pid} (no longer running): {path}",
-                file=sys.stderr,
-            )
+            continue
+        active.append(lock)
     return active
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,8 +222,7 @@ def test_session_lock_write_creates_file(tmp_path: Path) -> None:
         ]
     )
     assert result == 0
-    pid = os.getpid()
-    lock_path = tmp_path / ".jared" / f"session-{pid}.lock"
+    lock_path = tmp_path / ".jared" / "session-231.lock"
     assert lock_path.exists()
 
 
@@ -241,9 +240,9 @@ def test_session_lock_clear_removes_file(tmp_path: Path) -> None:
         ),
     )
     mod = import_cli()
-    result = mod.main(["session-lock-clear", "--repo-root", str(tmp_path)])
+    result = mod.main(["session-lock-clear", "--repo-root", str(tmp_path), "--issue", "231"])
     assert result == 0
-    lock_path = tmp_path / ".jared" / f"session-{os.getpid()}.lock"
+    lock_path = tmp_path / ".jared" / "session-231.lock"
     assert not lock_path.exists()
 
 

--- a/tests/test_session_lock.py
+++ b/tests/test_session_lock.py
@@ -1,8 +1,10 @@
-"""Unit tests for lib/session_lock.py — session-presence locks (#231)."""
+"""Unit tests for lib/session_lock.py — session-presence locks (#231, #259)."""
 
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -19,7 +21,7 @@ def test_lock_round_trips_through_disk(tmp_path: Path) -> None:
         issue=231,
     )
     path = session_lock.write_lock(repo_root=tmp_path, lock=lock)
-    assert path == tmp_path / ".jared" / "session-12847.lock"
+    assert path == tmp_path / ".jared" / "session-231.lock"
     assert path.exists()
 
     loaded = session_lock.read_lock(path)
@@ -34,7 +36,7 @@ def test_read_lock_returns_none_when_file_absent(tmp_path: Path) -> None:
 def test_read_lock_returns_none_when_json_corrupted(tmp_path: Path) -> None:
     lockdir = tmp_path / ".jared"
     lockdir.mkdir()
-    path = lockdir / "session-12847.lock"
+    path = lockdir / "session-231.lock"
     path.write_text("{not json")
     assert session_lock.read_lock(path) is None
 
@@ -79,7 +81,7 @@ def test_list_active_locks_empty_when_no_lockdir(tmp_path: Path) -> None:
     assert session_lock.list_active_locks(repo_root=tmp_path) == []
 
 
-def test_list_active_locks_returns_alive_locks(tmp_path: Path) -> None:
+def test_list_active_locks_returns_existing_locks(tmp_path: Path) -> None:
     lock = session_lock.Lock(
         pid=os.getpid(),
         started="2026-05-23T14:22:00Z",
@@ -93,44 +95,68 @@ def test_list_active_locks_returns_alive_locks(tmp_path: Path) -> None:
     assert active[0] == lock
 
 
-def test_list_active_locks_clears_stale_locks(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    stale = session_lock.Lock(
-        pid=9999999,
+def test_list_active_locks_no_longer_sweeps_by_pid_liveness(tmp_path: Path) -> None:
+    """Regression: pre-#259 list_active_locks deleted locks whose JSON PID was dead.
+
+    With issue-keyed locks, the PID is diagnostic only — a dead PID is the norm,
+    not a staleness signal. The lock must survive enumeration regardless.
+    """
+    lock = session_lock.Lock(
+        pid=9999999,  # almost certainly dead
         started="2026-05-23T10:00:00Z",
         session=None,
         worktree_path=None,
         issue=200,
     )
-    session_lock.write_lock(repo_root=tmp_path, lock=stale)
-    stale_path = tmp_path / ".jared" / "session-9999999.lock"
-    assert stale_path.exists()
+    session_lock.write_lock(repo_root=tmp_path, lock=lock)
+    lock_path = tmp_path / ".jared" / "session-200.lock"
+    assert lock_path.exists()
 
-    original_kill = os.kill
-
-    def fake_kill(pid: int, sig: int) -> None:
-        if pid == 9999999:
-            raise ProcessLookupError()
-        original_kill(pid, sig)
-
-    monkeypatch.setattr(os, "kill", fake_kill)
     active = session_lock.list_active_locks(repo_root=tmp_path)
 
-    assert active == []
-    assert not stale_path.exists()
-    captured = capsys.readouterr()
-    assert "stale lock" in captured.err.lower()
-    assert "9999999" in captured.err
+    assert len(active) == 1
+    assert active[0] == lock
+    assert lock_path.exists()
 
 
 def test_list_active_locks_skips_malformed_files(tmp_path: Path) -> None:
     lockdir = tmp_path / ".jared"
     lockdir.mkdir()
-    (lockdir / "session-12847.lock").write_text("{not json")
+    (lockdir / "session-231.lock").write_text("{not json")
     assert session_lock.list_active_locks(repo_root=tmp_path) == []
+
+
+def test_list_active_locks_migrates_legacy_pid_keyed_locks(tmp_path: Path) -> None:
+    """Pre-#259 locks named session-<pid>.lock have filename ≠ issue field; remove.
+
+    An in-place upgrade from a pre-#259 install will leave PID-keyed lock files
+    behind. The new code can detect them (filename number doesn't match the
+    recorded `issue` field) and clean them up on first read.
+    """
+    import json
+
+    lockdir = tmp_path / ".jared"
+    lockdir.mkdir()
+    # Pre-#259 shape: filename = PID, payload's issue = the actual issue.
+    legacy_pid = 2047095
+    legacy_path = lockdir / f"session-{legacy_pid}.lock"
+    legacy_path.write_text(
+        json.dumps(
+            {
+                "pid": legacy_pid,
+                "started": "2026-05-23T14:00:00Z",
+                "session": 1,
+                "worktree_path": None,
+                "issue": 231,
+            }
+        )
+    )
+    assert legacy_path.exists()
+
+    active = session_lock.list_active_locks(repo_root=tmp_path)
+
+    assert active == []
+    assert not legacy_path.exists()
 
 
 def test_clear_lock_removes_matching_file(tmp_path: Path) -> None:
@@ -143,13 +169,13 @@ def test_clear_lock_removes_matching_file(tmp_path: Path) -> None:
     )
     path = session_lock.write_lock(repo_root=tmp_path, lock=lock)
     assert path.exists()
-    session_lock.clear_lock(repo_root=tmp_path, pid=12847)
+    session_lock.clear_lock(repo_root=tmp_path, issue=231)
     assert not path.exists()
 
 
 def test_clear_lock_is_noop_when_file_absent(tmp_path: Path) -> None:
     # no lockdir, no file — should not raise
-    session_lock.clear_lock(repo_root=tmp_path, pid=12847)
+    session_lock.clear_lock(repo_root=tmp_path, issue=231)
 
 
 def test_clear_lock_leaves_other_sessions_alone(tmp_path: Path) -> None:
@@ -162,9 +188,71 @@ def test_clear_lock_leaves_other_sessions_alone(tmp_path: Path) -> None:
     session_lock.write_lock(repo_root=tmp_path, lock=own)
     session_lock.write_lock(repo_root=tmp_path, lock=sibling)
 
-    session_lock.clear_lock(repo_root=tmp_path, pid=12847)
+    session_lock.clear_lock(repo_root=tmp_path, issue=231)
 
-    own_path = tmp_path / ".jared" / "session-12847.lock"
-    sibling_path = tmp_path / ".jared" / "session-13201.lock"
+    own_path = tmp_path / ".jared" / "session-231.lock"
+    sibling_path = tmp_path / ".jared" / "session-235.lock"
     assert not own_path.exists()
     assert sibling_path.exists()
+
+
+def test_lock_lifecycle_survives_subprocess_boundary(tmp_path: Path) -> None:
+    """Regression test for #259: write/clear must work across subprocess boundaries.
+
+    Pre-#259, the CLI keyed the lock filename on `os.getpid()`. The subprocess
+    that wrote the lock exited immediately, so the lock was named after a
+    dead PID and the wrap's clear (running in a *different* subprocess with
+    its own getpid()) was a silent no-op. Issue-keyed locks survive both the
+    write and the clear correctly.
+    """
+    cli_path = Path(__file__).parents[1] / "skills" / "jared" / "scripts" / "jared"
+    issue = 260
+
+    # Write the lock in subprocess A.
+    write_result = subprocess.run(
+        [
+            sys.executable,
+            str(cli_path),
+            "session-lock-write",
+            "--repo-root",
+            str(tmp_path),
+            "--issue",
+            str(issue),
+            "--session",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert write_result.returncode == 0, write_result.stderr
+
+    # The file must exist after subprocess A exits — and the filename is the
+    # issue, not the (now-dead) writing PID.
+    lock_path = tmp_path / ".jared" / f"session-{issue}.lock"
+    assert lock_path.exists()
+
+    # list_active_locks (called by a third process) must still see the lock.
+    active = session_lock.list_active_locks(repo_root=tmp_path)
+    assert len(active) == 1
+    assert active[0].issue == issue
+
+    # Clear in subprocess B (different PID from subprocess A).
+    clear_result = subprocess.run(
+        [
+            sys.executable,
+            str(cli_path),
+            "session-lock-clear",
+            "--repo-root",
+            str(tmp_path),
+            "--issue",
+            str(issue),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert clear_result.returncode == 0, clear_result.stderr
+
+    assert not lock_path.exists()
+    assert session_lock.list_active_locks(repo_root=tmp_path) == []


### PR DESCRIPTION
## Summary

Bundles two related fixes to step 5 of the wrap-flow surface:

- **#259** — `lib/session_lock.py` lock-identity redesign. Filename is now `session-<issue>.lock` (derived from the issue this session was started against) instead of `session-<pid>.lock`. The pre-#259 PID-keyed scheme was stale-on-arrival because the writing CLI subprocess exits immediately; the B-leg refusal in `resolve_action` looked correct in tests but had never actually fired against a real sibling.
- **#260** — `commands/jared-wrap.md` step 5 doctrine. Updates the `session-lock-clear` invocation to pass `--issue <N>` and adds a "Worktree removal" sub-bullet for multi-session work whose branch has merged.

## Scope shift from #259's filed criteria

#259's acceptance criterion #1 was written as "removes those whose PID is either (a) the current `os.getpid()` OR (b) some explicitly-specified PID." Empirical investigation at start-time showed PID-keyed locks were *structurally* broken — the writing PID is always dead by the time anything reads the file. The criterion was reinterpreted (with operator approval) as "redesign lock identity to use issue, not PID; PID becomes diagnostic-only." The literal criteria are not satisfied; the underlying defect is.

## Empirical evidence captured at start-time

A lock written by `/jared-start --session 1` to `.jared/session-2047095.lock`:

```
{"pid": 2047095, "started": "2026-05-27T18:21:25Z", "session": 1, "worktree_path": "/home/brockamer/Code/jared-260", "issue": 260}
```

`kill -0 2047095` ≈ 60s after write: **dead**. `list_active_locks` would have swept this immediately as stale → `resolve_action` would have returned `PROCEED_SOLO` even though the session was active. The "cleared stale lock for PID …" warning seen at runtime was the bash subprocess from `/jared-start` sweeping itself.

## Verification

- **532 → 533 unit tests pass** (added `test_lock_lifecycle_survives_subprocess_boundary` + `test_list_active_locks_migrates_legacy_pid_keyed_locks`).
- `ruff check`, `mypy --strict` clean.
- **Manual subprocess-boundary smoke** confirmed:
  - SOLO `session-lock-write --issue 777` writes `session-777.lock` with `session=null`.
  - A fresh subprocess `session-resolve` (no flag) → `REFUSE_BLEG`. **Pre-fix this returned `PROCEED_SOLO` — the silently-broken path that has been wrong since #231 shipped.**
  - `session-resolve --session 1` against the same solo sibling → `REFUSE_BLEG` (solo-sibling refusal takes precedence over dup-N).
- **`git worktree remove "$(pwd)"` from inside the worktree** (via `git -C "$REPO_ROOT" …`) verified to succeed (exit 0); the calling shell's cwd becomes stale but that's a benign post-wrap side effect.
- **Migration smoke** on a real legacy lock: pre-existing `session-2047095.lock` at `/home/brockamer/Code/jared/.jared/` was removed on first `session-resolve` post-upgrade.

## Backward compatibility

In-place upgrades from pre-#259 installs may have orphan `session-<pid>.lock` files left over. `list_active_locks` detects them (filename number ≠ lock's `issue` field) and removes them opportunistically on first read. Operator-visible behavior: stale locks self-clean once any `/jared-start` or `jared summary` runs against the upgraded code.

## Test plan

- [x] All 533 tests pass locally
- [x] `ruff check` + `mypy --strict` clean
- [x] Solo-path B-leg refusal smoke: `session-lock-write --issue N` (no `--session`), then `session-resolve` in fresh subprocess → `REFUSE_BLEG`
- [x] Multi-path B-leg refusal smoke: same with `--session 1` → `REFUSE_BLEG` (solo-sibling takes precedence)
- [x] Cross-subprocess clear: write in subprocess A, clear from subprocess B with `--issue N` → file gone
- [x] Legacy-lock migration smoke: pre-existing `session-<pid>.lock` removed on first `list_active_locks` call
- [x] `git worktree remove` from inside the worktree (verified in `/tmp/wt-rm-test`)

Closes #259. Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)