### PR TITLE
feat(multi-session): stage proposal + wrap back-end

### DIFF
--- a/commands/jared-stage.md
+++ b/commands/jared-stage.md
@@ -52,9 +52,46 @@ To run /jared-stage automatically:
 
 The schedule skill fires `/jared-stage --report-only` at the configured times. The `--report-only` flag suppresses the "Approve?" prompt; the output lands wherever `/schedule` delivers it (notification, log thread). To apply scheduled-fire output, re-run `/jared-stage` interactively in a session.
 
+## Session-N partitioning (`--sessions N`)
+
+When the operator runs `/jared-stage --sessions N` (e.g., `--sessions 2`), propose session-N label assignments across the current candidate set.
+
+Flow:
+
+1. **Run the partition CLI:**
+
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared propose-partition --sessions N
+   ```
+
+2. **Capture stdout.** The CLI emits a per-session block showing `keep` (existing labels honored) and `add` (no existing label, partition proposes one), plus a `floats` block for candidates with no surface signal.
+
+3. **Display verbatim, voice-wrapped:**
+
+   > Looking at the partition for sessions 1 and 2 — here's what I'd propose based on file paths in the issue bodies:
+   >
+   > [verbatim CLI output]
+   >
+   > Approve? (`y` to apply all additions / `edit #N session=K` to override / `skip` to leave everything as-is)
+
+4. **On `y`:** apply each `add` assignment with:
+
+   ```bash
+   gh issue edit <N> --add-label session-K --repo <owner>/<repo>
+   ```
+
+5. **On `edit #N session=K`:** apply the operator's override for that issue, then continue applying the remaining `add` entries.
+
+6. **On `skip`:** do nothing; the partition is unchanged.
+
+**Honoring existing labels.** The partition algorithm never overrides an existing `session-N` label. To re-balance, the operator removes the label manually and re-runs `/jared-stage --sessions N`.
+
+**Single signal.** v1 uses only file paths cited in issue bodies. Two candidates whose bodies share a path are presumed to touch overlapping code. Issues with no paths in their body float (no label proposed) — they appear in the `floats` block for manual assignment.
+
 ## Flags
 
 - `--report-only`: emit proposals only; skip the approval prompt. Intended for scheduled fires.
+- `--sessions N`: propose session-N label assignments across current candidates. See **Session-N partitioning** above.
 - `--up-next-cap <N>`: override the default Up Next cap of 3. Useful for projects with different WIP norms.
 
 See `docs/superpowers/specs/2026-05-14-jared-stage-design.md` for the full design.

--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -69,6 +69,59 @@ Flow:
    - Apply non-close reconciliation: `jared move <N> "Backlog"` (or `"Up Next"`) for abandoned ones, `jared file ...` for newly-filed scope
    - Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/archive-plan.py --scan --repo <owner>/<repo>` for shippable plans
    - Update `## Current state` on issues where it meaningfully changed this session via `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/capture-context.py`
+
+5b. **Run the back-end flow.** After Session notes are posted and reconciliation is applied, run the commit → push → PR create → mergeable check → confirm merge → cleanup sequence. The flow is idempotent — re-running `/jared-wrap` re-evaluates state and picks up at the current step.
+
+   Loop:
+
+   ```bash
+   STEP=$(${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared wrap-state)
+   ```
+
+   Each iteration of the loop runs the CLI to determine the next step, then executes that step. Loop exits on `cleanup` (which runs the lock-clear + worktree-remove block below), or when the operator declines a confirm prompt, or when a non-actionable step (`wait_checks`, `surface_failure`, `surface_conflict`) is returned.
+
+   **Step actions:**
+
+   - **`commit`** (working tree dirty): Show `git status` to the operator. Ask: *"Commit message? (or 'skip' to leave uncommitted and exit)"*. On a message: run `git add -A && git commit -m "$msg"`. On `skip`: exit wrap (the lock is still cleared at the end). Loop continues after a successful commit.
+
+   - **`push`** (local commits ahead of remote): Run `git push -u origin $(git rev-parse --abbrev-ref HEAD)`. On failure, surface the git error and exit. Loop continues on success.
+
+   - **`create_pr`** (no PR for the branch): Auto-generate title from the issue title (the issue moved to In Progress at start). Auto-generate body from the issue's first paragraph + the commit subjects on the branch. Run:
+
+     ```bash
+     gh pr create --title "$TITLE" --body "$BODY"
+     ```
+
+     On failure, surface the gh error and exit. Loop continues on success.
+
+   - **`wait_checks`** (PR exists, checks pending): Print *"PR #N: checks pending. Re-run `/jared-wrap` when they're green and I'll handle the merge."* Exit the loop (do not poll). The remaining wrap steps (lock-clear) still run.
+
+   - **`surface_failure`** (PR exists, checks failed): Print the failed check names from `gh pr checks $PR --json`. Exit the loop. Lock-clear runs.
+
+   - **`surface_conflict`** (checks green but not mergeable): Print *"PR #N: conflict with main. Rebase in this worktree (`git fetch && git rebase origin/main`), resolve, push, and re-run `/jared-wrap`."* Exit the loop. Lock-clear runs.
+
+   - **`confirm_merge`** (checks green, mergeable): Render the confirm-merge block:
+
+     ```
+     PR #<N>: <title>
+       branch:     <branch>
+       mergeable:  yes
+       checks:     <count> passed
+       sibling:    <enumerate other session locks if present, with their branches>
+
+     Merge? (y / edit / no)
+     ```
+
+     On `y`: run `gh pr merge <N> --merge --delete-branch`. On success, loop continues (next state will be `cleanup`). On failure (e.g., GitHub rejected as not-mergeable since the last check), surface the gh error and exit the loop.
+
+     On `edit`: prompt for new title/body inline; run `gh pr edit <N> --title "$NEW_TITLE" --body "$NEW_BODY"`; re-render the confirm block.
+
+     On `no`: exit the loop. Lock-clear runs.
+
+   - **`cleanup`** (PR merged, branch still local): Run the lock-clear + worktree-remove block below.
+
+   **Concurrent-merge safety.** Two sessions reaching `confirm_merge` at nearly the same time both run the same `wrap-state` query just before the merge. GitHub's PR-merge API is atomic — the first call serializes ahead of the second. If the first's merge invalidates the second's mergeable state, the second's `gh pr merge` call returns an error from GitHub, which surfaces to the operator. No Jared-side lock is used.
+
    - Clear this session's presence lock. The lock is keyed by the issue this session was started against (`<N>` = the `/jared-start` argument), not by PID — PID-keyed locks were stale-on-arrival because the writing CLI subprocess exits immediately (#259):
      ```bash
      GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)

--- a/skills/jared/references/parallel-sessions.md
+++ b/skills/jared/references/parallel-sessions.md
@@ -22,24 +22,17 @@ parallel-session start (option 1a from the v1.1 multi-session shape spec).
 Not Jared, not `/jared-stage`, not `/jared-start`. Auto-application was
 considered and deferred — see `docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-shape.md` § "Workstream 1".
 
-## Pre-parallel-session operator ritual
+## Pre-parallel-session ritual
 
 Before launching two or more Claude sessions against the same repo:
 
-1. Glance at Up Next + In Progress and partition the next pull candidates
-   by *surface overlap* — which issues touch the same files, modules, or
-   shared helpers.
-2. Apply `session-1` to the group session 1 will own, `session-2` to the
-   group session 2 will own, etc. Items with no surface overlap stay
-   unlabeled and act as floats either session can claim.
-3. Start the sessions with `/jared-start <issue> --session N`. The flag
-   tells the session-presence resolver which claim it represents.
+1. Run `/jared-stage --sessions N` (e.g., `--sessions 2` for two sessions). Jared reads current `session-N` labels and the Up Next candidates, then proposes a partition based on file-paths overlap in issue bodies. Operator approves or edits per-item.
 
-The discipline is operator vigilance, not mechanism. The mechanism that
-*does* land per #235: `jared summary`'s WIP arithmetic collapses items
-sharing a `session-N` label into a single workstream count, so two
-session-1 issues + one session-2 issue render as "2 workstreams · 3 items"
-rather than three independent items pressuring the WIP cap.
+2. Start the sessions with `/jared-start <issue> --session N`, or `/jared-start --session N` (no issue) to pull the top of the session-N filtered queue.
+
+The partition is operator-approved per item; Jared never applies a `session-N` label without the operator saying so. To re-balance later, re-run `/jared-stage --sessions N` — existing labels are honored unless the operator removes them manually first.
+
+The WIP arithmetic lands per #235: `jared summary` collapses items sharing a `session-N` label into a single workstream count, so two session-1 issues + one session-2 issue render as "2 workstreams · 3 items" rather than three independent items pressuring the WIP cap.
 
 ## How per-session WIP arithmetic renders
 
@@ -101,6 +94,16 @@ git branch -d feature/<issue>-<slug>
 
 Each worktree needs its own `.venv` — `uv sync` or `uv pip install -e .`
 inside the new worktree before running tests.
+
+## The wrap back-end
+
+`/jared-wrap` runs the full commit → push → PR create → mergeable check → confirm merge → cleanup sequence after Session notes are posted. The operator confirms only the merge (the irreversible step against protected `main`).
+
+Idempotency: each step inspects current state via `jared wrap-state`. Re-running `/jared-wrap` after a failure or interruption picks up at the current state — no in-flight lock, no manual recovery sequencing. The state IS the lock.
+
+Concurrent merge safety: two sessions reaching the merge step around the same time both re-check `mergeable` immediately before calling `gh pr merge`. GitHub's PR-merge API is atomic; the second call rejects with a not-mergeable error if the first's merge created a conflict. No Jared-side serialization is needed.
+
+The back-end flow does not auto-commit. If the working tree is dirty at wrap time, wrap pauses and asks for a commit message — your commit discipline (phase-numbered prefixes, "why not what" bodies) is preserved.
 
 ## Triggers for the worktree default
 

--- a/skills/jared/references/parallel-sessions.md
+++ b/skills/jared/references/parallel-sessions.md
@@ -17,10 +17,14 @@ the next session-start.
 sit alongside without interfering — the per-session arithmetic only
 considers labels matching the strict shape.
 
-**Who applies and when.** The *operator* applies `session-N` labels at
-parallel-session start (option 1a from the v1.1 multi-session shape spec).
-Not Jared, not `/jared-stage`, not `/jared-start`. Auto-application was
-considered and deferred — see `docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-shape.md` § "Workstream 1".
+**Who applies and when.** The *operator* approves every `session-N` label
+change. `/jared-stage --sessions N` proposes assignments based on file-paths
+overlap and applies them only on operator approval. `/jared-start` and
+`/jared-file` never touch labels. The proposal-with-approval shape replaces
+the original manual-only model (option 1a from the v1.1 multi-session shape
+spec); the constraint that survives is operator approval — see
+`docs/superpowers/specs/2026-05-28-multi-session-back-end-design.md` for
+the new flow.
 
 ## Pre-parallel-session ritual
 

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -391,6 +391,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wa.set_defaults(func=_cmd_worktree_add)
 
+    pp = sub.add_parser(
+        "propose-partition",
+        help="Propose session-N label assignments across Up Next + currently-labeled items.",
+    )
+    pp.add_argument(
+        "--sessions",
+        type=int,
+        required=True,
+        metavar="K",
+        help="Number of parallel sessions to partition across (typically 2).",
+    )
+    pp.add_argument(
+        "--format",
+        choices=["human", "json"],
+        default="human",
+        help="Output format (default: human).",
+    )
+    pp.set_defaults(func=_cmd_propose_partition)
+
     return parser
 
 
@@ -1462,6 +1481,78 @@ def _cmd_worktree_add(args: argparse.Namespace) -> int:
         print(str(e), file=sys.stderr)
         return 1
     print(str(created))
+    return 0
+
+
+def _cmd_propose_partition(args: argparse.Namespace) -> int:
+    """Propose session-N label assignments for parallel Claude sessions."""
+    from dataclasses import asdict
+
+    from lib.partition import propose_partition  # type: ignore[import-not-found]
+
+    K = args.sessions
+    if K < 2:
+        print("ERROR: --sessions must be at least 2.", file=sys.stderr)
+        return 2
+
+    board = _load_board(args.board)
+
+    # Fetch candidate set with labels + bodies.
+    # NOTE: candidates are returned in GraphQL traversal order, not priority order.
+    # propose_partition's docstring notes "caller is expected to sort by priority"
+    # — Phase 3.6 can add priority-aware sorting when driving the stage flow.
+    open_items = board.fetch_open_issues_for_ties()
+
+    existing_labels: dict[int, int] = {}
+    for item in open_items:
+        for label in item.labels:
+            if label.startswith("session-"):
+                try:
+                    n = int(label.removeprefix("session-"))
+                except ValueError:
+                    continue
+                if 1 <= n <= K:
+                    existing_labels[item.number] = n
+                    break
+
+    proposal = propose_partition(open_items, K, existing_labels)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "keep": [asdict(a) for a in proposal.keep],
+                    "move": [asdict(a) for a in proposal.move],
+                    "add": [asdict(a) for a in proposal.add],
+                    "floats": [asdict(a) for a in proposal.floats],
+                }
+            )
+        )
+        return 0
+
+    # Human format
+    print(
+        f"Looking at {len(open_items)} candidates across "
+        f"sessions {', '.join(str(n) for n in range(1, K + 1))}."
+    )
+    print()
+    for n in range(1, K + 1):
+        session_assignments = [
+            a for a in proposal.keep + proposal.add if a.session == n
+        ]
+        print(f"session-{n} (proposing {len(session_assignments)} items):")
+        for a in session_assignments:
+            verb = "keep" if a in proposal.keep else "add"
+            print(f"  {verb} #{a.issue} — {a.reason}")
+        print()
+
+    if proposal.floats:
+        print("floats (no surface signal):")
+        for a in proposal.floats:
+            print(f"  #{a.issue} — {a.reason}")
+        print()
+
+    print("Approve? (y / edit / skip)")
     return 0
 
 

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 import tempfile
 from collections.abc import Sequence
@@ -67,6 +68,7 @@ ALL_SUBCOMMANDS = [
     "session-lock-write",
     "session-lock-clear",
     "worktree-add",
+    "wrap-state",
 ]
 
 
@@ -390,6 +392,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Session index (accepted for forward-compat; currently unused).",
     )
     wa.set_defaults(func=_cmd_worktree_add)
+
+    ws = sub.add_parser(
+        "wrap-state",
+        help="Collect git + PR state and print the next wrap step name.",
+    )
+    ws.set_defaults(func=_cmd_wrap_state)
 
     pp = sub.add_parser(
         "propose-partition",
@@ -1481,6 +1489,101 @@ def _cmd_worktree_add(args: argparse.Namespace) -> int:
         print(str(e), file=sys.stderr)
         return 1
     print(str(created))
+    return 0
+
+
+def _cmd_wrap_state(args: argparse.Namespace) -> int:
+    """Collect git + PR state, hand to decide_next_step, print the step name."""
+    import json as _json
+
+    from lib.wrap_state import GitState, PrState, decide_next_step  # type: ignore[import-not-found]
+
+    # Git state
+    status_result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty = bool(status_result.stdout.strip())
+
+    branch_result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    branch = branch_result.stdout.strip()
+
+    ahead_result = subprocess.run(
+        ["git", "rev-list", "--count", "@{u}..HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # @{u}..HEAD fails when no upstream; treat as ahead=False.
+    try:
+        ahead = int(ahead_result.stdout.strip() or "0") > 0
+    except ValueError:
+        ahead = False
+
+    git_state = GitState(dirty=dirty, branch=branch, ahead_of_remote=ahead)
+
+    # PR state
+    pr_result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            "--json",
+            "number,mergeable,mergeStateStatus,state,statusCheckRollup",
+            branch,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if pr_result.returncode != 0:
+        pr_state = PrState(
+            exists=False,
+            pr_number=None,
+            checks_status="none",
+            mergeable=None,
+            merged=False,
+        )
+    else:
+        pr_payload = _json.loads(pr_result.stdout)
+        # mergeable values: "MERGEABLE", "CONFLICTING", "UNKNOWN"
+        mergeable_value = pr_payload.get("mergeable")
+        mergeable: bool | None = None
+        if mergeable_value == "MERGEABLE":
+            mergeable = True
+        elif mergeable_value == "CONFLICTING":
+            mergeable = False
+        # else: UNKNOWN → None
+
+        # Aggregate checks
+        rollup = pr_payload.get("statusCheckRollup") or []
+        statuses = {c.get("conclusion") or c.get("status") for c in rollup}
+        if "FAILURE" in statuses or "CANCELLED" in statuses or "TIMED_OUT" in statuses:
+            checks_status: str = "failed"
+        elif "IN_PROGRESS" in statuses or "PENDING" in statuses or "QUEUED" in statuses:
+            checks_status = "pending"
+        elif rollup:
+            checks_status = "passed"
+        else:
+            checks_status = "none"
+
+        pr_state = PrState(
+            exists=True,
+            pr_number=pr_payload.get("number"),
+            checks_status=checks_status,  # type: ignore[arg-type]
+            mergeable=mergeable,
+            merged=(pr_payload.get("state") == "MERGED"),
+        )
+
+    print(decide_next_step(git_state, pr_state))
     return 0
 
 

--- a/skills/jared/scripts/lib/partition.py
+++ b/skills/jared/scripts/lib/partition.py
@@ -1,0 +1,57 @@
+"""Anti-overlap partition: propose session-N label assignments for parallel
+Claude sessions sharing one repo.
+
+Single signal (v1): file paths cited in the issue body. Two candidates whose
+bodies cite overlapping file paths are presumed to touch overlapping code.
+
+The partition is operator-approved per item. Existing session-N labels are
+honored (manual overrides win). A candidate with no surface signal is a
+float — no label proposed.
+
+See docs/superpowers/specs/2026-05-28-multi-session-back-end-design.md for
+the full design and the cuts that distinguish v1 from a more elaborate
+multi-signal version.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .ties import file_paths_in_body
+
+if TYPE_CHECKING:
+    pass  # OpenIssueForTies imported in Task 3.3 when propose_partition is added
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """Proposed session-N assignment for one issue.
+
+    `session=None` means float — no label proposed for this issue. `reason`
+    is a short rationale shown in the proposal output.
+    """
+
+    issue: int
+    session: int | None
+    reason: str
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """Full stage proposal across a candidate set.
+
+    `keep` — issue's existing session-N label is honored.
+    `move` — existing label, proposing a different session (reserved for a
+             future re-balance flag; v1 never populates this list).
+    `add`  — no existing label, proposing one.
+    `floats` — no surface signal; no label proposed.
+    """
+
+    keep: list[Assignment]
+    move: list[Assignment]
+    add: list[Assignment]
+    floats: list[Assignment]
+
+
+__all__ = ["Assignment", "Proposal", "file_paths_in_body"]

--- a/skills/jared/scripts/lib/partition.py
+++ b/skills/jared/scripts/lib/partition.py
@@ -54,4 +54,15 @@ class Proposal:
     floats: list[Assignment]
 
 
-__all__ = ["Assignment", "Proposal", "file_paths_in_body"]
+def extract_surface(body: str) -> frozenset[str]:
+    """Compute the surface fingerprint of an issue body — the set of file
+    paths it cites. Single signal for v1.
+
+    Direct alias of `lib.ties.file_paths_in_body`. Lives behind a partition-
+    specific name so future signal expansion (title scope, label clusters)
+    doesn't churn the partition-side import.
+    """
+    return file_paths_in_body(body)
+
+
+__all__ = ["Assignment", "Proposal", "extract_surface"]

--- a/skills/jared/scripts/lib/partition.py
+++ b/skills/jared/scripts/lib/partition.py
@@ -16,12 +16,8 @@ multi-signal version.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
-from .ties import file_paths_in_body
-
-if TYPE_CHECKING:
-    pass  # OpenIssueForTies imported in Task 3.3 when propose_partition is added
+from .ties import OpenIssueForTies, file_paths_in_body
 
 
 @dataclass(frozen=True)
@@ -65,4 +61,83 @@ def extract_surface(body: str) -> frozenset[str]:
     return file_paths_in_body(body)
 
 
-__all__ = ["Assignment", "Proposal", "extract_surface"]
+def propose_partition(
+    candidates: list[OpenIssueForTies],
+    K: int,
+    existing_session_labels: dict[int, int],
+) -> Proposal:
+    """Greedy anti-overlap partition.
+
+    Walks `candidates` in their given order (caller is expected to sort by
+    priority). For each candidate:
+
+    - If body has no file paths → float (no label proposed, regardless of
+      existing label).
+    - If an existing session-N label is set and 1 ≤ N ≤ K → keep (honor
+      operator's prior decision).
+    - Otherwise → pick the session with the largest cumulative surface
+      overlap (cohesion-first: overlapping issues co-locate); tie-break
+      by load (smaller session wins).
+
+    `move` is reserved for a future re-balance flag and is always empty in
+    v1 — existing labels are never overridden.
+    """
+    session_surfaces: dict[int, set[str]] = {n: set() for n in range(1, K + 1)}
+    session_loads: dict[int, int] = {n: 0 for n in range(1, K + 1)}
+
+    keep: list[Assignment] = []
+    move: list[Assignment] = []
+    add: list[Assignment] = []
+    floats: list[Assignment] = []
+
+    for candidate in candidates:
+        surface = extract_surface(candidate.body)
+        if not surface:
+            floats.append(
+                Assignment(
+                    issue=candidate.number,
+                    session=None,
+                    reason="no surface signal in body",
+                )
+            )
+            continue
+
+        existing = existing_session_labels.get(candidate.number)
+        if existing is not None and 1 <= existing <= K:
+            keep.append(
+                Assignment(
+                    issue=candidate.number,
+                    session=existing,
+                    reason="existing label honored",
+                )
+            )
+            session_surfaces[existing] |= surface
+            session_loads[existing] += 1
+            continue
+
+        # Pick session with largest surface overlap (cohesion-first), tie-break
+        # by smaller load so unrelated issues spread evenly.
+        best = max(
+            range(1, K + 1),
+            key=lambda n: (len(session_surfaces[n] & surface), -session_loads[n]),
+        )
+        overlap = session_surfaces[best] & surface
+        if overlap:
+            reason = f"shares {sorted(overlap)[0]} with session-{best}"
+        else:
+            reason = f"new cluster in session-{best} (lowest load)"
+
+        add.append(
+            Assignment(
+                issue=candidate.number,
+                session=best,
+                reason=reason,
+            )
+        )
+        session_surfaces[best] |= surface
+        session_loads[best] += 1
+
+    return Proposal(keep=keep, move=move, add=add, floats=floats)
+
+
+__all__ = ["Assignment", "Proposal", "extract_surface", "propose_partition"]

--- a/skills/jared/scripts/lib/ties.py
+++ b/skills/jared/scripts/lib/ties.py
@@ -300,8 +300,14 @@ _TITLE_STOP_WORDS: frozenset[str] = frozenset(
 _TITLE_TOKEN_OVERLAP_MIN = 2
 
 
-def _tokenize_title(title: str) -> frozenset[str]:
-    """Lowercase, drop punctuation, split, drop stop-words, drop length-1 tokens."""
+def tokenize_title(title: str) -> frozenset[str]:
+    """Tokenize a title into lowercase content words for adjacency scoring.
+
+    Drops punctuation, splits on whitespace, removes stop-words and
+    single-character tokens.
+
+    Public: also consumed by `lib/partition.py` (future signal, not v1).
+    """
     cleaned = re.sub(r"[^a-z0-9\s]+", " ", title.lower())
     return frozenset(
         tok for tok in cleaned.split() if len(tok) > 1 and tok not in _TITLE_STOP_WORDS
@@ -315,14 +321,14 @@ def analyze_title_tokens(
 
     Case-insensitive; punctuation stripped; stop-words removed.
     """
-    target_toks = _tokenize_title(target.title)
+    target_toks = tokenize_title(target.title)
     if len(target_toks) < _TITLE_TOKEN_OVERLAP_MIN:
         return []
     hits: list[SignalHit] = []
     for related in open_issues:
         if related.number == target.number:
             continue
-        related_toks = _tokenize_title(related.title)
+        related_toks = tokenize_title(related.title)
         shared = target_toks & related_toks
         if len(shared) >= _TITLE_TOKEN_OVERLAP_MIN:
             shared_list = sorted(shared)
@@ -342,7 +348,7 @@ def analyze_title_tokens(
 # excluded by requiring either a slash or an extension.
 # Lowercase extensions only by design — issue bodies conventionally use
 # lowercase paths (`lib/board.py`, not `lib/Board.PY`).
-_FILE_PATH_RE = re.compile(
+FILE_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9])"
     r"([A-Za-z0-9_.\-]+(?:/[A-Za-z0-9_.\-]+)+\.[a-z]+|"
     r"[A-Za-z0-9_.\-]+\.(?:py|md|ts|tsx|js|jsx|go|rs|java|sh|toml|yaml|yml|json))"
@@ -351,17 +357,20 @@ _FILE_PATH_RE = re.compile(
 )
 
 # Filenames that are too generic to count as tie-relevant.
-_GENERIC_FILES: frozenset[str] = frozenset(
+GENERIC_FILES: frozenset[str] = frozenset(
     {"README.md", "CHANGELOG.md", "LICENSE", "TODO.md", "NOTES.md"}
 )
 
 
-def _file_paths_in_body(body: str) -> frozenset[str]:
-    """Extract path-like tokens from body. Generic filenames excluded."""
+def file_paths_in_body(body: str) -> frozenset[str]:
+    """Extract path-like tokens from a body. Generic filenames excluded.
+
+    Public: also consumed by `lib/partition.py` to compute surface overlap.
+    """
     if not body:
         return frozenset()
-    paths = {m.group(1) for m in _FILE_PATH_RE.finditer(body)}
-    return frozenset(p for p in paths if p not in _GENERIC_FILES)
+    paths = {m.group(1) for m in FILE_PATH_RE.finditer(body)}
+    return frozenset(p for p in paths if p not in GENERIC_FILES)
 
 
 def analyze_file_paths(
@@ -373,14 +382,14 @@ def analyze_file_paths(
     filenames (README, CHANGELOG, etc.) are excluded. Requires bodies on
     both sides — caller skips this analyzer in low-budget partial mode.
     """
-    target_paths = _file_paths_in_body(target.body)
+    target_paths = file_paths_in_body(target.body)
     if not target_paths:
         return []
     hits: list[SignalHit] = []
     for related in open_issues:
         if related.number == target.number:
             continue
-        related_paths = _file_paths_in_body(related.body)
+        related_paths = file_paths_in_body(related.body)
         shared = target_paths & related_paths
         if shared:
             shared_list = sorted(shared)

--- a/skills/jared/scripts/lib/wrap_state.py
+++ b/skills/jared/scripts/lib/wrap_state.py
@@ -1,0 +1,78 @@
+"""Wrap back-end state detection — pure function, no I/O.
+
+The wrap slash command collects git state via `git status` and PR state via
+`gh pr view --json ...`, hands them to `decide_next_step`, and acts on the
+returned `StepName`. Re-running wrap re-evaluates state and picks up at
+whichever step is current — no in-flight lock needed; state IS the lock.
+
+See docs/superpowers/specs/2026-05-28-multi-session-back-end-design.md §
+"Phase 3 — Wrap back-end" for the full state table and rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+CheckStatus = Literal["pending", "passed", "failed", "none"]
+StepName = Literal[
+    "commit",
+    "push",
+    "create_pr",
+    "wait_checks",
+    "surface_failure",
+    "surface_conflict",
+    "confirm_merge",
+    "cleanup",
+]
+
+
+@dataclass(frozen=True)
+class GitState:
+    """Working-tree + branch state at wrap entry."""
+
+    dirty: bool
+    branch: str
+    ahead_of_remote: bool
+
+
+@dataclass(frozen=True)
+class PrState:
+    """Pull request state for the current branch."""
+
+    exists: bool
+    pr_number: int | None
+    checks_status: CheckStatus
+    mergeable: bool | None
+    merged: bool
+
+
+def decide_next_step(git_state: GitState, pr_state: PrState) -> StepName:
+    """Pick the next wrap step from current state.
+
+    Precedence (highest first):
+      1. Dirty tree → commit (must be addressed before any PR action).
+      2. PR merged → cleanup (worktree + branch removal).
+      3. Branch ahead of remote → push.
+      4. No PR → create_pr.
+      5. PR checks pending → wait_checks (exit clean; re-run when green).
+      6. PR checks failed → surface_failure (exit clean; operator fixes).
+      7. PR checks green, not mergeable → surface_conflict (rebase needed).
+      8. PR checks green, mergeable → confirm_merge.
+    """
+    if git_state.dirty:
+        return "commit"
+    if pr_state.merged:
+        return "cleanup"
+    if git_state.ahead_of_remote:
+        return "push"
+    if not pr_state.exists:
+        return "create_pr"
+    if pr_state.checks_status == "pending":
+        return "wait_checks"
+    if pr_state.checks_status == "failed":
+        return "surface_failure"
+    # checks_status == "passed" (or "none" — treated as passed for now)
+    if pr_state.mergeable is False:
+        return "surface_conflict"
+    return "confirm_merge"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,8 +264,11 @@ def patch_gh_multi(
                     "number": number,
                     "title": issue.get("title", ""),
                     "state": issue.get("state", "OPEN"),
+                    "body": issue.get("body", ""),
                     "labels": {"nodes": label_nodes},
                     "projectItems": project_items,
+                    "milestone": None,
+                    "blockedBy": {"nodes": []},
                 }
             )
         return _json.dumps(

--- a/tests/test_cmd_propose_partition.py
+++ b/tests/test_cmd_propose_partition.py
@@ -1,0 +1,84 @@
+"""Tests for `jared propose-partition`."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import import_cli, patch_gh_multi, write_minimal_board
+
+
+def test_propose_partition_human_format_renders_proposal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    board_md = write_minimal_board(tmp_path)
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {
+                "number": 1,
+                "title": "A",
+                "state": "OPEN",
+                "body": "Edits `lib/board.py`.",
+            },
+            {
+                "number": 2,
+                "title": "B",
+                "state": "OPEN",
+                "body": "Edits `commands/jared-wrap.md`.",
+            },
+        ],
+        statuses={1: ("Up Next", "High"), 2: ("Up Next", "Medium")},
+        labels_by_number={1: [], 2: []},
+    )
+
+    mod = import_cli()
+    rc = mod.main(
+        ["--board", str(board_md), "propose-partition", "--sessions", "2"]
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "session-1" in out
+    assert "session-2" in out
+    assert "#1" in out and "#2" in out
+
+
+def test_propose_partition_json_format_returns_structured_proposal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    board_md = write_minimal_board(tmp_path)
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {"number": 1, "title": "A", "state": "OPEN", "body": "Edits `x/y.py`."},
+        ],
+        statuses={1: ("Up Next", "High")},
+        labels_by_number={1: []},
+    )
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "propose-partition",
+            "--sessions",
+            "2",
+            "--format",
+            "json",
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    payload = json.loads(out)
+    assert "keep" in payload
+    assert "add" in payload
+    assert "floats" in payload
+    # Issue 1 has file paths and no existing label → should be in `add`.
+    assert any(a["issue"] == 1 for a in payload["add"])

--- a/tests/test_cmd_propose_partition.py
+++ b/tests/test_cmd_propose_partition.py
@@ -35,9 +35,7 @@ def test_propose_partition_human_format_renders_proposal(
     )
 
     mod = import_cli()
-    rc = mod.main(
-        ["--board", str(board_md), "propose-partition", "--sessions", "2"]
-    )
+    rc = mod.main(["--board", str(board_md), "propose-partition", "--sessions", "2"])
     out = capsys.readouterr().out
 
     assert rc == 0

--- a/tests/test_cmd_wrap_state.py
+++ b/tests/test_cmd_wrap_state.py
@@ -1,0 +1,44 @@
+"""Tests for `jared wrap-state` — collects git + PR state, prints next step name."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import import_cli, write_minimal_board
+
+
+def test_wrap_state_dirty_tree_prints_commit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    board_md = write_minimal_board(tmp_path)
+
+    with patch("subprocess.run") as mock_run:
+        # `git status --porcelain` returns dirty output.
+        # `git rev-parse --abbrev-ref HEAD` returns a branch.
+        # `git rev-list --count @{u}..HEAD` returns "0".
+        # `gh pr view --json ...` returns no PR.
+        def _run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            from subprocess import CompletedProcess
+
+            argv = cmd if isinstance(cmd, list) else cmd.split()
+            if argv[:2] == ["git", "status"]:
+                return CompletedProcess(argv, 0, " M file.py\n", "")
+            if argv[:2] == ["git", "rev-parse"]:
+                return CompletedProcess(argv, 0, "feature/100-worktree\n", "")
+            if argv[:2] == ["git", "rev-list"]:
+                return CompletedProcess(argv, 0, "0\n", "")
+            if argv[:2] == ["gh", "pr"]:
+                return CompletedProcess(argv, 1, "", "no pull requests found")
+            return CompletedProcess(argv, 0, "", "")
+
+        mock_run.side_effect = _run
+
+        mod = import_cli()
+        rc = mod.main(["--board", str(board_md), "wrap-state"])
+
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert out == "commit"

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,0 +1,23 @@
+"""Tests for the partition module — anti-overlap session-N assignment."""
+
+from skills.jared.scripts.lib.partition import Assignment, Proposal
+
+
+def test_assignment_dataclass_shape() -> None:
+    a = Assignment(issue=42, session=1, reason="existing label honored")
+    assert a.issue == 42
+    assert a.session == 1
+    assert a.reason == "existing label honored"
+
+
+def test_assignment_session_none_for_float() -> None:
+    a = Assignment(issue=42, session=None, reason="no surface signal in body")
+    assert a.session is None
+
+
+def test_proposal_dataclass_shape() -> None:
+    p = Proposal(keep=[], move=[], add=[], floats=[])
+    assert p.keep == []
+    assert p.move == []
+    assert p.add == []
+    assert p.floats == []

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,6 +1,12 @@
 """Tests for the partition module — anti-overlap session-N assignment."""
 
-from skills.jared.scripts.lib.partition import Assignment, Proposal, extract_surface
+from skills.jared.scripts.lib.partition import (
+    Assignment,
+    Proposal,
+    extract_surface,
+    propose_partition,
+)
+from skills.jared.scripts.lib.ties import OpenIssueForTies
 
 
 def test_assignment_dataclass_shape() -> None:
@@ -43,3 +49,48 @@ def test_extract_surface_empty_body_returns_empty() -> None:
 
 def test_extract_surface_no_paths_returns_empty() -> None:
     assert extract_surface("Prose with no paths anywhere.") == frozenset()
+
+
+def _candidate(
+    number: int,
+    *,
+    title: str = "",
+    body: str = "",
+    labels: tuple[str, ...] = (),
+) -> OpenIssueForTies:
+    return OpenIssueForTies(
+        number=number,
+        title=title,
+        body=body,
+        labels=labels,
+        milestone=None,
+        status="Up Next",
+        priority="Medium",
+        blocked_by=(),
+    )
+
+
+def test_propose_partition_disjoint_clusters_split_cleanly() -> None:
+    """Two candidate groups citing entirely different file paths land in
+    different sessions."""
+    candidates = [
+        _candidate(1, body="Update `lib/board.py`."),
+        _candidate(2, body="Refactor `lib/board.py`."),
+        _candidate(3, body="Edit `commands/jared-stage.md`."),
+        _candidate(4, body="Edit `commands/jared-wrap.md`."),
+    ]
+    proposal = propose_partition(candidates, K=2, existing_session_labels={})
+
+    # All four are `add` (no existing labels)
+    assert len(proposal.add) == 4
+    assert len(proposal.keep) == 0
+    assert len(proposal.move) == 0
+    assert len(proposal.floats) == 0
+
+    # Issues 1 and 2 share lib/board.py — should be in the same session
+    by_issue = {a.issue: a.session for a in proposal.add}
+    assert by_issue[1] == by_issue[2]
+    # Issues 3 and 4 share commands/ — should be in the same session
+    assert by_issue[3] == by_issue[4]
+    # The two groups should be in different sessions
+    assert by_issue[1] != by_issue[3]

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -94,3 +94,50 @@ def test_propose_partition_disjoint_clusters_split_cleanly() -> None:
     assert by_issue[3] == by_issue[4]
     # The two groups should be in different sessions
     assert by_issue[1] != by_issue[3]
+
+
+def test_propose_partition_honors_existing_labels() -> None:
+    """Issues with existing session-N labels land in `keep`, not `add`."""
+    candidates = [
+        _candidate(1, body="Update `lib/board.py`."),
+        _candidate(2, body="Refactor `lib/board.py`."),
+    ]
+    proposal = propose_partition(
+        candidates,
+        K=2,
+        existing_session_labels={1: 1, 2: 2},
+    )
+    assert len(proposal.keep) == 2
+    assert len(proposal.add) == 0
+    keep_sessions = {a.issue: a.session for a in proposal.keep}
+    assert keep_sessions[1] == 1
+    assert keep_sessions[2] == 2
+
+
+def test_propose_partition_float_candidate_with_no_surface() -> None:
+    """A candidate whose body has no file paths is a float — no label
+    proposed even if other candidates could absorb it."""
+    candidates = [
+        _candidate(1, body="Prose-only issue with no paths anywhere."),
+    ]
+    proposal = propose_partition(candidates, K=2, existing_session_labels={})
+    assert len(proposal.floats) == 1
+    assert proposal.floats[0].issue == 1
+    assert proposal.floats[0].session is None
+    assert len(proposal.add) == 0
+
+
+def test_propose_partition_load_balance_tiebreak_on_zero_overlap() -> None:
+    """When no overlap exists with any session, the smaller-load session wins."""
+    candidates = [
+        _candidate(1, body="Touches `a/a.py`."),
+        _candidate(2, body="Touches `b/b.py`."),
+        _candidate(3, body="Touches `c/c.py`."),
+    ]
+    proposal = propose_partition(candidates, K=2, existing_session_labels={})
+    # Three disjoint candidates, two sessions: split 2/1.
+    counts = {1: 0, 2: 0}
+    for a in proposal.add:
+        if a.session is not None:
+            counts[a.session] += 1
+    assert sorted(counts.values()) == [1, 2]

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -1,6 +1,6 @@
 """Tests for the partition module — anti-overlap session-N assignment."""
 
-from skills.jared.scripts.lib.partition import Assignment, Proposal
+from skills.jared.scripts.lib.partition import Assignment, Proposal, extract_surface
 
 
 def test_assignment_dataclass_shape() -> None:
@@ -21,3 +21,25 @@ def test_proposal_dataclass_shape() -> None:
     assert p.move == []
     assert p.add == []
     assert p.floats == []
+
+
+def test_extract_surface_returns_file_paths_from_body() -> None:
+    body = "Fix bug in `lib/board.py` and update `commands/jared-stage.md`."
+    surface = extract_surface(body)
+    assert "lib/board.py" in surface
+    assert "commands/jared-stage.md" in surface
+
+
+def test_extract_surface_excludes_generic_files() -> None:
+    body = "Touches README.md and lib/board.py."
+    surface = extract_surface(body)
+    assert "README.md" not in surface
+    assert "lib/board.py" in surface
+
+
+def test_extract_surface_empty_body_returns_empty() -> None:
+    assert extract_surface("") == frozenset()
+
+
+def test_extract_surface_no_paths_returns_empty() -> None:
+    assert extract_surface("Prose with no paths anywhere.") == frozenset()

--- a/tests/test_ties_analyzers.py
+++ b/tests/test_ties_analyzers.py
@@ -285,3 +285,19 @@ class TestAnalyzeFilePaths:
         others = [_make_issue(1, body="Touches `lib/board.py`.")]
         hits = analyze_file_paths(target, others)
         assert hits == []
+
+
+def test_public_extractors_importable() -> None:
+    """Regression: lib/partition.py depends on these symbols being public.
+    If anyone re-privates them, this test fails loudly."""
+    from skills.jared.scripts.lib.ties import (
+        FILE_PATH_RE,
+        GENERIC_FILES,
+        file_paths_in_body,
+        tokenize_title,
+    )
+
+    assert callable(file_paths_in_body)
+    assert callable(tokenize_title)
+    assert isinstance(GENERIC_FILES, frozenset)
+    assert FILE_PATH_RE.pattern  # has a pattern attribute

--- a/tests/test_wrap_state.py
+++ b/tests/test_wrap_state.py
@@ -46,33 +46,23 @@ def test_decide_clean_no_pr_returns_create_pr() -> None:
 
 
 def test_decide_pr_checks_pending_returns_wait_checks() -> None:
-    assert (
-        decide_next_step(_git(), _pr(exists=True, checks="pending"))
-        == "wait_checks"
-    )
+    assert decide_next_step(_git(), _pr(exists=True, checks="pending")) == "wait_checks"
 
 
 def test_decide_pr_checks_failed_returns_surface_failure() -> None:
-    assert (
-        decide_next_step(_git(), _pr(exists=True, checks="failed"))
-        == "surface_failure"
-    )
+    assert decide_next_step(_git(), _pr(exists=True, checks="failed")) == "surface_failure"
 
 
 def test_decide_pr_checks_green_not_mergeable_returns_surface_conflict() -> None:
     assert (
-        decide_next_step(
-            _git(), _pr(exists=True, checks="passed", mergeable=False)
-        )
+        decide_next_step(_git(), _pr(exists=True, checks="passed", mergeable=False))
         == "surface_conflict"
     )
 
 
 def test_decide_pr_checks_green_mergeable_returns_confirm_merge() -> None:
     assert (
-        decide_next_step(
-            _git(), _pr(exists=True, checks="passed", mergeable=True)
-        )
+        decide_next_step(_git(), _pr(exists=True, checks="passed", mergeable=True))
         == "confirm_merge"
     )
 

--- a/tests/test_wrap_state.py
+++ b/tests/test_wrap_state.py
@@ -1,0 +1,92 @@
+"""Tests for the wrap state-detection table.
+
+The pure function `decide_next_step(git_state, pr_state)` is the spine of the
+wrap back-end flow's idempotency: each step inspects state and decides whether
+to act, so re-running wrap picks up at the same step.
+"""
+
+from skills.jared.scripts.lib.wrap_state import (
+    CheckStatus,
+    GitState,
+    PrState,
+    decide_next_step,
+)
+
+
+def _git(dirty: bool = False, ahead: bool = False) -> GitState:
+    return GitState(dirty=dirty, branch="feature/100-worktree", ahead_of_remote=ahead)
+
+
+def _pr(
+    *,
+    exists: bool = False,
+    checks: CheckStatus = "none",
+    mergeable: bool | None = None,
+    merged: bool = False,
+) -> PrState:
+    return PrState(
+        exists=exists,
+        pr_number=42 if exists else None,
+        checks_status=checks,
+        mergeable=mergeable,
+        merged=merged,
+    )
+
+
+def test_decide_dirty_tree_returns_commit() -> None:
+    assert decide_next_step(_git(dirty=True), _pr()) == "commit"
+
+
+def test_decide_ahead_no_pr_returns_push() -> None:
+    assert decide_next_step(_git(ahead=True), _pr()) == "push"
+
+
+def test_decide_clean_no_pr_returns_create_pr() -> None:
+    assert decide_next_step(_git(), _pr()) == "create_pr"
+
+
+def test_decide_pr_checks_pending_returns_wait_checks() -> None:
+    assert (
+        decide_next_step(_git(), _pr(exists=True, checks="pending"))
+        == "wait_checks"
+    )
+
+
+def test_decide_pr_checks_failed_returns_surface_failure() -> None:
+    assert (
+        decide_next_step(_git(), _pr(exists=True, checks="failed"))
+        == "surface_failure"
+    )
+
+
+def test_decide_pr_checks_green_not_mergeable_returns_surface_conflict() -> None:
+    assert (
+        decide_next_step(
+            _git(), _pr(exists=True, checks="passed", mergeable=False)
+        )
+        == "surface_conflict"
+    )
+
+
+def test_decide_pr_checks_green_mergeable_returns_confirm_merge() -> None:
+    assert (
+        decide_next_step(
+            _git(), _pr(exists=True, checks="passed", mergeable=True)
+        )
+        == "confirm_merge"
+    )
+
+
+def test_decide_pr_merged_returns_cleanup() -> None:
+    assert decide_next_step(_git(), _pr(exists=True, merged=True)) == "cleanup"
+
+
+def test_decide_dirty_tree_takes_precedence_over_pr_state() -> None:
+    """Dirty working tree must be addressed before any PR-side action."""
+    assert (
+        decide_next_step(
+            _git(dirty=True),
+            _pr(exists=True, checks="passed", mergeable=True),
+        )
+        == "commit"
+    )


### PR DESCRIPTION
## Summary

- **Stage:** `/jared-stage --sessions N` proposes session-N label assignments via single-signal file-paths overlap. Existing labels honored; floats (no signal) surfaced. Closes #253.
- **Wrap:** `/jared-wrap` runs commit (prompt) → push → PR create → mergeable check → confirm merge → cleanup back-end after Session notes. Idempotent re-run via `jared wrap-state`. Closes #272.
- **Refactor:** Promote four private symbols in `lib/ties.py` to public (`file_paths_in_body`, `GENERIC_FILES`, `tokenize_title`, `FILE_PATH_RE`) so `lib/partition.py` can reuse them.
- **Doctrine:** `references/parallel-sessions.md` updated for the new flow.

Phases 2–5 of `docs/superpowers/specs/2026-05-28-multi-session-back-end-design.md`. Phase 1 (start-side filter) shipped as PR #271.

## What's in this PR

- `lib/partition.py` — `Assignment`, `Proposal`, `extract_surface`, `propose_partition` (~140 LOC, cohesion-first greedy algorithm)
- `lib/wrap_state.py` — `GitState`, `PrState`, `decide_next_step` pure-function state machine (~70 LOC)
- `jared propose-partition --sessions K [--format human|json]` CLI subcommand
- `jared wrap-state` CLI subcommand
- `commands/jared-stage.md` extended with `## Session-N partitioning (--sessions N)` section
- `commands/jared-wrap.md` extended with step 5b back-end flow
- `references/parallel-sessions.md` doctrine updates
- ~140 lines of new unit tests (test_partition, test_wrap_state, test_cmd_propose_partition, test_cmd_wrap_state) + public-import regression test in test_ties_analyzers
- Conftest extension: `patch_gh_multi` now forwards `body`, `milestone`, `blockedBy` fields (necessary for partition tests; backward compatible)

## Concurrent-merge safety

Trust GitHub's PR-merge API atomicity. `decide_next_step` re-evaluates mergeable just before the merge step. No Jared-side serialization lock.

## Known follow-ups (not gating)

1. **Spec correction:** § Phase 1 says "smallest cumulative surface-overlap" but the algorithm should (and does) maximize overlap for cohesion. The test correctly captured intent; the implementation flipped the polarity. Spec prose needs the fix post-merge.
2. **Wrap `branch == "main"` guard:** The back-end flow assumes a feature branch. If an operator runs `/jared-wrap` on `main` directly, wrap-state would return `create_pr` and the slash command would attempt a malformed PR. Add a guard in the wrap slash command.
3. **The "Who applies and when" paragraph in `parallel-sessions.md`** was reconciled inline in this PR — see commit `7e37bb8`.

## Test plan

- [x] `pytest` — 557 passed, 1 deselected (integration marker)
- [x] `ruff check . && ruff format --check . && mypy` clean (56 source files)
- [ ] Manual smoke: `./skills/jared/scripts/jared propose-partition --sessions 2` against `brockamer/jared` — confirm partition output
- [ ] Manual smoke: `./skills/jared/scripts/jared wrap-state` from a feature branch with uncommitted changes — confirm prints `commit`
- [ ] Manual smoke: run a wrap end-to-end on a throwaway branch to verify the back-end flow walks through commit → push → PR → confirm → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)