### PR TITLE
chore(archive): multi-session back-end spec + plan

### DIFF
--- a/docs/superpowers/plans/archived/2026-05/2026-05-28-multi-session-back-end.md
+++ b/docs/superpowers/plans/archived/2026-05/2026-05-28-multi-session-back-end.md
@@ -1,4 +1,11 @@
+---
+**Shipped in #233 on 2026-05-28. Final decisions captured in issue body.**
+---
+
 # Multi-session back-end Implementation Plan
+
+**Issue:** #233
+**Status:** Shipped via PR #271 (closes #270) and PR #273 (closes #253, #272). Parent epic #233 closed 2026-05-28.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/superpowers/specs/archived/2026-05/2026-05-28-multi-session-back-end-design.md
+++ b/docs/superpowers/specs/archived/2026-05/2026-05-28-multi-session-back-end-design.md
@@ -1,8 +1,13 @@
+---
+**Shipped in #233 on 2026-05-28. Final decisions captured in issue body.**
+---
+
 # Multi-session back-end: stage proposal, start filter, wrap merge
 
+**Issue:** #233
 **Date:** 2026-05-28
-**Status:** Design — pending implementation plan
-**Related issues:** #253 (extends scope), new issue for start-side filter, new issue for wrap back-end. #233's "v0.22 readiness — multi-session safety checklist" can close once both PRs land.
+**Status:** Shipped via PR #271 (closes #270) and PR #273 (closes #253, #272). Parent epic #233 closed 2026-05-28.
+**Related issues:** #270, #253, #272 (all closed). #233 v0.22 multi-session readiness umbrella (closed).
 **Related references:** `skills/jared/references/parallel-sessions.md`, `docs/superpowers/specs/archived/2026-05/2026-05-23-multi-session-impl-design.md`.
 
 ## Problem


### PR DESCRIPTION
## Summary

Archives both `docs/superpowers/specs/2026-05-28-multi-session-back-end-design.md` and `docs/superpowers/plans/2026-05-28-multi-session-back-end.md` to `archived/2026-05/` via `archive-plan.py`. Both reference #233 (closed 2026-05-28 with the v0.22 multi-session ship).

Also updates #233's `## Planning` section to point at the archived paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)