### PR TITLE
release: v0.26.0 — multi-session back-end + #275 cleanup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format: each entry starts with `## v<x.y.z> — YYYY-MM-DD`, followed by terse b
 
 Convention is documented in [CLAUDE.md](CLAUDE.md) § Versioning. Pre-`v0.2.0` history is omitted — `v0.2.0` is the level-up release that established the current Jared shape.
 
+## v0.26.0 — 2026-05-28
+
+**Features**
+- Multi-session back-end — the staging, start, and wrap surfaces now coordinate across parallel Claude sessions instead of just naming them. `lib/partition.py` (new) computes a cohesion-first greedy partition over Up Next/Backlog candidates: each candidate lands in the session whose cumulative file-surface it overlaps with most, so conflict-prone items co-locate rather than spread across sessions. `jared propose-partition --sessions N` exposes the proposal as human or JSON output; `/jared-stage --sessions N` drives the partition + operator-approved label application. `jared next-session-prompt --session N` filters Top of Up Next by `session-N` label, and `/jared-start` passes the flag through so sibling sessions see only their own work. `jared wrap-state` collects git + PR state and prints the next step (`commit` / `push` / `create_pr` / `wait_checks` / `confirm_merge` / `cleanup` / etc.); `/jared-wrap` drives the commit → push → PR → merge → cleanup loop off it. (#271 spec, #273 impl, #274 archive — Phases 1.1 → 5.1)
+- `lib/ties.py` extractors promoted to public — `file_paths_in_body`, `GENERIC_FILES`, `tokenize_title`, `FILE_PATH_RE` are now the supported import surface for partition and any future tie-aware tooling. (#273, Phase 2.1, regression-tested in Phase 2.2)
+
+**Bug fixes**
+- `/jared-wrap` step 5b now guards against running the back-end loop on `main` — if the current branch is `main`, the loop is skipped entirely and the lock-clear + worktree-removal bullets run unconditionally. Previously, a `/jared-wrap` invoked from the primary repo while still on `main` would hit `wrap-state` → `create_pr` and attempt `gh pr create` for `main`, which fails confusingly or produces a malformed PR. (#275)
+- Archived multi-session spec at `docs/superpowers/specs/archived/2026-05/2026-05-28-multi-session-back-end-design.md` § "Phase 1 — Stage proposal" prose now matches the cohesion-first implementation: "largest cumulative surface-overlap" instead of "smallest." Future readers of the archived design see the algorithm direction that matches the shipped code. (#275)
+
 ## v0.25.0 — 2026-05-27
 
 **Doctrine**

--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -72,6 +72,17 @@ Flow:
 
 5b. **Run the back-end flow.** After Session notes are posted and reconciliation is applied, run the commit → push → PR create → mergeable check → confirm merge → cleanup sequence. The flow is idempotent — re-running `/jared-wrap` re-evaluates state and picks up at the current step.
 
+   **Precondition — branch guard.** The back-end flow assumes the session worked on a feature branch. If the current branch is `main`, skip the loop entirely and jump directly to the lock-clear + worktree-removal bullets below — running the loop on `main` would attempt `gh pr create` for the main branch, which either fails with a confusing GitHub error or produces a malformed PR. Check:
+
+   ```bash
+   if [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]; then
+     echo "On main — skipping back-end PR flow."
+     # proceed to lock-clear / worktree cleanup below
+   fi
+   ```
+
+   When the guard fires, the lock-clear still runs (the session may have written one) and the worktree-removal bullet is a no-op (worktrees are never created against `main`).
+
    Loop:
 
    ```bash

--- a/docs/superpowers/specs/archived/2026-05/2026-05-28-multi-session-back-end-design.md
+++ b/docs/superpowers/specs/archived/2026-05/2026-05-28-multi-session-back-end-design.md
@@ -112,9 +112,11 @@ def propose_partition(
     existing_session_labels: dict[int, int],
 ) -> Proposal:
     """Greedy partition: walk candidates in priority order, assign each to the
-    session with the lowest cumulative surface-overlap so far. Tie-break by
-    load-balance (smaller session wins). Existing labels are honored unless the
-    operator opts into a full re-balance (a future flag — not in v1).
+    session with the largest cumulative surface-overlap so far (cohesion-first:
+    co-locate work that shares files, so conflict-prone items land in one
+    session rather than across sessions). Tie-break by load-balance (smaller
+    session wins). Existing labels are honored unless the operator opts into a
+    full re-balance (a future flag — not in v1).
 
     A candidate with no surface signal is a float: no proposal.
     """
@@ -126,7 +128,7 @@ For each candidate in priority order:
 
 1. If it has an existing `session-N` label and N ≤ K, propose `keep` (honor the operator's prior decision).
 2. If it has no surface signal (no file paths in body), propose `float` (no label).
-3. Otherwise, compute its overlap (set-intersection of surface) against each session's current cumulative surface. Pick the session with the smallest intersection. Tie-break by smaller per-session load.
+3. Otherwise, compute its overlap (set-intersection of surface) against each session's current cumulative surface. Pick the session with the **largest** intersection (cohesion-first — co-locate items that share files). Tie-break by smaller per-session load.
 
 Output as a `Proposal` — `keep`/`move`/`add`/`floats` lists.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.25.0"
+version = "0.26.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Cuts **v0.26.0**, bundling the multi-session back-end shipped earlier today (#271 spec / #273 impl / #274 archive — Phases 1.1 → 5.1) with the post-ship cleanup from #275.

### Headline feature (already merged via #273)

The staging, start, and wrap surfaces now coordinate across parallel Claude sessions instead of just naming them.

- `lib/partition.py` — cohesion-first greedy partition over Up Next / Backlog candidates. Each candidate lands in the session whose cumulative file-surface it overlaps with most, so conflict-prone items co-locate rather than spread.
- `jared propose-partition --sessions N` — human + JSON output.
- `/jared-stage --sessions N` — partition + operator-approved label application.
- `jared next-session-prompt --session N` — filters Top of Up Next by `session-N` label.
- `/jared-start <issue> --session N` — passes the flag through; sibling sessions see only their own work.
- `jared wrap-state` — collects git + PR state, prints the next step (`commit` / `push` / `create_pr` / `wait_checks` / `confirm_merge` / `cleanup` etc.).
- `/jared-wrap` — drives the commit → push → PR → merge → cleanup loop off `wrap-state`.
- `lib/ties.py` — `file_paths_in_body`, `GENERIC_FILES`, `tokenize_title`, `FILE_PATH_RE` promoted to the public extractor surface.

### #275 cleanup folded in

- `/jared-wrap` step 5b now guards against running on `main`. The loop is skipped entirely if `git rev-parse --abbrev-ref HEAD` is `main`; the lock-clear + worktree-removal bullets still run. Prior behavior would call `gh pr create` for `main`, which fails confusingly.
- Archived multi-session spec § "Phase 1 — Stage proposal" prose now matches the cohesion-first implementation ("largest cumulative surface-overlap" instead of "smallest"). Future readers of the archived design see the algorithm direction that matches the shipped code.

### Release plumbing

- `.claude-plugin/plugin.json` and `pyproject.toml` → `0.26.0`.
- `CHANGELOG.md` entry under the new format (Features / Bug fixes).

## Test plan

- [x] `pytest -q` — 557 passed, 1 deselected
- [x] `ruff check .` — clean
- [x] `mypy` — clean
- [ ] Post-merge: tag `v0.26.0`, push tag, `gh release create` with notes mirroring the CHANGELOG entry
- [ ] Post-merge: `/plugin update jared` + `/reload-plugins` on this machine to validate the install path

## Backward compatibility

No removed flags or surfaces. Multi-session features are opt-in via `--session N` / `--sessions N`; solo workflows are unchanged.

## Upgrading

```
/plugin update jared
/reload-plugins
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)