### PR TITLE
refactor(sweep): retire dead check_closed_not_done + honest test fixtures (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,6 @@ Open items on board: 6
   docs/superpowers/plans/2026-05-03-89-shipped-section.md:
     all referenced issues closed ([89]) — propose archiving
 
-== Closed items not on Done ==
-  None
-
 Sweep complete. Advisory only — review and propose before applying.
 ```
 

--- a/skills/jared/references/board-sweep.md
+++ b/skills/jared/references/board-sweep.md
@@ -23,7 +23,7 @@ Every open item needs **Status** and **Priority**, plus any categorical fields t
 
 Status in particular is easy to miss: GitHub's auto-add-to-project workflow adds issues to the board without populating Status, so items can land with Priority set (because `jared-file` sets it explicitly) but Status=None. `scripts/sweep.py` flags both gaps.
 
-`scripts/sweep.py` also flags **closed items whose Status ≠ Done** — GitHub's auto-move on close sometimes fails, and stale board state accumulates. Move them to Done manually during the sweep.
+**Closed items whose Status ≠ Done** are surfaced by `jared summary` (and so every `/jared-start`) under a `Stuck closed (N):` heading — GitHub's auto-move on close sometimes fails, leaving an issue closed on GitHub but parked in Backlog / In Progress. The detector lists recently-closed issues and flags any whose Project Status isn't Done; move them to Done with the proposed `jared set <N> Status Done`. (This is the bounded recent-closed probe; sweep no longer carries its own duplicate scan — see #223.)
 
 ### 2. WIP
 

--- a/skills/jared/references/new-board.md
+++ b/skills/jared/references/new-board.md
@@ -63,7 +63,7 @@ Three close paths, one of them safe either way:
 | `gh issue close <N>` | **Yes** — no fallback |
 | PR merge with `Closes #N` | **Yes** — no fallback |
 
-If you run on a project with the workflow off, paths 2 and 3 silently leave items in their pre-close Status column (typically Backlog or In Progress) while GitHub reports them as closed. `sweep.py` / `/jared-groom` detect this (`check_closed_not_done`) and now propose `jared set <N> Status Done` per stuck item — the routine sweep drains the drift instead of just reporting it.
+If you run on a project with the workflow off, paths 2 and 3 silently leave items in their pre-close Status column (typically Backlog or In Progress) while GitHub reports them as closed. `jared summary` (and so every `/jared-start`) surfaces this drift under a `Stuck closed (N):` heading — it lists recently-closed issues and flags any whose project Status isn't Done, proposing `jared set <N> Status Done` per item.
 
 ### 3. Optional: scaffold Superpowers-style planning
 

--- a/skills/jared/references/operations.md
+++ b/skills/jared/references/operations.md
@@ -52,7 +52,7 @@ The escape-hatch examples below are written with these rules applied.
 
 ### Closed-items cache (sweep optimization, #186)
 
-`sweep.py` runs `check_off_board_issues` and `check_closed_not_done`, both of which need closed items in the snapshot — `check_closed_not_done` specifically needs closed-with-Status-not-Done items, so a pure Done-only cache would make them invisible.
+`sweep.py` runs `check_off_board_issues`, a pure number-intersection between open repo issues and board items. It needs the closed board items in the snapshot too, so a closed-but-on-board issue isn't false-flagged as off-board — hence the cache holds the closed subset alongside the open pull.
 
 To avoid re-pulling the full mature-board history every sweep cycle, sweep maintains a persistent **closed-items cache** at `${JARED_CACHE_DIR}/<project>-closed.json` (24-hour default TTL). On warm-cache reads, sweep pulls open items via `Board.open_items()` (cost scales with open count, not total board size) and merges with the cached closed items. Dedup rule: open-items pull wins on number collision (handles external reopen).
 

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -1056,8 +1056,10 @@ def _detect_stuck_closed_recent(board: Board, *, days: int) -> list[dict[str, An
     Bounded lookback keeps cost proportional to recent-closure volume
     (typically 5-20 per active board) rather than total Done count. This
     is now the only stuck-closed detector — the old item-snapshot scan
-    (`check_closed_not_done`) was a no-op once both fetch paths stopped
-    carrying `content.state`, and was retired in #223.
+    (`check_closed_not_done`) keyed on `content.state == "CLOSED"`, which
+    `gh project item-list` has never populated (the field was a mistaken
+    premise; #189). It was therefore a no-op in every architecture it
+    shipped in, and was retired in #223.
 
     Returns a `[{"number", "title", "current_status"}]` shape, so the
     renderer is unchanged.

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -1047,19 +1047,20 @@ def _fetch_board_items(board: Board) -> list[dict[str, Any]]:
 def _detect_stuck_closed_recent(board: Board, *, days: int) -> list[dict[str, Any]]:
     """Stuck-closed drift detection for the open-only summary path (#185).
 
-    `check_closed_not_done` (lib.board) needs CLOSED items already in the
-    snapshot; that worked when summary pulled the full Done-inclusive
-    `board_items()`. The new `open_items()` path skips closed items, so
-    detection pivots to: list issues closed in the last `days`, probe
-    each one's project Status, flag anything that isn't on Done.
+    Detecting "closed on GitHub but Status != Done" needs the issue's
+    GitHub state, which the open-only `open_items()` path omits (and which
+    `gh project item-list` never populates — see #189/#223). So detection
+    works from the closed side instead: list issues closed in the last
+    `days`, probe each one's project Status, flag anything not on Done.
 
     Bounded lookback keeps cost proportional to recent-closure volume
-    (typically 5-20 per active board) rather than total Done count.
-    Drift older than the window is sweep's job — sweep still pulls the
-    full board and runs `check_closed_not_done` against it.
+    (typically 5-20 per active board) rather than total Done count. This
+    is now the only stuck-closed detector — the old item-snapshot scan
+    (`check_closed_not_done`) was a no-op once both fetch paths stopped
+    carrying `content.state`, and was retired in #223.
 
-    Returns the same `[{"number", "title", "current_status"}]` shape
-    `check_closed_not_done` returns, so the renderer is unchanged.
+    Returns a `[{"number", "title", "current_status"}]` shape, so the
+    renderer is unchanged.
 
     On `GhInvocationError` from the underlying `_fetch_recently_closed`
     (recent-closure count exceeds the cap on an exceptionally busy board),

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -1279,39 +1279,6 @@ def parse_shipped_section(plan_text: str) -> list[int]:
     return refs if refs is not None else []
 
 
-def check_closed_not_done(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Closed issues should auto-move to Done. If they don't, return them.
-
-    Detection-only. Each entry is `{number, title, current_status}` —
-    callers decide the rendering (sweep adds a `Propose: jared set <N>
-    Status Done` remediation suffix; the CLI's `summary` command renders
-    them under a separate `Stuck closed (N):` heading and excludes them
-    from the `In Progress` count). Keeping format out of the detector
-    means each call site can pick its own affordance.
-
-    The drift usually comes from projects whose built-in "Item closed →
-    Done" workflow is disabled — paths like `gh issue close` and PR-merge
-    auto-close rely on it entirely (only `jared close` has its own
-    explicit-Status fallback).
-    """
-    stuck = []
-    for i in items:
-        content = i.get("content") or {}
-        if content.get("state") != "CLOSED":
-            continue
-        status = i.get("status") or ""
-        if status == "Done":
-            continue
-        stuck.append(
-            {
-                "number": content.get("number"),
-                "title": (content.get("title") or i.get("title") or "")[:60],
-                "current_status": status or "no Status",
-            }
-        )
-    return stuck
-
-
 def _flatten_project_item_for_project(
     project_items_node: Any, project_number: int
 ) -> dict[str, Any] | None:

--- a/skills/jared/scripts/sweep.py
+++ b/skills/jared/scripts/sweep.py
@@ -11,8 +11,6 @@ references/board-sweep.md:
      Status is checked because GitHub's auto-add-to-project workflow adds
      items without populating Status; items landing as Status=None sort
      below everything and vanish until someone sets it manually.
-  1b. Closed items not on Done — auto-move sometimes fails to fire;
-      closed issues with Status != Done accumulate and pollute queries.
   2. WIP cap — In Progress within limit, flag stalled items
   3. Up Next queue — size and pullable-top check
   4. Aging — High-priority Backlog items >14 days old
@@ -57,7 +55,6 @@ from lib import cache as board_cache  # type: ignore[import-not-found]  # noqa: 
 from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     Board,
     GhInvocationError,
-    check_closed_not_done,
 )
 from lib.board import (
     check_graphql_budget as board_check_graphql_budget,
@@ -323,19 +320,6 @@ def check_metadata(items: list[dict[str, Any]]) -> list[str]:
     return missing
 
 
-def format_closed_not_done_line(entry: dict[str, Any]) -> str:
-    """Render a stuck-item entry with its remediation command.
-
-    Format lives at the sweep/groom render site, not in the detector.
-    Other sweep checks that want a Propose-style suffix follow this same
-    shape — their format helper, their render site.
-    """
-    n = entry["number"]
-    return (
-        f"#{n} [{entry['current_status']}]: {entry['title']} — Propose: jared set {n} Status Done"
-    )
-
-
 def check_wip(items: list[dict[str, Any]], limit: int) -> list[str]:
     in_progress = [i for i in items if i.get("status") == "In Progress"]
     findings = []
@@ -476,8 +460,8 @@ def check_off_board_issues(
 
     Caller passes `issues_by_number` already filtered to repo-open
     issues (see `fetch_open_issues_bulk` which uses `--state open`).
-    A board item with Status=Done still counts as "on the board" —
-    that's a different drift handled by `check_closed_not_done`.
+    A board item with Status=Done still counts as "on the board" — it's
+    on the project, just in a different column.
     """
     on_board = {
         (i.get("content") or {}).get("number")
@@ -944,15 +928,6 @@ def main() -> int:
                 print(f"  {line}")
         except (RuntimeError, GhInvocationError) as e:
             print(f"  (skipped — {e})")
-    print()
-
-    print("== Closed items not on Done ==")
-    stuck = check_closed_not_done(items)
-    if stuck:
-        for entry in stuck:
-            print(f"  {format_closed_not_done_line(entry)}")
-    else:
-        print("  None")
     print()
 
     print("== Off-board issues (open in repo, missing from project) ==")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -59,13 +59,12 @@ def test_different_projects_use_separate_cache_files(tmp_path: Path) -> None:
 
 # ---------- Closed-items cache (#186) ----------
 #
-# Sweep needs Done + stuck-closed items in the snapshot to run
-# `check_off_board_issues` (state-agnostic intersection) and
-# `check_closed_not_done` (closed AND status != Done). A pure Done-only cache
-# makes stuck items invisible, so this cache holds ALL closed items with their
-# current Status field. Long TTL because the closed-item *set* is mostly
-# monotone; first-party Status mutations invalidate to catch the mutable cases
-# (close-into-Done, reopen, manual Status reset).
+# Sweep needs closed board items in the snapshot so `check_off_board_issues`
+# (a state-agnostic number intersection) doesn't false-positive an open repo
+# issue that's already on the board under a Done column. The cache holds the
+# closed subset with its current Status field. Long TTL because the closed-item
+# *set* is mostly monotone; first-party Status mutations invalidate to catch the
+# mutable cases (close-into-Done, reopen, manual Status reset).
 
 
 def test_get_closed_items_returns_none_when_no_cache_file(tmp_path: Path) -> None:

--- a/tests/test_sweep_checks.py
+++ b/tests/test_sweep_checks.py
@@ -15,62 +15,20 @@ import pytest
 from tests.conftest import import_sweep, patch_gh
 
 
-def _item(number: int, state: str, status: str, title: str = "") -> dict[str, Any]:
-    """Shape matches what `gh project item-list --format json` returns."""
+def _item(number: int, status: str, title: str = "") -> dict[str, Any]:
+    """Cold-path item shape: what `gh project item-list --format json` returns.
+
+    Note the deliberate absence of a `content.state` key — `item-list`
+    does not populate the GitHub issue state (#189/#223). Sweep's checks
+    that run on this snapshot key on the top-level `status` (the Project
+    board column), never on `content.state`. A fixture that invented a
+    `state` key here is exactly the lie #223 set out to remove: it let a
+    state-keyed filter pass in tests while no-op'ing in production.
+    """
     return {
-        "content": {"number": number, "state": state, "title": title or f"Issue {number}"},
+        "content": {"number": number, "title": title or f"Issue {number}"},
         "status": status,
     }
-
-
-def test_check_closed_not_done_returns_empty_when_all_closed_on_done() -> None:
-    mod = import_sweep()
-    items = [
-        _item(1, "CLOSED", "Done"),
-        _item(2, "CLOSED", "Done"),
-        _item(3, "OPEN", "In Progress"),
-    ]
-    assert mod.check_closed_not_done(items) == []
-
-
-def test_check_closed_not_done_flags_stuck_items() -> None:
-    mod = import_sweep()
-    items = [
-        _item(42, "CLOSED", "Done", title="Done properly"),
-        _item(92, "CLOSED", "Backlog", title="Stuck in Backlog"),
-        _item(93, "CLOSED", "In Progress", title="Stuck in In Progress"),
-        _item(100, "OPEN", "Backlog", title="Open — not stuck"),
-    ]
-    stuck = mod.check_closed_not_done(items)
-    numbers = [entry["number"] for entry in stuck]
-    assert numbers == [92, 93]
-    assert stuck[0]["current_status"] == "Backlog"
-    assert stuck[1]["current_status"] == "In Progress"
-
-
-def test_check_closed_not_done_handles_no_status() -> None:
-    """An item that's CLOSED but missing the status key entirely (older API
-    responses, or pre-workflow boards) still gets flagged — its
-    current_status renders as 'no Status' so the downstream format is
-    still readable."""
-    mod = import_sweep()
-    items = [{"content": {"number": 99, "state": "CLOSED", "title": "No status at all"}}]
-    [entry] = mod.check_closed_not_done(items)
-    assert entry["number"] == 99
-    assert entry["current_status"] == "no Status"
-
-
-def test_check_closed_not_done_ignores_missing_content() -> None:
-    """Items without a `content` payload (e.g. draft items) must not crash."""
-    mod = import_sweep()
-    items = [
-        {"status": "Backlog"},  # no content at all
-        _item(5, "CLOSED", "Backlog"),
-    ]
-    stuck = mod.check_closed_not_done(items)
-    # Only the well-formed closed item is flagged.
-    assert len(stuck) == 1
-    assert stuck[0]["number"] == 5
 
 
 def test_check_metadata_flags_missing_status_key() -> None:
@@ -334,9 +292,9 @@ def test_check_off_board_issues_returns_empty_when_all_on_board() -> None:
     """Healthy case: every open repo issue has a project item."""
     mod = import_sweep()
     items = [
-        _item(1, "OPEN", "In Progress"),
-        _item(2, "OPEN", "Up Next"),
-        _item(3, "OPEN", "Backlog"),
+        _item(1, "In Progress"),
+        _item(2, "Up Next"),
+        _item(3, "Backlog"),
     ]
     issues_by_number = {
         1: _open_issue(1),
@@ -352,8 +310,8 @@ def test_check_off_board_issues_flags_repo_issue_missing_from_project() -> None:
     see it without a sweep. Surface it with a `jared add-to-board` recovery."""
     mod = import_sweep()
     items = [
-        _item(1, "OPEN", "In Progress"),
-        _item(2, "OPEN", "Up Next"),
+        _item(1, "In Progress"),
+        _item(2, "Up Next"),
     ]
     issues_by_number = {
         1: _open_issue(1),
@@ -372,7 +330,7 @@ def test_check_off_board_issues_flags_repo_issue_missing_from_project() -> None:
 
 def test_check_off_board_issues_handles_multiple_ghosts() -> None:
     mod = import_sweep()
-    items = [_item(1, "OPEN", "Backlog")]
+    items = [_item(1, "Backlog")]
     issues_by_number = {
         1: _open_issue(1),
         50: _open_issue(50, title="ghost A"),
@@ -390,44 +348,27 @@ def test_check_off_board_issues_ignores_closed_repo_issues() -> None:
     caller to pass open issues only — it doesn't re-filter.
     """
     mod = import_sweep()
-    items = [_item(1, "OPEN", "Backlog")]
+    items = [_item(1, "Backlog")]
     # Caller already filtered; only pass open ones in.
     issues_by_number = {1: _open_issue(1)}
     assert mod.check_off_board_issues(items, issues_by_number) == []
 
 
-def test_check_off_board_issues_ignores_closed_board_items() -> None:
-    """A board item whose content state is CLOSED still 'covers' a
-    repo-open issue with the same number — but that's a different drift
-    pattern (the repo says open, the board has it closed). Handled by
-    `check_closed_not_done`, not here. This check only flags repo-open
-    issues that have NO project item at all.
+def test_check_off_board_issues_ignores_done_board_items() -> None:
+    """A board item sitting in the Done column still 'covers' a repo-open
+    issue with the same number — the off-board check is a pure number
+    intersection and doesn't care which column the item is in. This check
+    only flags repo-open issues that have NO project item at all.
     """
     mod = import_sweep()
     items = [
-        _item(1, "OPEN", "Backlog"),
-        _item(99, "CLOSED", "Done"),  # board has it
+        _item(1, "Backlog"),
+        _item(99, "Done"),  # board has it, parked in Done
     ]
     issues_by_number = {1: _open_issue(1), 99: _open_issue(99)}
-    # 99 is on the board (even if mismatched state) — not flagged here.
+    # 99 is on the board — not flagged here.
     findings = mod.check_off_board_issues(items, issues_by_number)
     assert findings == []
-
-
-def test_format_closed_not_done_line_includes_propose_command() -> None:
-    """The render-site formatter names the remediation command so the groom
-    flow has a concrete next action to propose with per-item approval.
-
-    Format lives here, not in check_closed_not_done — so next sweep-check
-    that needs a Propose-style suffix can follow the same
-    detector-returns-data / renderer-formats-line split.
-    """
-    mod = import_sweep()
-    entry = {"number": 92, "current_status": "Backlog", "title": "Stuck"}
-    line = mod.format_closed_not_done_line(entry)
-    assert "jared set 92 Status Done" in line
-    assert "[Backlog]" in line
-    assert "Stuck" in line
 
 
 def test_check_doc_sync_gate_flags_code_only_pr() -> None:
@@ -727,14 +668,18 @@ def test_merge_open_with_closed_dedup_open_wins() -> None:
     """
     sweep = import_sweep()
 
+    # Open items come from Board.open_items() (warm/GraphQL path), which DOES
+    # populate content.state — and only ever with "OPEN" (the query filters to
+    # open issues). Closed-cache items are warmed from the cold-path
+    # `gh project item-list` subset, which omits content.state entirely.
     open_items = [
         {"content": {"number": 10, "state": "OPEN"}, "status": "In Progress"},
         {"content": {"number": 11, "state": "OPEN"}, "status": "Backlog"},
     ]
     closed_items = [
-        # #10 was reopened externally — stale closed entry should be dropped
-        {"content": {"number": 10, "state": "CLOSED"}, "status": "Done"},
-        {"content": {"number": 99, "state": "CLOSED"}, "status": "Done"},
+        # #10 was reopened externally — stale closed entry should be dropped.
+        {"content": {"number": 10}, "status": "Done"},
+        {"content": {"number": 99}, "status": "Done"},
     ]
 
     merged = sweep.merge_open_with_closed(open_items, closed_items)
@@ -778,8 +723,9 @@ def test_fetch_items_with_closed_cache_warm_hit_returns_merged(
     cache.set_closed_items(
         project_number=7,
         items=[
-            {"content": {"number": 50, "state": "CLOSED"}, "status": "Done"},
-            {"content": {"number": 51, "state": "CLOSED"}, "status": "Done"},
+            # Closed-cache shape: cold-path-derived, no content.state key.
+            {"content": {"number": 50}, "status": "Done"},
+            {"content": {"number": 51}, "status": "Done"},
         ],
         cache_dir=cache_dir,
     )
@@ -893,10 +839,12 @@ def test_fetch_items_with_closed_cache_cold_miss_warms_cache(
     )
     board = Board.from_path(board_md)
 
+    # Cold-path `gh project item-list` output: no content.state on any item
+    # (open or closed) — only the top-level Project `status` column.
     full_items = [
-        {"content": {"number": 70, "state": "OPEN"}, "status": "In Progress"},
-        {"content": {"number": 80, "state": "CLOSED"}, "status": "Done"},
-        {"content": {"number": 81, "state": "CLOSED"}, "status": "Done"},
+        {"content": {"number": 70}, "status": "In Progress"},
+        {"content": {"number": 80}, "status": "Done"},
+        {"content": {"number": 81}, "status": "Done"},
     ]
     patch_gh(monkeypatch, stdout=json.dumps({"items": full_items}))
 
@@ -935,7 +883,8 @@ def test_fetch_items_with_closed_cache_falls_back_when_open_items_paginates(
     cache_dir = Path(os.environ["JARED_CACHE_DIR"])
     cache.set_closed_items(
         project_number=7,
-        items=[{"content": {"number": 50, "state": "CLOSED"}, "status": "Done"}],
+        # Closed-cache shape: cold-path-derived, no content.state key.
+        items=[{"content": {"number": 50}, "status": "Done"}],
         cache_dir=cache_dir,
     )
 
@@ -958,9 +907,10 @@ def test_fetch_items_with_closed_cache_falls_back_when_open_items_paginates(
     monkeypatch.setattr(Board, "open_items", fake_open_items)
 
     # Cold path returns the full board pull, then re-warms the cache.
+    # `gh project item-list` shape: no content.state key.
     full_items = [
-        {"content": {"number": 10, "state": "OPEN"}, "status": "In Progress"},
-        {"content": {"number": 50, "state": "CLOSED"}, "status": "Done"},
+        {"content": {"number": 10}, "status": "In Progress"},
+        {"content": {"number": 50}, "status": "Done"},
     ]
     patch_gh(monkeypatch, stdout=json.dumps({"items": full_items}))
 
@@ -987,9 +937,10 @@ def test_fetch_items_with_closed_cache_respects_jared_no_cache(
 
     cache_dir = Path(os.environ["JARED_CACHE_DIR"])
     # Pre-seed the closed-cache; JARED_NO_CACHE should ignore it.
+    # Closed-cache shape: cold-path-derived, no content.state key.
     cache.set_closed_items(
         project_number=7,
-        items=[{"content": {"number": 999, "state": "CLOSED"}, "status": "Done"}],
+        items=[{"content": {"number": 999}, "status": "Done"}],
         cache_dir=cache_dir,
     )
 
@@ -1008,7 +959,8 @@ def test_fetch_items_with_closed_cache_respects_jared_no_cache(
 
     monkeypatch.setenv("JARED_NO_CACHE", "1")
 
-    full_items = [{"content": {"number": 1, "state": "OPEN"}, "status": "Backlog"}]
+    # Cold-path `gh project item-list` shape: no content.state key.
+    full_items = [{"content": {"number": 1}, "status": "Backlog"}]
     patch_gh(monkeypatch, stdout=json.dumps({"items": full_items}))
 
     items = sweep.fetch_items_with_closed_cache(board, "brockamer", "7")


### PR DESCRIPTION
Closes #223.

## What this does

#223 was scoped (by a comment) down to "make the lying test fixtures honest" — the semantic-decision work having shipped in #224. Tracing which real shape each fixture should match surfaced a deeper finding, which reframed the work.

## Finding: `check_closed_not_done` was a permanent no-op

`check_closed_not_done` (lib/board.py) keys on `content.state == "CLOSED"`. No production path ever supplies an item with that:

- **sweep's only call site** (sweep.py:950) feeds it `fetch_items_with_closed_cache` output. The **warm** branch is `open_items()` (GraphQL `states: OPEN` → `content.state` is always `"OPEN"`) merged with closed-cache items (cold-derived → **no `state` key**); the **cold** branch is `fetch_items()` / `gh project item-list` (**no `state` key**).
- the **CLI `summary` path** stopped calling it at #185, pivoting to `_detect_stuck_closed_recent` — a bounded recent-closed Status probe that surfaces under the `Stuck closed (N):` heading.

So the detector returned `[]` unconditionally in production. Its 5 tests passed **only because the fixtures invented `content.state`** — the exact #189 pathology this issue family set out to kill. A "green" fixture couldn't be made honest, because nothing produces its triggering input.

Operator decision (asked mid-session): **retire** the detector rather than re-wire a Done-inclusive, state-bearing GraphQL pull.

## Changes

**Retire**
- delete `check_closed_not_done` (lib/board.py) + `format_closed_not_done_line` + the `== Closed items not on Done ==` sweep section + the import
- delete the 4 detector tests + the renderer test

**Honest fixtures** (the original AC)
- `_item` helper → cold-path shape (`gh project item-list`): no `content.state`
- cold-path `patch_gh` fixtures + closed-cache fixtures → drop `content.state`
- warm-path `open_items` fixtures **keep** `content.state` (GraphQL legitimately populates it). The two shapes are now labelled in-fixture, not conflated.

**Docs reconciled**: sweep.py module header, README sample output, `new-board.md`, `operations.md` (closed-cache rationale), `test_cache.py` comment, and the `_detect_stuck_closed_recent` docstring — all now name the surviving detector.

## Validation
- `pytest` — 551 passed (5 dead tests removed). The one unrelated failure, `test_cmd_file.py::test_file_inline_body_staging_round_trip_mismatch_errors`, is **pre-existing on `main`** (confirmed by stashing this branch's diff) and untouched by this PR.
- `ruff check .` — clean
- `mypy` — clean

## Note for the reviewer
The pre-existing `test_cmd_file` failure on `main` looks like a real bug (a round-trip mismatch that should error returns rc 0). Out of scope here — flagging for a separate decision on whether to file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)