### PR TITLE
fix(test): file round-trip-mismatch test brittle to $TMPDIR (#280)

### DIFF
--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -1,5 +1,6 @@
 import json as _json
 import subprocess as _subprocess
+import tempfile
 from io import StringIO
 from pathlib import Path
 from textwrap import dedent
@@ -301,10 +302,15 @@ def test_file_inline_body_staging_round_trip_mismatch_errors(
     real_read_text = Path.read_text
 
     def maybe_truncating_read_text(self: Path, *a: object, **kw: object) -> str:
-        # Only intercept the temp body file (created in /tmp directly,
-        # not under any subdirectory). The board file lives under
-        # tmp_path/docs/, so we won't break Board parsing.
-        if self.parent == Path("/tmp") and self.suffix == ".md":
+        # Only intercept the staged body file. NamedTemporaryFile creates it
+        # directly in tempfile.gettempdir() (which honors $TMPDIR), so match
+        # the parent against the live tempdir rather than a hardcoded /tmp —
+        # otherwise this fires only when the system tempdir is exactly /tmp
+        # and silently no-ops under TMPDIR=/tmp/sub (e.g. the CC sandbox).
+        # The board file lives under tmp_path/docs/, nested below the tempdir
+        # rather than directly in it, so it stays unintercepted and Board
+        # parsing keeps working.
+        if self.parent == Path(tempfile.gettempdir()) and self.suffix == ".md":
             return ""
         return real_read_text(self, *a, **kw)  # type: ignore[arg-type]
 


### PR DESCRIPTION
Closes #280.

## What

`test_file_inline_body_staging_round_trip_mismatch_errors` passed only when the system tempdir resolved to exactly `/tmp`. The test fakes silent staging corruption by monkeypatching `Path.read_text` to truncate the staged body file, but gated the interception on `self.parent == Path("/tmp")`. `NamedTemporaryFile` honors `$TMPDIR`, so under `TMPDIR=/tmp/sub` (the Claude Code sandbox) the staged file's parent is `/tmp/sub`, the parent-match missed, the truncating read-back never fired, and the command returned rc 0 — failing the test's `assert rc != 0`.

## Fix

Match the parent against `tempfile.gettempdir()` instead of a hardcoded `/tmp`. This honors `$TMPDIR` while preserving the *directly-in-tempdir* (not nested) discrimination that shields the board file under `tmp_path/docs/` from interception — `parent ==` rather than a `startswith`, so the nested board `.md` stays unintercepted and Board parsing keeps working.

**Test-only change.** The production round-trip fence at `jared:610-630` was already correct — this was a brittle test, not a production defect.

## Validation

- Target test green with `TMPDIR` unset, `=/tmp`, and `=/tmp/sub`
- Full suite: 552 passed
- `ruff check`, `ruff format --check`, `mypy --strict` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)