### PR TITLE
perf(api): extend ETag/conditional GET to issue-body reads (#216)

### DIFF
--- a/skills/jared/scripts/archive-plan.py
+++ b/skills/jared/scripts/archive-plan.py
@@ -32,6 +32,9 @@ from typing import cast
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
+    fetch_issue_body_rest as board_fetch_issue_body_rest,
+)
+from lib.board import (
     fetch_issue_state_rest as board_fetch_issue_state_rest,
 )
 from lib.board import (
@@ -39,9 +42,6 @@ from lib.board import (
 )
 from lib.board import (
     parse_shipped_section as board_parse_shipped_section,
-)
-from lib.board import (
-    run_gh as board_run_gh,
 )
 from lib.board import (
     run_gh_raw as board_run_gh_raw,
@@ -66,11 +66,10 @@ def issue_state(repo: str, number: int) -> tuple[str, str | None]:
 
 
 def fetch_issue_body(repo: str, number: int) -> str:
-    # REST `core` bucket instead of graphql (#208); same pattern as
-    # lib.board.fetch_issue_state_rest. No new wrapper per acceptance criteria —
-    # inline at the call site keeps the seam visible.
-    data = board_run_gh(["api", f"repos/{repo}/issues/{number}"])
-    return data.get("body") or ""
+    # REST `core` bucket with ETag/conditional GET (#216): delegates to
+    # lib.board.fetch_issue_body_rest so the --scan fan-out across stable plan
+    # bodies can short-circuit repeat reads to a 304.
+    return cast("str", board_fetch_issue_body_rest(repo, number))
 
 
 def write_issue_body(repo: str, number: int, body: str) -> None:

--- a/skills/jared/scripts/capture-context.py
+++ b/skills/jared/scripts/capture-context.py
@@ -32,12 +32,13 @@ import re
 import sys
 import tempfile
 from pathlib import Path
+from typing import cast
 
 # Make sibling lib/ importable regardless of cwd — same pattern as the jared CLI.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
-    run_gh as board_run_gh,
+    fetch_issue_body_rest as board_fetch_issue_body_rest,
 )
 from lib.board import (
     run_gh_raw as board_run_gh_raw,
@@ -54,11 +55,10 @@ SECTION_ORDER = [
 
 
 def fetch_body(repo: str, number: int) -> str:
-    # REST `core` bucket instead of graphql (#208); same pattern as
-    # lib.board.fetch_issue_state_rest. No new wrapper per acceptance criteria —
-    # inline at the call site keeps the seam visible.
-    data = board_run_gh(["api", f"repos/{repo}/issues/{number}"])
-    return data.get("body") or ""
+    # REST `core` bucket with ETag/conditional GET (#216): delegates to
+    # lib.board.fetch_issue_body_rest, the body-read twin of
+    # fetch_issue_state_rest, so repeat reads can short-circuit to a 304.
+    return cast("str", board_fetch_issue_body_rest(repo, number))
 
 
 def write_body(repo: str, number: int, body: str) -> None:

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -974,6 +974,33 @@ def fetch_issue_state_rest(repo: str, number: int) -> tuple[str, str | None]:
     return _parse_issue_state_payload(data)
 
 
+def fetch_issue_body_rest(repo: str, number: int) -> str:
+    """Return an issue's Markdown body via REST, with ETag/conditional GET (#216).
+
+    The body-read twin of `fetch_issue_state_rest`: rides the same
+    `_fetch_issue_rest_with_etag` layer (#147) so a repeat read of an
+    unchanged body short-circuits to a 304 without spending REST `core`
+    points — most valuable for `archive-plan.py --scan`, which fans out
+    across many stable plan bodies. `JARED_NO_CACHE=1` bypasses the ETag
+    layer and falls back to the unconditional `gh api` flow.
+
+    Any failure mode (network error, 304 with an empty cache, missing body
+    field) resolves to "", matching the `data.get("body") or ""` contract
+    the batch call sites already relied on.
+    """
+    if os.environ.get("JARED_NO_CACHE") == "1":
+        try:
+            data = run_gh(["api", f"repos/{repo}/issues/{number}"])
+        except GhInvocationError:
+            return ""
+        return data.get("body") or ""
+
+    data = _fetch_issue_rest_with_etag(repo, number)
+    if data is None:
+        return ""
+    return data.get("body") or ""
+
+
 def _child_env() -> dict[str, str]:
     """Env for `gh` subprocess calls, with GH_TOKEN/GITHUB_TOKEN removed.
 

--- a/tests/test_issue_body_etag.py
+++ b/tests/test_issue_body_etag.py
@@ -1,0 +1,225 @@
+"""Tests for the ETag/conditional GET layer on fetch_issue_body_rest (#216).
+
+`fetch_issue_body_rest` is the body-read twin of `fetch_issue_state_rest`
+(#147): it rides the same `_fetch_issue_rest_with_etag` layer so a repeat
+read of an unchanged body short-circuits to a 304 without spending REST
+`core` points, then extracts the `body` field.
+
+  - First call: `gh api -i` returns 200 with headers + body. The wrapper
+    captures the ETag and writes both etag + body to disk; the helper
+    returns the `body` string.
+  - Second call: sends `If-None-Match: <etag>` and gets 304 (exit 1, no
+    body). The wrapper returns the cached body; the helper extracts `body`.
+  - JARED_NO_CACHE=1 falls back to the unconditional REST path.
+  - Any failure mode (network error, 304 with empty cache, missing body
+    field) resolves to "" — matching the `data.get("body") or ""` contract
+    the two batch call sites already rely on.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from skills.jared.scripts.lib import cache
+
+
+def _make_200_response(etag: str, body_json: str) -> str:
+    """Build a `gh api -i` 200 response: status line, headers, blank, body."""
+    return (
+        "HTTP/2.0 200 OK\r\n"
+        "Content-Type: application/json; charset=utf-8\r\n"
+        f"Etag: {etag}\r\n"
+        "\r\n"
+        f"{body_json}"
+    )
+
+
+def _make_304_response(etag: str) -> tuple[str, str, int]:
+    """Build a `gh api -i` 304 response shape (stdout, stderr, returncode)."""
+    stdout = f"HTTP/2.0 304 Not Modified\r\nEtag: {etag}\r\n\r\n"
+    return stdout, "gh: HTTP 304", 1
+
+
+def test_first_call_with_empty_cache_returns_body_and_no_conditional_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cache miss path: returns the body string, no If-None-Match in gh args."""
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = _make_200_response('W/"abc123"', '{"body": "## Context\\nhello"}')
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: Any) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    body = board.fetch_issue_body_rest("brockamer/jared", 216)
+    assert body == "## Context\nhello"
+    assert len(captured) == 1
+    args = captured[0]
+    assert args[:3] == ["gh", "api", "-i"]
+    assert "If-None-Match:" not in " ".join(args)
+
+
+def test_first_call_writes_etag_and_body_to_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful 200 response must populate the on-disk ETag cache."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stdout = _make_200_response('W/"abc123"', '{"body": "the spec"}')
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    body = board.fetch_issue_body_rest("brockamer/jared", 216)
+    assert body == "the spec"
+
+    cache_dir = Path(os.environ["JARED_CACHE_DIR"])
+    cached = cache.get_issue_etag("brockamer/jared", 216, cache_dir=cache_dir)
+    assert cached is not None
+    etag, cached_body = cached
+    assert etag == 'W/"abc123"'
+    assert cached_body["body"] == "the spec"
+
+
+def test_second_call_sends_conditional_header_and_uses_cached_body_on_304(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With a cached ETag, send If-None-Match and return cached body on 304."""
+    from skills.jared.scripts.lib import board
+
+    cache_dir = Path(os.environ["JARED_CACHE_DIR"])
+    cache.set_issue_etag(
+        "brockamer/jared",
+        216,
+        etag='W/"abc123"',
+        body={"body": "cached spec text"},
+        cache_dir=cache_dir,
+    )
+
+    captured: list[list[str]] = []
+    stdout_304, stderr_304, rc_304 = _make_304_response('"abc123"')
+
+    class FakeResult:
+        returncode = rc_304
+        stdout = stdout_304
+        stderr = stderr_304
+
+    def fake_run(args: list[str], **kw: Any) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    body = board.fetch_issue_body_rest("brockamer/jared", 216)
+    assert body == "cached spec text"
+
+    args = captured[0]
+    assert "-H" in args
+    h_idx = args.index("-H")
+    assert args[h_idx + 1] == 'If-None-Match: W/"abc123"'
+
+
+def test_no_cache_env_var_bypasses_etag_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARED_NO_CACHE=1 skips `-i` and conditional GET entirely."""
+    monkeypatch.setenv("JARED_NO_CACHE", "1")
+    from skills.jared.scripts.lib import board
+
+    captured: list[list[str]] = []
+
+    class FakeResult:
+        returncode = 0
+        stdout = '{"body": "uncached path"}'
+        stderr = ""
+
+    def fake_run(args: list[str], **kw: Any) -> FakeResult:
+        captured.append(args)
+        return FakeResult()
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    body = board.fetch_issue_body_rest("brockamer/jared", 99)
+    assert body == "uncached path"
+    args = captured[0]
+    assert "-i" not in args
+    assert "If-None-Match:" not in " ".join(args)
+
+
+def test_gh_failure_without_http_status_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Network failure / bad invocation surfaces "" rather than crashing."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: connection refused"
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    body = board.fetch_issue_body_rest("brockamer/jared", 99999)
+    assert body == ""
+
+
+def test_304_with_no_cached_body_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """304 with an empty cache surfaces "" rather than a silent stale read."""
+    from skills.jared.scripts.lib import board
+
+    stdout_304, stderr_304, rc_304 = _make_304_response('"abc123"')
+
+    class FakeResult:
+        returncode = rc_304
+        stdout = stdout_304
+        stderr = stderr_304
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    body = board.fetch_issue_body_rest("brockamer/jared", 216)
+    assert body == ""
+
+
+def test_missing_body_field_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 200 response whose payload has a null/absent body field yields ""."""
+    from skills.jared.scripts.lib import board
+
+    class FakeResult:
+        returncode = 0
+        stdout = _make_200_response('W/"nobody"', '{"body": null}')
+        stderr = ""
+
+    monkeypatch.setattr(
+        "skills.jared.scripts.lib.board.subprocess.run",
+        lambda *a, **kw: FakeResult(),
+    )
+
+    body = board.fetch_issue_body_rest("brockamer/jared", 216)
+    assert body == ""


### PR DESCRIPTION
Closes #216.

## What

Adds `fetch_issue_body_rest(repo, number) -> str` to `lib/board.py` — the body-read twin of `fetch_issue_state_rest`. It rides the same `_fetch_issue_rest_with_etag` layer (#147), so a repeat read of an unchanged issue body short-circuits to a **304** without spending REST `core` points. Most valuable for `archive-plan.py --scan`, which fans out across many stable plan bodies.

`capture-context.py:fetch_body` and `archive-plan.py:fetch_issue_body` now delegate to the helper instead of inlining bare `gh api repos/.../issues/N` calls — retiring the "no new wrapper" carve-out that #208 left in place by design.

## Acceptance criteria

- [x] `fetch_issue_body_rest` helper added to `lib/board.py`, wrapping `_fetch_issue_rest_with_etag` and extracting the `body` field.
- [x] `capture-context.py` and `archive-plan.py` use the new helper.
- [x] `JARED_NO_CACHE=1` bypasses the ETag layer for body reads (matches `fetch_issue_state_rest`).
- [x] Test coverage mirroring the existing `fetch_issue_state_rest` ETag tests (`tests/test_issue_body_etag.py`, 7 cases).

## Notes

- Shared `(repo, number)` cache key over the full issue JSON means a state read primes a body read and vice-versa — a small bonus beyond what the issue asked for.
- All failure modes (network error, 304 with empty cache, missing `body` field) resolve to `""`, matching the `data.get("body") or ""` contract the call sites already relied on.

## Validation

`ruff check` clean · `ruff format --check` clean · `mypy` clean · `pytest` 559 passed (7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)