### PR TITLE
fix(session): anchor .jared/ at absolute root when REPO_ROOT collapses to '.' (#284)

### DIFF
--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -36,7 +36,7 @@ Flow:
 
    ```bash
    GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
-   REPO_ROOT=$(dirname "$GIT_COMMON_DIR")  # handles both main checkout and worktrees
+   REPO_ROOT=$(realpath "$(dirname "$GIT_COMMON_DIR")")
    ```
 
    Walk the active locks and decide the action via the Python lib:

--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -136,7 +136,7 @@ Flow:
    - Clear this session's presence lock. The lock is keyed by the issue this session was started against (`<N>` = the `/jared-start` argument), not by PID — PID-keyed locks were stale-on-arrival because the writing CLI subprocess exits immediately (#259):
      ```bash
      GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
-     REPO_ROOT=$(dirname "$GIT_COMMON_DIR")
+     REPO_ROOT=$(realpath "$(dirname "$GIT_COMMON_DIR")")
      ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared session-lock-clear --repo-root "$REPO_ROOT" --issue <N>
      ```
      Removes `<repo>/.jared/session-<N>.lock` so the next `/jared-start` doesn't see this session as a live sibling. Sibling sessions' locks (other issues) are left untouched.

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -1442,7 +1442,7 @@ def _render_refusal_message(
 
 def _cmd_session_resolve(args: argparse.Namespace) -> int:
     """Walk active locks, resolve the action for the supplied flags, print result."""
-    repo_root = Path(args.repo_root)
+    repo_root = Path(args.repo_root).resolve()
     siblings = session_lock.list_active_locks(repo_root)
     flags = session_lock.Flags(session=args.session, no_worktree=args.no_worktree)
     action = session_lock.resolve_action(siblings=siblings, flags=flags)
@@ -1457,7 +1457,7 @@ def _cmd_session_lock_write(args: argparse.Namespace) -> int:
     """Write a lock file for this PID."""
     import datetime
 
-    repo_root = Path(args.repo_root)
+    repo_root = Path(args.repo_root).resolve()
     started = (
         datetime.datetime.now(datetime.timezone.utc)
         .isoformat(timespec="seconds")
@@ -1476,7 +1476,7 @@ def _cmd_session_lock_write(args: argparse.Namespace) -> int:
 
 def _cmd_session_lock_clear(args: argparse.Namespace) -> int:
     """Clear this issue's lock file."""
-    session_lock.clear_lock(repo_root=Path(args.repo_root), issue=args.issue)
+    session_lock.clear_lock(repo_root=Path(args.repo_root).resolve(), issue=args.issue)
     return 0
 
 

--- a/skills/jared/scripts/lib/session_lock.py
+++ b/skills/jared/scripts/lib/session_lock.py
@@ -39,7 +39,11 @@ class Lock:
 
 
 def _lock_dir(repo_root: Path) -> Path:
-    return repo_root / ".jared"
+    # `.resolve()` anchors `.jared/` at the true (absolute) repo root even when
+    # the caller passes a relative root — e.g. REPO_ROOT collapsing to '.' in the
+    # main checkout (#284). A cwd-relative lock dir breaks cross-session sibling
+    # detection. Every lock path flows through here, so this is the single net.
+    return repo_root.resolve() / ".jared"
 
 
 def _lock_path(repo_root: Path, issue: int) -> Path:

--- a/tests/test_session_lock.py
+++ b/tests/test_session_lock.py
@@ -56,6 +56,28 @@ def test_write_lock_with_solo_session(tmp_path: Path) -> None:
     assert loaded.worktree_path is None
 
 
+def test_write_lock_with_relative_repo_root_anchors_at_true_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #284: in the main checkout REPO_ROOT collapses to a relative
+    '.', so the lock trio receives a relative root. The lock must still land `.jared/`
+    at the true (absolute) repo root — a cwd-relative lock breaks the cross-session
+    sibling detection the whole multi-session discipline rests on.
+    """
+    monkeypatch.chdir(tmp_path)
+    lock = session_lock.Lock(
+        pid=4242,
+        started="2026-05-30T15:00:00Z",
+        session=1,
+        worktree_path=None,
+        issue=284,
+    )
+    # The bug shape: caller passes a relative root (REPO_ROOT='.').
+    path = session_lock.write_lock(repo_root=Path("."), lock=lock)
+    assert path.is_absolute()
+    assert path == tmp_path.resolve() / ".jared" / "session-284.lock"
+
+
 def test_is_alive_returns_true_for_current_process() -> None:
     assert session_lock.is_alive(os.getpid()) is True
 


### PR DESCRIPTION
Closes #284.

## Problem

In the **main checkout**, `git rev-parse --git-common-dir` returns the relative string `.git`, so `REPO_ROOT=$(dirname "$GIT_COMMON_DIR")` collapses to `.`. The session-lock trio then wrote `.jared/` cwd-relative. The moment a second session starts from a different cwd (e.g. inside a worktree), the relative lookup misses the sibling lock and the B-leg refusal never fires — silently defeating cross-session sibling detection. Hit live during a session-2 start.

## Fix

- **Load-bearing:** wrap `REPO_ROOT` in `realpath` in `commands/jared-start.md` and `commands/jared-wrap.md`, and drop the false `# handles both` comment. This is the primary fix — it makes the root absolute **once, while cwd is still the main checkout**, before `/jared-start` shifts cwd into the worktree.
- **Deliberately NOT** `git rev-parse --show-toplevel` — that regresses the worktree case by scattering `.jared/` per-worktree and killing cross-worktree sibling detection (per the issue's explicit guardrail).
- **Safety net:** `.resolve()` in `_lock_dir` (the single chokepoint every lock path flows through) plus the three CLI lock handlers, matching the existing `_cmd_worktree_add` pattern.

## What the test guards (and what it doesn't)

The regression test exercises the `.resolve()` **safety net** with cwd = the true root (the pre-worktree-shift / session-resolve case): a lock written with a relative repo-root anchors `.jared/` at the true absolute root.

It does **not** guard the load-bearing `realpath` prose (markdown isn't executable), nor the post-cwd-shift scenario where `Path(".").resolve()` would resolve to the *worktree* rather than main root — which is exactly why the shell `realpath` is load-bearing and `.resolve()` alone "does not independently fix the main-checkout case." The prose fix is verified by inspection.

## Validation

- `ruff check` ✅ · `ruff format --check` ✅ · `mypy` (strict) ✅ · `pytest` **560 passed**
- CLI smoke against the patched script: a session-1 lock written with `--repo-root .` from one cwd is found from a *different* cwd via the absolute root (`session-resolve --session 1` → `REFUSE_DUP_SESSION_N`, exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)