### PR TITLE
fix(worktree): cut session branches from origin/main with a pre-fetch (#283)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,11 @@ exists so the moment a second session enters the picture, the discipline kicks
 in automatically.
 
 `/jared-wrap` clears the lock at session end. Stale locks (from crashed sessions)
-are caught and cleared by the next `/jared-start`'s PID-liveness check.
+are **not** auto-swept: the recorded PID is the lock-writing CLI subprocess, which
+exits immediately, so PID-liveness can't tell a crashed session from a live one
+(see `lib/session_lock.py` `list_active_locks`). Instead, the next `/jared-start`
+surfaces the orphan in its refusal, and the operator clears it explicitly with
+`jared session-lock-clear --issue N` after confirming the session is actually dead.
 
 For background and the recovery-sequence incident that motivated this mechanism,
 see issue #231 and `docs/superpowers/specs/2026-05-23-multi-session-impl-design.md`.

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -1487,7 +1487,9 @@ def _cmd_worktree_add(args: argparse.Namespace) -> int:
     target = repo_root.parent / f"{repo_basename}-{args.issue}"
     branch = f"feature/{args.issue}-worktree"
     try:
-        created = _worktree.create_worktree(repo=repo_root, target=target, branch=branch, base="main")
+        created = _worktree.create_worktree(
+            repo=repo_root, target=target, branch=branch, base="origin/main", fetch=True
+        )
     except _worktree.WorktreeError as e:
         print(str(e), file=sys.stderr)
         return 1

--- a/skills/jared/scripts/lib/worktree.py
+++ b/skills/jared/scripts/lib/worktree.py
@@ -66,8 +66,16 @@ def list_worktrees(repo: Path) -> list[WorktreeEntry]:
     return entries
 
 
-def create_worktree(repo: Path, target: Path, branch: str, base: str = "main") -> Path:
+def create_worktree(
+    repo: Path, target: Path, branch: str, base: str = "origin/main", fetch: bool = False
+) -> Path:
     """Create a new worktree at `target` checked out on a fresh `branch`.
+
+    `base` defaults to `origin/main` so session branches are cut from the remote
+    tip, not local main — squash-merge leaves local main carrying zombie commits
+    that would otherwise ride into every new session branch (#283). When `fetch`
+    is true, the base's remote is refreshed before the worktree add so the ref is
+    current; callers basing off a remote ref should pass `fetch=True`.
 
     Handles collisions per spec D5:
     - Path is already a registered worktree → return target (resuming).
@@ -85,6 +93,19 @@ def create_worktree(repo: Path, target: Path, branch: str, base: str = "main") -
             f"  remediation: remove the directory (`rm -rf {target}`) and re-run, "
             f"or run `git -C {repo} worktree remove {target}` if it was once registered."
         )
+
+    if fetch:
+        # Refresh the base ref before cutting the branch. Without this, even
+        # base=origin/main is only as current as the last fetch (#283).
+        remote = base.split("/", 1)[0] if "/" in base else None
+        fetch_cmd = ["git", "-C", str(repo), "fetch", *([remote] if remote else [])]
+        fetch_result = subprocess.run(fetch_cmd, capture_output=True, text=True)
+        if fetch_result.returncode != 0:
+            raise WorktreeError(
+                f"git fetch failed before worktree add:\n"
+                f"  command: {' '.join(fetch_cmd)}\n"
+                f"  stderr: {fetch_result.stderr.strip()}"
+            )
 
     cmd = ["git", "-C", str(repo), "worktree", "add", str(target), "-b", branch, base]
     result = subprocess.run(cmd, capture_output=True, text=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 
 import pytest
 
-from tests.conftest import graphql_item_response, import_cli, patch_gh, patch_gh_by_arg
+from tests.conftest import git_cmd, graphql_item_response, import_cli, patch_gh, patch_gh_by_arg
 
 CLI = Path(__file__).parents[1] / "skills" / "jared" / "scripts" / "jared"
 
@@ -249,6 +249,13 @@ def test_session_lock_clear_removes_file(tmp_path: Path) -> None:
 def test_worktree_add_creates_at_sibling_path(
     main_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # worktree-add now fetches origin and bases the new branch on origin/main
+    # (#283), so the repo needs a reachable origin carrying main.
+    origin = main_repo.parent / "origin.git"
+    git_cmd(main_repo, "init", "--bare", str(origin))
+    git_cmd(main_repo, "remote", "add", "origin", str(origin))
+    git_cmd(main_repo, "push", "origin", "main")
+
     mod = import_cli()
     result = mod.main(
         [

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -110,3 +110,43 @@ def test_create_worktree_at_orphan_path_raises(main_repo: Path, tmp_path: Path) 
     msg = str(exc_info.value)
     assert "not a registered worktree" in msg.lower() or "exists" in msg.lower()
     assert str(target) in msg
+
+
+def test_session_branch_cut_from_origin_main_after_fetch(tmp_path: Path) -> None:
+    """Regression for #283: a session branch must be cut from a freshly-fetched
+    origin/main, not stale local main. Squash-merge leaves local main carrying
+    zombie commits; cutting from local main rides them into every new session
+    branch. The fix fetches first, then bases the branch on origin/main.
+    """
+    # An upstream repo plays the role of `origin`.
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    git_cmd(upstream, "init", "-b", "main")
+    git_cmd(upstream, "config", "user.email", "u@example.com")
+    git_cmd(upstream, "config", "user.name", "u")
+    (upstream / "README.md").write_text("initial\n")
+    git_cmd(upstream, "add", "README.md")
+    git_cmd(upstream, "commit", "-m", "initial")
+
+    # Local clone — its origin/main tracking ref starts at 'initial'.
+    local = tmp_path / "local"
+    git_cmd(tmp_path, "clone", str(upstream), str(local))
+    git_cmd(local, "config", "user.email", "l@example.com")
+    git_cmd(local, "config", "user.name", "l")
+
+    # Upstream advances. Local main AND the un-fetched origin/main are now stale.
+    (upstream / "feature.txt").write_text("upstream advance\n")
+    git_cmd(upstream, "add", "feature.txt")
+    git_cmd(upstream, "commit", "-m", "advance origin/main")
+    upstream_tip = git_cmd(upstream, "rev-parse", "main")
+
+    target = tmp_path / "local-283"
+    worktree.create_worktree(
+        repo=local, target=target, branch="feature/283-test", base="origin/main", fetch=True
+    )
+
+    # The branch was cut from the freshly-fetched origin/main tip, not stale local main.
+    branch_tip = git_cmd(local, "rev-parse", "feature/283-test")
+    assert branch_tip == upstream_tip
+    # The upstream-only commit rode in — proves the fetch ran before the worktree add.
+    assert (target / "feature.txt").exists()


### PR DESCRIPTION
Closes #283.

## Problem

Session worktree branches were cut from **local `main`** (`create_worktree(..., base="main")`, no fetch), violating the hard branch-off-origin convention. Squash-merge leaves local `main` carrying zombie commits, which then ride into every new session branch. Jared's own prose already said `origin/main` — the code had drifted from the docs.

## Fix

- `create_worktree` default `base` → `origin/main`, and a new `fetch` parameter runs `git fetch <remote>` **before** `git worktree add` so the base ref is current (a remote-tracking ref is otherwise only as fresh as the last fetch).
- `_cmd_worktree_add` passes `base="origin/main", fetch=True`.
- The fetch runs only on the actual-add path, after the collision checks — resuming an existing worktree doesn't fetch.

## Behavior change

`worktree-add` now **requires an `origin` remote**: with none, `git fetch` fails and surfaces a legible `WorktreeError`. This is intentional — the multi-session convention is branch-off-origin — but it's a real change for any local-only repo where worktree-add previously worked off `main`.

## Caller audit

The only production caller of `create_worktree` is `_cmd_worktree_add` (verified by grep across the tree, including the extensionless `jared` entry point). It passes `base`/`fetch` explicitly, so the default flip changes no caller silently. Existing tests pass `base="main"` explicitly and are unaffected.

## What the test proves

The regression test builds a real **upstream→clone** topology, advances upstream by one commit (making both local `main` and the un-fetched `origin/main` stale), then calls `create_worktree(..., base="origin/main", fetch=True)` and asserts the new branch's tip equals the **freshly-fetched** upstream tip — and that the upstream-only commit rode into the worktree (proving the fetch ran before the add). A stale-local-main cut would fail both assertions. This controls the staleness scenario more precisely than a single live invocation could.

## Validation

- `ruff check` ✅ · `ruff format --check` ✅ · `mypy` (strict) ✅ · `pytest` **572 passed**
- The existing CLI `worktree-add` test gains an `origin` remote, reflecting the new requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)