### PR TITLE
fix(next-session-prompt): --session posture surfaces staged Backlog work (#286)

### DIFF
--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -16,7 +16,7 @@ Flow:
    ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared next-session-prompt --include-session-checks ${SESSION_FLAG:+--session $SESSION_FLAG}
    ```
 
-   When the operator passes `--session N`, the Top of Up Next section is filtered to `session-N`-labeled items. The menu shown for "Which issue would you like to pull?" is the session-N partition; items labeled for other sessions are hidden. If no items are labeled session-N, the section prints `(none labeled session-N)` and the operator must label items via `/jared-stage --sessions N` before pulling.
+   When the operator passes `--session N`, the Top of Up Next section is filtered to `session-N`-labeled items. The menu shown for "Which issue would you like to pull?" is the session-N partition; items labeled for other sessions are hidden. Session-N work that is labeled but still sits in Backlog appears under a distinct `## Session-N staged (not yet in Up Next)` subsection — these are *not* directly pullable; promote them to Up Next via `/jared-stage --sessions N` first. If no items are labeled session-N in **either** Up Next or Backlog, the section prints `(none labeled session-N in Up Next or Backlog)` and the operator must label items via `/jared-stage --sessions N` before pulling.
 
    Capture stdout. The CLI walks the live board and emits structured sections — In flight (with each issue's most recent Session-note one-liner), Top of Up Next, Recently closed (7d), and a `## Quick health check` block iff the board has `## Session start checks` configured. Use this output verbatim as the **posture block** in step 8 (no further parsing or condensing required).
 

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -1035,7 +1035,9 @@ def _now_local_iso() -> str:
 def _fetch_board_items(board: Board) -> list[dict[str, Any]]:
     """Wrapper that delegates to Board.open_items().
 
-    next-session-prompt only filters by status In Progress / Up Next, so
+    next-session-prompt's recommendation reads In Progress / Up Next, and
+    its --session posture additionally scans Backlog for session-N-labeled
+    work staged but not yet promoted (#286). All three are open statuses, so
     the open-only path is what it actually wants. Done-inclusive
     `board_items()` would just bloat GraphQL cost on mature boards (#185).
     Closed items in the handoff come from `_fetch_recently_closed`, which
@@ -1218,10 +1220,20 @@ def _cmd_next_session_prompt(args: argparse.Namespace) -> int:
     in_progress = [i for i in items if i.get("status") == "In Progress"]
     up_next_all = [i for i in items if i.get("status") == "Up Next"]
     session_filter: int | None = getattr(args, "session", None)
+    # Backlog items carrying the session-N label: staged but not yet promoted
+    # to Up Next. propose-partition (#286) labels across all open issues, so
+    # session work can sit in Backlog; surfacing it here keeps the --session
+    # posture from lying with "(none labeled session-N)" while staged work exists.
+    staged_backlog: list[dict[str, Any]] = []
     if session_filter is not None:
         label = f"session-{session_filter}"
         up_next_all = [
             item for item in up_next_all if label in (item.get("labels") or ())
+        ]
+        staged_backlog = [
+            item
+            for item in items
+            if item.get("status") == "Backlog" and label in (item.get("labels") or ())
         ]
     up_next = up_next_all[:3]
     closed = _fetch_recently_closed(board, days=7)
@@ -1259,11 +1271,22 @@ def _cmd_next_session_prompt(args: argparse.Namespace) -> int:
             content = item.get("content") or {}
             prio = item.get("priority") or "-"
             print(f"- #{content.get('number')} [{prio}] {content.get('title', '')}")
+    elif session_filter is not None and staged_backlog:
+        # Nothing in Up Next, but staged work exists in Backlog (shown below).
+        print(f"(none in Up Next — see staged session-{session_filter} below)")
     elif session_filter is not None:
-        print(f"(none labeled session-{session_filter})")
+        print(f"(none labeled session-{session_filter} in Up Next or Backlog)")
     else:
         print("(empty queue)")
     print()
+    if session_filter is not None and staged_backlog:
+        print(f"## Session-{session_filter} staged (not yet in Up Next)")
+        print()
+        for item in staged_backlog:
+            content = item.get("content") or {}
+            prio = item.get("priority") or "-"
+            print(f"- #{content.get('number')} [{prio}] {content.get('title', '')}")
+        print()
     print("## Recently closed (last 7 days)")
     print()
     if closed:

--- a/tests/test_cmd_next_session_prompt.py
+++ b/tests/test_cmd_next_session_prompt.py
@@ -342,8 +342,9 @@ def test_next_session_prompt_session_flag_with_no_matches_renders_empty_marker(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """--session N with zero matching items prints an explicit empty marker
-    instead of falling through to unlabeled items."""
+    """--session N with zero matching items in EITHER Up Next or Backlog
+    prints the combined empty marker instead of falling through to
+    unlabeled items."""
     board_md = write_minimal_board(tmp_path)
     patch_gh_multi(
         monkeypatch,
@@ -359,5 +360,102 @@ def test_next_session_prompt_session_flag_with_no_matches_renders_empty_marker(
     out = capsys.readouterr().out
 
     assert rc == 0
-    assert "(none labeled session-1)" in out
+    assert "(none labeled session-1 in Up Next or Backlog)" in out
     assert "#300" not in out  # no silent fall-through
+
+
+def test_next_session_prompt_session_flag_surfaces_backlog_staged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--session N surfaces session-N-labeled Backlog items under a distinct
+    `## Session-N staged` subsection, kept separate from the Up Next
+    recommendation. Other sessions' Backlog items are excluded (#286)."""
+    board_md = write_minimal_board(tmp_path)
+    # Four session-1 Backlog items — exceeds Up Next's [:3] cap on purpose:
+    # the staged subsection must NOT truncate, since hiding staged work is
+    # the exact bug this issue fixes.
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {"number": 100, "title": "Session-1 up next", "state": "OPEN"},
+            {"number": 400, "title": "Session-1 staged A", "state": "OPEN"},
+            {"number": 401, "title": "Session-1 staged B", "state": "OPEN"},
+            {"number": 402, "title": "Session-1 staged C", "state": "OPEN"},
+            {"number": 403, "title": "Session-1 staged D", "state": "OPEN"},
+            {"number": 500, "title": "Session-2 staged in backlog", "state": "OPEN"},
+        ],
+        statuses={
+            100: ("Up Next", "High"),
+            400: ("Backlog", "Medium"),
+            401: ("Backlog", "Medium"),
+            402: ("Backlog", "Medium"),
+            403: ("Backlog", "Medium"),
+            500: ("Backlog", "Medium"),
+        },
+        labels_by_number={
+            100: ["session-1"],
+            400: ["session-1"],
+            401: ["session-1"],
+            402: ["session-1"],
+            403: ["session-1"],
+            500: ["session-2"],
+        },
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "next-session-prompt", "--session", "1"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    # Up Next recommendation still carries the in-column item
+    assert "#100" in out
+    # Distinct staged subsection surfaces ALL Backlog items — no [:3] cap
+    assert "## Session-1 staged (not yet in Up Next)" in out
+    for n in (400, 401, 402, 403):
+        assert f"#{n}" in out
+    # Other sessions' Backlog work stays hidden
+    assert "#500" not in out
+    # Staged subsection sits between Up Next and Recently closed
+    up_next_at = out.find("## Top of Up Next")
+    staged_at = out.find("## Session-1 staged")
+    closed_at = out.find("## Recently closed")
+    assert up_next_at < staged_at < closed_at
+
+
+def test_next_session_prompt_session_flag_backlog_only_no_false_empty_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When Up Next has no session-N items but Backlog does, the combined
+    empty marker must NOT fire — the staged Backlog work is real (#286)."""
+    board_md = write_minimal_board(tmp_path)
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=[
+            {"number": 300, "title": "Unlabeled up next", "state": "OPEN"},
+            {"number": 400, "title": "Session-1 staged in backlog", "state": "OPEN"},
+        ],
+        statuses={
+            300: ("Up Next", "High"),
+            400: ("Backlog", "Medium"),
+        },
+        labels_by_number={
+            300: [],
+            400: ["session-1"],
+        },
+    )
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "next-session-prompt", "--session", "1"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "## Session-1 staged (not yet in Up Next)" in out
+    assert "#400" in out
+    # The lying combined marker must not appear when Backlog has staged work
+    assert "(none labeled session-1 in Up Next or Backlog)" not in out
+    # Unlabeled Up Next item still excluded — no silent fall-through
+    assert "#300" not in out


### PR DESCRIPTION
## What

`next-session-prompt --session N` only scanned the Up Next column, so session-N work staged into Backlog was invisible — the empty marker printed `(none labeled session-N)` while staged issues existed (the original report saw 18 session-2 Backlog items hidden this way, forcing a manual `gh issue list --label session-2` fallback).

## Changes

- **Backlog scan.** `_cmd_next_session_prompt` now scans Backlog for `session-N`-labeled items, surfaced under a distinct `## Session-N staged (not yet in Up Next)` subsection — kept separate from the Up Next recommendation, and uncapped (the whole point is to stop posture from hiding staged work).
- **Honest empty marker.** Now reads `(none labeled session-N in Up Next or Backlog)` and fires only when *both* columns are genuinely empty. When Up Next is empty but Backlog has staged work, an intermediate pointer (`(none in Up Next — see staged session-N below)`) leads to the staged subsection instead of lying.
- **Tests.** Two new tests + one updated in `tests/test_cmd_next_session_prompt.py` (first Backlog fixtures in this file). The staged-surfacing test uses 4 Backlog items on purpose, pinning the no-`[:3]`-cap behavior so a future cap-copy can't silently recreate the bug class.
- **Doc reconciliation.** Updated the `_fetch_board_items` docstring (status-scope) and `commands/jared-start.md`, including a note that staged Backlog items need `/jared-stage` promotion before they're pullable. Left `jared-cli.md` / `SKILL.md` untouched per the issue body.

## Validation

- `pytest` 574 passed, `ruff check` clean, `ruff format --check` clean, `mypy --strict` clean.
- Live smoke against the jared board: `--session 1` correctly shows session-1 Up Next items; `--session 2` correctly renders the combined empty marker. Section ordering contract preserved.

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)