### PR TITLE
feat(worktree): derive branch slug from issue title (#278)

### DIFF
--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -55,13 +55,15 @@ Flow:
    **On PROCEED_MULTI:** create the worktree before continuing:
 
    ```bash
+   TITLE=$(gh issue view <N> --json title -q .title)
    ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared worktree-add \
      --repo-root "$REPO_ROOT" \
      --issue <N> \
-     --session "$SESSION_FLAG"
+     --session "$SESSION_FLAG" \
+     --title "$TITLE"
    ```
 
-   This calls `lib.worktree.create_worktree` to make `~/Code/<repo>-<N>/` (path shape per spec D1), checks out a fresh `feature/<N>-<slug>` branch from `origin/main`, and emits the target path on stdout. CWD shifts to the worktree for the remainder of the session.
+   This calls `lib.worktree.create_worktree` to make `~/Code/<repo>-<N>/` (path shape per spec D1), checks out a fresh `feature/<N>-<slug>` branch from `origin/main`, and emits the target path on stdout. CWD shifts to the worktree for the remainder of the session. Passing `--title` lets `worktree-add` slugify the branch name without a second `gh` round-trip; if omitted (e.g. manual invocation), the CLI fetches the title itself and falls back to `feature/<N>-worktree` when none can be derived.
 
    **In all PROCEED cases:** write the session lock:
 

--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -33,6 +33,7 @@ from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     pre_flight_check,
     print_redaction_diff,
     resolve_body,
+    run_gh,
 )
 from lib import session_lock  # type: ignore[import-not-found]  # noqa: E402
 from lib import worktree as _worktree  # type: ignore[import-not-found]  # noqa: E402
@@ -384,12 +385,22 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     wa.add_argument("--repo-root", required=True, help="Path to the main checkout.")
-    wa.add_argument("--issue", type=int, required=True, help="Issue number — used to name the worktree.")
+    wa.add_argument(
+        "--issue", type=int, required=True, help="Issue number — used to name the worktree."
+    )
     wa.add_argument(
         "--session",
         type=int,
         default=None,
         help="Session index (accepted for forward-compat; currently unused).",
+    )
+    wa.add_argument(
+        "--title",
+        default=None,
+        help=(
+            "Issue title to slugify into the branch name, skipping the gh fetch. "
+            "jared-start threads this through from the title it already has."
+        ),
     )
     wa.set_defaults(func=_cmd_worktree_add)
 
@@ -550,9 +561,7 @@ def _cmd_file(args: argparse.Namespace) -> int:
     if not args.no_milestone:
         # Query params on the URL — `gh api -f key=value` is a request body
         # field, and on /milestones a body flips GET-list into POST-create.
-        milestones = board.run_gh(
-            ["api", f"repos/{board.repo}/milestones?state=open&per_page=100"]
-        )
+        milestones = board.run_gh(["api", f"repos/{board.repo}/milestones?state=open&per_page=100"])
         # Defensive: REST returns a list; an empty/missing payload is treated
         # as "no open milestones" rather than crashing on attribute access.
         open_titles = [
@@ -964,9 +973,7 @@ def _cmd_summary(args: argparse.Namespace) -> int:
 
     workstreams = _count_workstreams(in_progress)
     if workstreams < len(in_progress):
-        in_progress_header = (
-            f"In Progress ({workstreams} workstreams · {len(in_progress)} items):"
-        )
+        in_progress_header = f"In Progress ({workstreams} workstreams · {len(in_progress)} items):"
     else:
         in_progress_header = f"In Progress ({len(in_progress)}):"
 
@@ -1220,9 +1227,7 @@ def _cmd_next_session_prompt(args: argparse.Namespace) -> int:
     session_filter: int | None = getattr(args, "session", None)
     if session_filter is not None:
         label = f"session-{session_filter}"
-        up_next_all = [
-            item for item in up_next_all if label in (item.get("labels") or ())
-        ]
+        up_next_all = [item for item in up_next_all if label in (item.get("labels") or ())]
     up_next = up_next_all[:3]
     closed = _fetch_recently_closed(board, days=7)
 
@@ -1424,9 +1429,7 @@ def _render_refusal_message(
         # logic in resolve_action), render that solo sibling rather than the
         # arbitrary first entry — the operator needs to see the actual trap shape.
         sib = next((s for s in siblings if s.session is None), siblings[0])
-        mode = (
-            f"session-{sib.session}" if sib.session is not None else "solo (on shared .git/HEAD)"
-        )
+        mode = f"session-{sib.session}" if sib.session is not None else "solo (on shared .git/HEAD)"
         print(
             f"ERROR: another active jared session detected.\n"
             f"  Sibling: PID {sib.pid}, started {sib.started}, issue #{sib.issue}\n"
@@ -1480,12 +1483,40 @@ def _cmd_session_lock_clear(args: argparse.Namespace) -> int:
     return 0
 
 
+def _slugify(title: str, max_len: int = 50) -> str:
+    """Lowercase, hyphenate, and trim a title into a git-branch-safe slug.
+
+    Collapses any run of non-alphanumerics to a single hyphen, strips leading
+    and trailing hyphens, and truncates at `max_len` without leaving a dangling
+    hyphen. Returns "" for an empty or punctuation-only title, which callers
+    treat as "no slug" and fall back to.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    if len(slug) > max_len:
+        slug = slug[:max_len].rstrip("-")
+    return slug
+
+
+def _resolve_worktree_slug(args: argparse.Namespace) -> str:
+    """Pick the branch slug: an explicit --title (threaded by jared-start),
+    else the fetched issue title; fall back to "worktree" when neither yields
+    a usable slug."""
+    if args.title:
+        return _slugify(args.title) or "worktree"
+    try:
+        data = run_gh(["issue", "view", str(args.issue), "--json", "title"])
+        slug = _slugify((data or {}).get("title") or "")
+    except (GhInvocationError, OSError):
+        slug = ""
+    return slug or "worktree"
+
+
 def _cmd_worktree_add(args: argparse.Namespace) -> int:
     """Create a worktree at <parent-of-repo>/<repo-basename>-<issue>/ on a fresh branch."""
     repo_root = Path(args.repo_root).resolve()
     repo_basename = repo_root.name
     target = repo_root.parent / f"{repo_basename}-{args.issue}"
-    branch = f"feature/{args.issue}-worktree"
+    branch = f"feature/{args.issue}-{_resolve_worktree_slug(args)}"
     try:
         created = _worktree.create_worktree(
             repo=repo_root, target=target, branch=branch, base="origin/main", fetch=True
@@ -1645,9 +1676,7 @@ def _cmd_propose_partition(args: argparse.Namespace) -> int:
     )
     print()
     for n in range(1, K + 1):
-        session_assignments = [
-            a for a in proposal.keep + proposal.add if a.session == n
-        ]
+        session_assignments = [a for a in proposal.keep + proposal.add if a.session == n]
         print(f"session-{n} (proposing {len(session_assignments)} items):")
         for a in session_assignments:
             verb = "keep" if a in proposal.keep else "add"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,14 @@ from textwrap import dedent
 
 import pytest
 
-from tests.conftest import git_cmd, graphql_item_response, import_cli, patch_gh, patch_gh_by_arg
+from tests.conftest import (
+    FakeGhResult,
+    git_cmd,
+    graphql_item_response,
+    import_cli,
+    patch_gh,
+    patch_gh_by_arg,
+)
 
 CLI = Path(__file__).parents[1] / "skills" / "jared" / "scripts" / "jared"
 
@@ -246,15 +253,45 @@ def test_session_lock_clear_removes_file(tmp_path: Path) -> None:
     assert not lock_path.exists()
 
 
-def test_worktree_add_creates_at_sibling_path(
-    main_repo: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # worktree-add now fetches origin and bases the new branch on origin/main
+def _add_origin(main_repo: Path) -> None:
+    # worktree-add fetches origin and bases the new branch on origin/main
     # (#283), so the repo needs a reachable origin carrying main.
     origin = main_repo.parent / "origin.git"
     git_cmd(main_repo, "init", "--bare", str(origin))
     git_cmd(main_repo, "remote", "add", "origin", str(origin))
     git_cmd(main_repo, "push", "origin", "main")
+
+
+def _patch_gh_title(
+    monkeypatch: pytest.MonkeyPatch, *, title: str = "", fail: bool = False
+) -> None:
+    """Fake only `gh issue view` (the worktree-add title fetch); delegate every
+    other subprocess call to the real `subprocess.run`.
+
+    The standard `patch_gh*` helpers replace `subprocess.run` wholesale, which
+    would also break the real `git fetch`/`git worktree add` this command needs
+    on disk. worktree-add is the one command that must run real git but fake gh.
+    """
+    real_run = subprocess.run
+
+    def fake_run(args: list[str], **kw: object) -> object:
+        if "issue" in args and "view" in args:
+            if fail:
+                return FakeGhResult(stdout="", returncode=1, stderr="HTTP 404")
+            return FakeGhResult(stdout=f'{{"title": "{title}"}}')
+        return real_run(args, **kw)  # type: ignore[call-overload]
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+
+def test_worktree_add_creates_at_sibling_path(
+    main_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _add_origin(main_repo)
+    # Empty title from gh → branch falls back to -worktree.
+    _patch_gh_title(monkeypatch, title="")
 
     mod = import_cli()
     result = mod.main(
@@ -271,6 +308,75 @@ def test_worktree_add_creates_at_sibling_path(
     expected_target = main_repo.parent / f"{main_repo.name}-231"
     assert str(expected_target) in captured.out
     assert expected_target.exists()
+    assert git_cmd(expected_target, "rev-parse", "--abbrev-ref", "HEAD") == "feature/231-worktree"
+
+
+def test_worktree_add_derives_branch_slug_from_issue_title(
+    main_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _add_origin(main_repo)
+    _patch_gh_title(monkeypatch, title="Derive slug from issue title")
+
+    mod = import_cli()
+    result = mod.main(["worktree-add", "--repo-root", str(main_repo), "--issue", "278"])
+    assert result == 0
+    target = main_repo.parent / f"{main_repo.name}-278"
+    branch = git_cmd(target, "rev-parse", "--abbrev-ref", "HEAD")
+    assert branch == "feature/278-derive-slug-from-issue-title"
+
+
+def test_worktree_add_title_flag_is_slugified(
+    main_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _add_origin(main_repo)
+    _patch_gh_title(monkeypatch, title="Should Not Be Used")
+
+    mod = import_cli()
+    result = mod.main(
+        [
+            "worktree-add",
+            "--repo-root",
+            str(main_repo),
+            "--issue",
+            "278",
+            "--title",
+            "Fix the Thing!",
+        ]
+    )
+    assert result == 0
+    target = main_repo.parent / f"{main_repo.name}-278"
+    branch = git_cmd(target, "rev-parse", "--abbrev-ref", "HEAD")
+    assert branch == "feature/278-fix-the-thing"
+
+
+def test_worktree_add_falls_back_to_worktree_when_title_unavailable(
+    main_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _add_origin(main_repo)
+    # gh errors → fetch raises → branch falls back to -worktree, not a crash.
+    _patch_gh_title(monkeypatch, fail=True)
+
+    mod = import_cli()
+    result = mod.main(["worktree-add", "--repo-root", str(main_repo), "--issue", "278"])
+    assert result == 0
+    target = main_repo.parent / f"{main_repo.name}-278"
+    branch = git_cmd(target, "rev-parse", "--abbrev-ref", "HEAD")
+    assert branch == "feature/278-worktree"
+
+
+def test_slugify_normalizes_and_truncates() -> None:
+    mod = import_cli()
+    assert mod._slugify("Derive slug from issue title") == "derive-slug-from-issue-title"
+    assert mod._slugify("Fix the Thing!") == "fix-the-thing"
+    assert mod._slugify("  Leading/trailing -- punctuation.  ") == "leading-trailing-punctuation"
+    assert mod._slugify("") == ""
+    # Truncates at the length cap without a trailing hyphen.
+    long = mod._slugify("a" * 30 + " " + "b" * 30, max_len=40)
+    assert len(long) <= 40
+    assert not long.endswith("-")
 
 
 def test_session_resolve_refuse_bleg_renders_solo_sibling_mode(


### PR DESCRIPTION
Closes #278.

## What

`jared worktree-add` hardcoded the branch as `feature/<issue>-worktree`, so every parallel-session branch read `feature/901-worktree`, `feature/278-worktree`, … — indistinguishable at a glance in `git branch` / PR lists. It now derives a human-readable slug from the issue title: `feature/<issue>-<slug>`.

## How

- **`_slugify`** — lowercase, hyphenate non-alphanumeric runs, strip/trim to a branch-safe slug (truncates at a length cap without a dangling hyphen).
- **`_resolve_worktree_slug`** — uses an explicit `--title` when given, else self-fetches via `gh issue view <N> --json title`; falls back to `feature/<issue>-worktree` when neither yields a usable slug.
- **jared-start threads `--title`** through from the title it already has, so the multi-session hot path needs no extra `gh` round-trip and doesn't depend on `gh` resolving the repo from process cwd. Self-fetch is the fallback for manual invocation.

A single override flag (`--title`) is wired to a real caller (jared-start), per the #114 "tested ≠ consumed" discipline — no second uncalled flag.

## Acceptance criteria

- [x] `worktree-add` fetches the issue title and slugifies it
- [x] Branch is `feature/<issue>-<slug>`; falls back to `feature/<issue>-worktree` when the title can't be fetched
- [x] `--title` override skips the network round-trip — and has a real consumer (jared-start)
- [x] jared-start step 1b threads the title through

## Validation

- 576 unit tests pass (offline). worktree-add tests use a routing fake that runs **real git** while faking only the **gh** title fetch — worktree-add is the one command needing both, so the standard wholesale `subprocess.run` patch won't do.
- `ruff check .`, `ruff format --check .`, `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)