### PR TITLE
docs(wrap): integrate main before the PR + name the two conflict classes

### DIFF
--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -83,6 +83,17 @@ Flow:
 
    When the guard fires, the lock-clear still runs (the session may have written one) and the worktree-removal bullet is a no-op (worktrees are never created against `main`).
 
+   **Integrate `main` before the PR.** Parallel sessions diverge from `main` while they work. Before pushing or opening the PR, fold the current `main` into the branch and resolve *here* — in the session that has full context — rather than discovering it at merge time:
+
+   ```bash
+   git fetch origin && git merge --no-edit origin/main
+   ```
+
+   - **Clean merge:** re-run the formatter and tests (`ruff format . && ruff check . && pytest`), then enter the loop. Formatting *on top of* `main` is the point — it collapses spurious whitespace/format conflicts (a line you never logically touched, reformatted differently on each branch) before they can reach the PR.
+   - **Conflict:** resolve in place, re-run format + tests, and `git commit` the merge. Genuine logic collisions (two sessions editing the same function) surface here, in-session, instead of as a terse "unmergeable" after the PR already exists.
+
+   Merge, not rebase — the branch may already be pushed, and a merge avoids the force-push a rebase would require. See `references/parallel-sessions.md` § "Integrate `main` before the PR" for the rationale and the two conflict classes this addresses.
+
    Loop:
 
    ```bash
@@ -109,7 +120,7 @@ Flow:
 
    - **`surface_failure`** (PR exists, checks failed): Print the failed check names from `gh pr checks $PR --json`. Exit the loop. Lock-clear runs.
 
-   - **`surface_conflict`** (checks green but not mergeable): Print *"PR #N: conflict with main. Rebase in this worktree (`git fetch && git rebase origin/main`), resolve, push, and re-run `/jared-wrap`."* Exit the loop. Lock-clear runs.
+   - **`surface_conflict`** (checks green but not mergeable): Print *"PR #N: conflict with main. Integrate in this worktree (`git fetch && git merge origin/main`), resolve, push, and re-run `/jared-wrap`."* Exit the loop. Lock-clear runs. (This is the fallback when the integrate-before-PR step above was skipped or `main` advanced after it ran — merge, not rebase, since the branch is already pushed.)
 
    - **`confirm_merge`** (checks green, mergeable): Render the confirm-merge block:
 

--- a/skills/jared/references/parallel-sessions.md
+++ b/skills/jared/references/parallel-sessions.md
@@ -101,13 +101,57 @@ inside the new worktree before running tests.
 
 ## The wrap back-end
 
-`/jared-wrap` runs the full commit → push → PR create → mergeable check → confirm merge → cleanup sequence after Session notes are posted. The operator confirms only the merge (the irreversible step against protected `main`).
+`/jared-wrap` runs the full commit → integrate `main` → push → PR create → mergeable check → confirm merge → cleanup sequence after Session notes are posted. The operator confirms only the merge (the irreversible step against protected `main`).
 
 Idempotency: each step inspects current state via `jared wrap-state`. Re-running `/jared-wrap` after a failure or interruption picks up at the current state — no in-flight lock, no manual recovery sequencing. The state IS the lock.
 
 Concurrent merge safety: two sessions reaching the merge step around the same time both re-check `mergeable` immediately before calling `gh pr merge`. GitHub's PR-merge API is atomic; the second call rejects with a not-mergeable error if the first's merge created a conflict. No Jared-side serialization is needed.
 
 The back-end flow does not auto-commit. If the working tree is dirty at wrap time, wrap pauses and asks for a commit message — your commit discipline (phase-numbered prefixes, "why not what" bodies) is preserved.
+
+## Integrate `main` before the PR
+
+Parallel sessions branch from the same `origin/main` and then diverge. By
+the time the second session wraps, `main` has usually moved — the first
+session's work landed. The wrap back-end therefore folds `main` into the
+branch (`git fetch && git merge --no-edit origin/main`) *before* pushing or
+opening the PR, not after GitHub reports the PR unmergeable.
+
+Two distinct conflict classes motivate this, and integrating early addresses
+both:
+
+- **Spurious (formatting/whitespace).** A whole-file `ruff format` run
+  reformats lines *outside* your diff — a comprehension collapsed to one
+  line, an import reordered. If the other branch reformatted the same line
+  in a different surrounding context, the two diverge and git flags a
+  conflict on code neither session logically touched. Integrating `main`
+  *before* you format means you format on top of `main`'s canonical form and
+  produce the identical output — the divergence never arises. This is the
+  common, two-minute-to-resolve class, and integrating early eliminates it
+  rather than just relocating it.
+- **Genuine (same logic).** Two sessions edited the same function, the same
+  argparse block, the shared import list, or the same `lib/board.py` helper.
+  Git genuinely can't reconcile them. Integrating early doesn't *prevent*
+  this, but it surfaces it in the session that still holds the context to
+  resolve it well — far better than a terse "unmergeable" discovered at
+  merge time, after the PR exists and the reasoning has gone cold.
+
+**Merge, not rebase.** The branch may already be pushed (wrap is
+idempotent and re-runnable), so a rebase would force a force-push and risk
+the other session's view of a shared branch. A merge commit is safe and
+consistent with the concurrent-merge-safety model above.
+
+### Reducing the genuine class is a structural problem, not a wrap problem
+
+Integrating early surfaces genuine conflicts earlier; it can't stop two
+sessions from colliding in a hot file. The dominant driver is the
+`skills/jared/scripts/jared` CLI monolith (and, secondarily, `lib/board.py`):
+nearly every feature edits it, so two unrelated issues routinely both touch
+it. The remedy is **opportunistic extraction**, not a refactor project: when
+a session substantially edits one region (a subcommand's `_cmd_*` handler and
+its argparse block), lift *that* region into a focused module as part of that
+issue's work. The monolith shrinks where it's hottest, with no dedicated
+big-bang split — which would itself be the kind of sprawl this project avoids.
 
 ## Triggers for the worktree default
 


### PR DESCRIPTION
## Why

Parallel sessions kept producing merge conflicts. Investigating the conflict from PR #293 (this session) showed it was **spurious** — `ruff format` reformatted a line `#278` never logically touched, which diverged from #292's reformat of the same line. The wrap back-end only handled conflicts *reactively*, after GitHub reported the PR unmergeable — i.e. after the format divergence was already baked in.

## What

**`commands/jared-wrap.md`** — adds an **"Integrate `main` before the PR"** step to the back-end flow, before `push`/`create_pr`:
- `git fetch origin && git merge --no-edit origin/main` → re-run format + tests → resolve in-session → then push + PR.
- Clean merge: you format *on top of* main's canonical form, so spurious format-churn conflicts can't arise.
- Conflict: genuine logic collisions surface in the session that still holds the context.
- Aligns the `surface_conflict` fallback text from **rebase → merge** (the branch may already be pushed; merge avoids a force-push).

**`references/parallel-sessions.md`** — documents the rationale and names the **two conflict classes** (spurious format-churn vs. genuine same-logic), plus a note that the genuine class is a *structural* problem driven by the 1739-line `jared` monolith — addressed by **opportunistic extraction** as you touch hot regions, not a big-bang refactor.

## Scope

Doctrine-only (two `.md` files). No code, no new wrap-state. Per the repo's "Evolving Jared's discipline" rule, doctrine lands as doc edits rather than a spec → plan cycle.

## Validation

- 578 tests pass; this PR was itself wrapped with the new integrate-before-PR step (no-op this time — `main` hadn't moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)