### PR TITLE
docs(jared): fix drifted worktree prose (cwd, milestone example, wrap branch-name) (#287)

### DIFF
--- a/commands/jared-file.md
+++ b/commands/jared-file.md
@@ -45,11 +45,14 @@ Flow:
      --body-file <path or ->          # OR --body "<inline text>" \
      --priority <High|Medium|Low> \
      --status "<status column>" \
+     --no-milestone \                 # OR --milestone "<title>" — exactly one is mandatory (#238)
      --label <label> \
      --field "<Field Name>=<Option Name>"
    ```
 
-   `--status` defaults to `Backlog`. `--label` and `--field` are repeatable.
+   `--status` defaults to `Backlog`. Exactly one of `--milestone "<title>"`
+   or `--no-milestone` is mandatory — `jared file` exits 2 without one (#238).
+   `--label` and `--field` are repeatable.
    The CLI creates the issue, adds it to the project board, sets Priority
    + Status + every `--field`, and verifies the post-state before printing
    `OK: filed #N → <status>, Priority=<prio>`. Any failing step exits

--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -63,7 +63,7 @@ Flow:
      --title "$TITLE"
    ```
 
-   This calls `lib.worktree.create_worktree` to make `~/Code/<repo>-<N>/` (path shape per spec D1), checks out a fresh `feature/<N>-<slug>` branch from `origin/main`, and emits the target path on stdout. CWD shifts to the worktree for the remainder of the session. Passing `--title` lets `worktree-add` slugify the branch name without a second `gh` round-trip; if omitted (e.g. manual invocation), the CLI fetches the title itself and falls back to `feature/<N>-worktree` when none can be derived.
+   This calls `lib.worktree.create_worktree` to make `~/Code/<repo>-<N>/` (path shape per spec D1), checks out a fresh `feature/<N>-<slug>` branch from `origin/main`, and emits the target path on stdout. **CWD does not shift to the worktree** — the harness resets the shell's working directory to the repo root on every Bash call, and `worktree-add` is a Python subprocess that cannot move the parent shell's cwd anyway. Capture the emitted path and prefix every subsequent git/gh op with `git -C <abs-worktree-path>` (or pass an absolute path); do not rely on a persistent `cd`, and do not reach for a `WORKTREE` env var either — env vars don't survive across Bash calls. Passing `--title` lets `worktree-add` slugify the branch name without a second `gh` round-trip; if omitted (e.g. manual invocation), the CLI fetches the title itself and falls back to `feature/<N>-worktree` when none can be derived.
 
    **In all PROCEED cases:** write the session lock:
 

--- a/commands/jared-wrap.md
+++ b/commands/jared-wrap.md
@@ -161,10 +161,11 @@ Flow:
      ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/jared session-lock-clear --repo-root "$REPO_ROOT" --issue <N>
      ```
      Removes `<repo>/.jared/session-<N>.lock` so the next `/jared-start` doesn't see this session as a live sibling. Sibling sessions' locks (other issues) are left untouched.
-   - **Worktree removal (multi-session only).** When this session worked from a worktree (created by `/jared-start <N> --session N` — non-null `worktree_path` on the lock) AND the corresponding `feature/<N>-worktree` branch has merged into main, remove the worktree and delete the branch from the main checkout:
+   - **Worktree removal (multi-session only).** When this session worked from a worktree (created by `/jared-start <N> --session N` — non-null `worktree_path` on the lock) AND the session's `feature/<N>-<slug>` branch has merged into main, remove the worktree and delete the branch from the main checkout. Read the branch name from the worktree first — it's slugified from the issue title (#278), not a fixed string, so don't reconstruct it by hand:
      ```bash
+     BRANCH=$(git -C "<worktree-path>" rev-parse --abbrev-ref HEAD)
      git -C "$REPO_ROOT" worktree remove "<worktree-path>"
-     git -C "$REPO_ROOT" branch -d feature/<N>-worktree
+     git -C "$REPO_ROOT" branch -d "$BRANCH"
      ```
      The cleanup is **scoped to this session's issue**, not lockdir-wide — sibling worktrees from other parallel sessions are not touched. Skip the bullet entirely for solo sessions (worktree_path is null) and for sessions whose branch hasn't merged yet (the operator decides whether to keep the unmerged worktree around). The rule comes from operator feedback after the 2026-05-24 wrap of #227's session-1 left an orphan `~/Code/jared-227/` on disk — see the `[[feedback-wrap-remove-merged-worktree]]` user-memory note for the original framing.
 

--- a/skills/jared/references/parallel-sessions.md
+++ b/skills/jared/references/parallel-sessions.md
@@ -85,7 +85,10 @@ branch, and a commit from either side risks stealing the other's WIP.
 ```bash
 git fetch origin
 git worktree add ~/Code/<repo>-<issue> -b feature/<issue>-<slug> origin/main
-cd ~/Code/<repo>-<issue>
+# Don't rely on `cd` — the harness resets cwd to the repo root between Bash
+# calls (and env vars don't persist either). Prefix every op with the
+# absolute worktree path instead:
+git -C ~/Code/<repo>-<issue> status
 ```
 
 Each session gets its own working directory with its own HEAD while sharing


### PR DESCRIPTION
Closes #287.

## What's changed

Four documentation drifts in the multi-session worktree path, all surfaced at session time. CLI contracts are unchanged — markdown only.

**Doctrine**
- **`jared-start.md`** — dropped the "CWD shifts to the worktree for the remainder of the session" claim. Verified empirically this session: the harness resets the shell's cwd to the repo root on every Bash call (`cd /tmp` in one call, `pwd` in the next returns the repo root), and `worktree-add` is a Python subprocess that cannot move the parent shell's cwd anyway. Now mandates `git -C <abs-worktree-path>` per op, with an explicit "no `WORKTREE` env-var alternative" note (env vars don't persist across calls either).
- **`parallel-sessions.md`** — replaced the bare `cd ~/Code/<repo>-<issue>` in the correct-pattern block with `git -C <abs-path>` for the same reason.
- **`jared-file.md`** — the `jared file` example omitted the required milestone flag, so a copy-paste failed exit 2. Added `--no-milestone` (plus a commented `--milestone "<title>"` variant) and a "exactly one is mandatory (#238)" note. `jared file` enforces this at `scripts/jared:572`.

**Bug fix**
- **`jared-wrap.md`** — the wrap-time worktree cleanup hardcoded `git branch -d feature/<N>-worktree`. Once #278 began slugifying branch names from the issue title (`feature/<N>-<slug>`), that delete silently failed to match. Now reads the branch dynamically (`git -C <worktree> rev-parse --abbrev-ref HEAD`) before removing the worktree. This is the genuine instance of the branch-name drift the issue's original criterion #2 was groping toward — #287 pointed at jared-start.md / parallel-sessions.md, but those were already correct post-#278; jared-wrap.md was the actual broken site.

## Scope note

#287's original criterion #2 (rewrite `feature/<N>-<slug>` → `feature/<N>-worktree` in jared-start.md / parallel-sessions.md) was **dropped** during `/jared-start`: #278 (merged 2026-05-31) changed the code to derive the slug from the title, so the existing `feature/<N>-<slug>` prose is now correct — implementing the original #2 would have re-broken the docs. Issue body reshaped to reflect this.

## Validation

- `ruff check .` clean
- `pytest` — 586 passed, 1 deselected (doc-only change; no Python touched, no test asserts on the changed prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)