### PR TITLE
release: v0.27.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "author": {
     "name": "Daniel Brock"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format: each entry starts with `## v<x.y.z> — YYYY-MM-DD`, followed by terse b
 
 Convention is documented in [CLAUDE.md](CLAUDE.md) § Versioning. Pre-`v0.2.0` history is omitted — `v0.2.0` is the level-up release that established the current Jared shape.
 
+## v0.27.1 — 2026-06-01
+
+**Bug fixes**
+- `/jared-stage`'s `is_pullable` no longer gates readiness on the `<details>` display wrapper — an issue with substantive `## Acceptance criteria` bullets is pullable whether or not the bullets sit inside the fold, so well-specified issues filed without the wrapper are no longer wrongly deferred as "non-canonical". (#307)
+- `/jared-stage`'s Blocked-revisit check keys on the populated `Status` field rather than `content.state` (which `gh project item-list` never populates), so a resolved blocker is detected by its Done-column placement. (#298)
+
 ## v0.27.0 — 2026-05-31
 
 **Features**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.27.0"
+version = "0.27.1"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Patch release covering the two `/jared-stage` bug fixes merged since v0.27.0.

**Bug fixes**
- `is_pullable` no longer gates readiness on the `<details>` display wrapper — well-specified issues filed without the fold are no longer wrongly deferred. (#307)
- Blocked-revisit keys on the populated `Status` field, not `content.state`. (#298)

Bumps `.claude-plugin/plugin.json` + `pyproject.toml` to 0.27.1 and adds the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)