### PR TITLE
release: v0.28.0 — BoardProvider abstraction + milestone doctrine

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: each entry starts with `## v<x.y.z> — YYYY-MM-DD`, followed by terse b
 
 Convention is documented in [CLAUDE.md](CLAUDE.md) § Versioning. Pre-`v0.2.0` history is omitted — `v0.2.0` is the level-up release that established the current Jared shape.
 
+## v0.28.0 — 2026-06-02
+
+**Refactor**
+- Board operations now route through a backend-neutral `BoardProvider` contract (`lib/board_provider.py`) — semantic methods speaking stable integer issue refs and neutral dataclasses (`BoardItem`, `Comment`, `Edge`, `Milestone`), with all `gh`/GraphQL/field-id/option-id detail sealed inside the sole implementation, `GitHubProjectsProvider` (`lib/github_provider.py`). `Board` becomes a thin config-parsing facade exposing `board.provider`, and the `jared` CLI subcommands route through it instead of raw `gh`. Behavior-preserving groundwork for the KanbanFlow back-end (epic #313, Phase 1 of 6). (#320)
+
+**Doctrine**
+- Codified the lightweight, theme-based milestone convention in `docs/project-board.md` — theme names over version numbers, one phase-milestone open at a time, a one-sentence deliverable required, dates optional. (#311)
+- Corrected the milestone Roadmap-view guidance: a dateless board surfaces its active phase via a Milestone-grouped Table/Board view, since GitHub's date-driven Roadmap layout renders an empty timeline against intentionally dateless milestones. (#312)
+
 ## v0.27.1 — 2026-06-01
 
 **Bug fixes**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.27.1"
+version = "0.28.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Release v0.28.0

Cuts the release for the work merged to `main` since v0.27.1 (3 PRs / 25 commits, no open PRs to wait on). Behavior-preserving — the headline is an internal architecture seam, not a user-facing change.

### What's in this release

**Refactor**
- Board operations now route through a backend-neutral `BoardProvider` contract (`lib/board_provider.py`) — semantic methods speaking stable integer issue refs and neutral dataclasses (`BoardItem`, `Comment`, `Edge`, `Milestone`), with all `gh`/GraphQL/field-id/option-id detail sealed inside the sole implementation, `GitHubProjectsProvider` (`lib/github_provider.py`). `Board` becomes a thin config-parsing facade exposing `board.provider`, and the `jared` CLI subcommands route through it instead of raw `gh`. Groundwork for the KanbanFlow back-end (epic #313, Phase 1 of 6). (#320)

**Doctrine**
- Codified the lightweight, theme-based milestone convention in `docs/project-board.md`. (#311)
- Corrected the milestone Roadmap-view guidance for dateless boards. (#312)

### This PR's diff

Version + CHANGELOG only — `.claude-plugin/plugin.json` and `pyproject.toml` bumped `0.27.1 → 0.28.0`, plus the `## v0.28.0` CHANGELOG entry. No source changes.

### Validation

- `pytest`: 639 passed, 1 deselected (integration).
- `ruff check .`: clean. `mypy`: clean (63 source files).
- `ruff format --check .` flags `tests/test_stage.py` — **pre-existing drift on `main`**, unrelated to this PR (commit 5f8494f documents it and narrowed the per-task format gate to touched files). Left untouched; reformatting it here would be out of scope.

### Post-merge steps (not part of this PR)

After `--merge`:
1. `git tag v0.28.0 && git push origin v0.28.0`
2. `gh release create v0.28.0 --title "v0.28.0 — BoardProvider abstraction + milestone doctrine" --notes "<release notes>"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
