### PR TITLE
fix(jared): #321 Phase-3 cleanup — interface-purity + strict-parity residues from #320 review

### DIFF
--- a/skills/jared/scripts/jared
+++ b/skills/jared/scripts/jared
@@ -34,11 +34,15 @@ from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
     print_redaction_diff,
     resolve_body,
 )
-from lib.board_provider import BoardItem  # type: ignore[import-not-found]  # noqa: E402
+from lib.board_provider import (  # type: ignore[import-not-found]  # noqa: E402
+    BoardItem,
+    ClosedItem,
+)
 from lib.github_provider import (  # type: ignore[import-not-found]  # noqa: E402
     FileBoardSetupError,
     FileCreateError,
     FileRoundTripError,
+    IssueResolutionError,
 )
 from lib import session_lock  # type: ignore[import-not-found]  # noqa: E402
 from lib import worktree as _worktree  # type: ignore[import-not-found]  # noqa: E402
@@ -527,6 +531,17 @@ def _cmd_file(args: argparse.Namespace) -> int:
         name, value = spec.split("=", 1)
         extra_specs.append((name, value))
 
+    # Validate Priority/Status/extra field values up front — before the
+    # read-only milestone GET and the body PII scan — so a bad --priority/
+    # --status/--field fails fast without paying for that I/O or being
+    # mislabeled as a PII refusal (exit 1, not 2). The provider raises
+    # FieldNotFound/OptionNotFound, caught by main() → exit 1; the resolved
+    # IDs never cross back into the CLI (#321 item 4, preserving the #314
+    # fork-gate). provider.file() re-validates as its own fence.
+    board.provider.validate_fields(
+        priority=args.priority, status=status, fields=extra_specs or None
+    )
+
     # Milestone resolution (#238). Every filing must declare intent: either
     # --milestone NAME (validated against open milestones) or --no-milestone
     # (explicit opt-out). Missing both → refuse with a listing. Eight
@@ -632,7 +647,11 @@ def _cmd_file(args: argparse.Namespace) -> int:
     # call invalidate_items() internally; the provider layer deliberately does
     # not touch the cache, so the CLI layer must drive invalidation here. (#52)
     board.invalidate_items()
-    issue_url = f"https://github.com/{board.repo}/issues/{item.number}"
+    # Echo the URL gh emitted at create time (carried on the BoardItem), not a
+    # reconstructed github.com URL — the two diverge on GitHub Enterprise hosts
+    # (#321 item 3). Reconstruct only as a defensive fallback if the provider
+    # somehow left it unset; GitHubProjectsProvider.file() always populates it.
+    issue_url = item.url or f"https://github.com/{board.repo}/issues/{item.number}"
     print(f"OK: filed #{item.number} → {status}, Priority={args.priority}")
     print(f"URL: {issue_url}")
     return 0
@@ -719,6 +738,13 @@ def _cmd_blocked_by(args: argparse.Namespace) -> int:
             board.provider.remove_blocked_by(args.dependent, args.blocker)
         else:
             board.provider.add_blocked_by(args.dependent, args.blocker)
+    except IssueResolutionError as e:
+        # Node-id resolution failed before the mutation ever ran. The
+        # provider's message already carries the "could not resolve issue
+        # node IDs" phrasing — print it verbatim (#321 item 5). Must precede
+        # the GhInvocationError branch since IssueResolutionError subclasses it.
+        print(f"error: {e}", file=sys.stderr)
+        return 2
     except GhInvocationError as e:
         mutation_name = "removeBlockedBy" if args.remove else "addBlockedBy"
         print(f"error: {mutation_name} failed: {e}", file=sys.stderr)
@@ -948,14 +974,12 @@ def _detect_stuck_closed_recent(board: Board, *, days: int) -> list[dict[str, An
             file=sys.stderr,
         )
         return []
-    numbers = [entry["number"] for entry in closed if isinstance(entry.get("number"), int)]
+    # ClosedItem.number is always an int (provider constructs it via int()),
+    # so the old isinstance guard against malformed dicts is no longer needed.
+    numbers = [entry.number for entry in closed]
     if not numbers:
         return []
-    titles = {
-        entry["number"]: entry.get("title") or ""
-        for entry in closed
-        if isinstance(entry.get("number"), int)
-    }
+    titles = {entry.number: entry.title for entry in closed}
     # One aliased GraphQL call covers every recently-closed issue's
     # projectItems lookup, instead of N per-issue calls — the wall-clock
     # bottleneck on mature boards (gh-cli startup overhead dominates).
@@ -982,7 +1006,7 @@ def _detect_stuck_closed_recent(board: Board, *, days: int) -> list[dict[str, An
     return stuck
 
 
-def _fetch_recently_closed(board: Board, *, days: int) -> list[dict[str, Any]]:
+def _fetch_recently_closed(board: Board, *, days: int) -> list[ClosedItem]:
     """Delegate to provider.recently_closed(days=days).
 
     Thin wrapper kept for call-site continuity — callers use the same
@@ -1103,8 +1127,8 @@ def _cmd_next_session_prompt(args: argparse.Namespace) -> int:
     print()
     if closed:
         for c in closed:
-            date = (c.get("closedAt") or "")[:10]
-            print(f"- #{c['number']} {c['title']}  ({date})")
+            date = c.closed_at[:10]
+            print(f"- #{c.number} {c.title}  ({date})")
     else:
         print("(none)")
     print()

--- a/skills/jared/scripts/lib/board_provider.py
+++ b/skills/jared/scripts/lib/board_provider.py
@@ -42,13 +42,11 @@ class BoardItem:
     # Opaque backend addressing token (GitHub project-item node-id, KanbanFlow
     # _id). Populated by get_item; the interface promises nothing about its format.
     provider_ref: str | None = None
-
-
-@dataclass
-class Comment:
-    body: str
-    author: str
-    created_at: str
+    # Opaque issue URL exactly as the backend's create call emitted it
+    # (gh issue create stdout). Populated by file(). Echoing it avoids
+    # reconstructing a github.com URL that diverges on GitHub Enterprise
+    # hosts (#321 item 3). The interface promises nothing about its format.
+    url: str | None = None
 
 
 @dataclass
@@ -65,17 +63,39 @@ class Milestone:
     due: str | None = None
 
 
+@dataclass
+class ClosedItem:
+    """A recently-closed issue, in neutral terms.
+
+    Replaces the raw `{number, title, closedAt}` dict that `recently_closed`
+    used to return — the GitHub-camelCase `closedAt` key was the one provider
+    internal leaking across this boundary (#321 item 1). `closed_at` is an
+    opaque timestamp string; the interface promises nothing about its format
+    beyond lexicographic sortability (callers slice/compare, never parse).
+    """
+
+    number: int
+    title: str
+    closed_at: str
+
+
 @runtime_checkable
 class BoardProvider(Protocol):
     # --- reads ---
     def get_item(self, ref: IssueRef) -> BoardItem | None: ...
     def list_open_items(self) -> list[BoardItem]: ...
     def get_body(self, ref: IssueRef) -> str: ...
-    def list_comments(self, ref: IssueRef) -> list[Comment]: ...
     def fetch_blocked_by_edges(self) -> list[Edge]: ...
-    def recently_closed(self, *, days: int) -> list[dict[str, object]]: ...
+    def recently_closed(self, *, days: int) -> list[ClosedItem]: ...
 
     # --- writes ---
+    def validate_fields(
+        self,
+        *,
+        priority: str,
+        status: str,
+        fields: list[tuple[str, str]] | None = None,
+    ) -> None: ...
     def file(
         self,
         *,

--- a/skills/jared/scripts/lib/github_provider.py
+++ b/skills/jared/scripts/lib/github_provider.py
@@ -18,7 +18,6 @@ from .board import (
     OptionNotFound,
     _flatten_project_item_for_project,
     fetch_issue_body_rest,
-    fetch_recent_comments_batch,
     run_gh,
     run_gh_raw,
     run_graphql,
@@ -29,7 +28,7 @@ from .board import (
 from .board_provider import (
     BoardItem,
     Capability,
-    Comment,
+    ClosedItem,
     Edge,
     IssueRef,
     Milestone,
@@ -69,6 +68,19 @@ class FileBoardSetupError(Exception):
         self.issue_url = issue_url
         self.cause = cause
         super().__init__(str(cause))
+
+
+class IssueResolutionError(GhInvocationError):
+    """Failed to resolve an issue ref to its GitHub node-id (the `gh issue view
+    --json id` step that precedes a blocked-by mutation).
+
+    Subclasses GhInvocationError so any existing `except GhInvocationError`
+    still catches it, but lets the CLI distinguish a *resolution* failure from
+    a downstream *mutation* failure and restore the specific
+    "could not resolve issue node IDs" message (#321 item 5). The message
+    carries that GitHub-specific phrasing so the CLI can print it verbatim
+    without itself referencing node-ids.
+    """
 
 
 _OPEN_ITEMS_QUERY = """
@@ -291,27 +303,6 @@ class GitHubProjectsProvider:
         """Return the issue's Markdown body via REST (with ETag/conditional GET)."""
         return fetch_issue_body_rest(self.repo, ref)
 
-    def list_comments(self, ref: IssueRef) -> list[Comment]:
-        """Return the most recent comments for issue `ref`.
-
-        Mapping notes:
-        - body: node["body"]
-        - created_at: node["createdAt"]
-        - author: absent from fetch_recent_comments_batch query → "" (degraded field).
-          The upstream query is `comments(last: N) { nodes { body createdAt } }` — no
-          author node. Editing board.py to add author is out of scope for this task.
-        """
-        batch = fetch_recent_comments_batch(self.repo, [ref])
-        nodes = batch.get(ref, [])
-        return [
-            Comment(
-                body=str(node.get("body", "")),
-                author="",
-                created_at=str(node.get("createdAt", "")),
-            )
-            for node in nodes
-        ]
-
     def fetch_blocked_by_edges(self) -> list[Edge]:
         """Return all blocked-by edges for open issues in this repo.
 
@@ -469,31 +460,41 @@ class GitHubProjectsProvider:
         return item_id
 
     def _resolve_issue_node_id(self, issue_number: int) -> str:
-        """Return the GitHub node-id for `issue_number` (needed for blocked-by)."""
-        data = run_gh(
-            [
-                "issue",
-                "view",
-                str(issue_number),
-                "--repo",
-                self.repo,
-                "--json",
-                "id",
-            ]
-        )
+        """Return the GitHub node-id for `issue_number` (needed for blocked-by).
+
+        Raises IssueResolutionError (not a bare GhInvocationError) on lookup
+        failure so the CLI can distinguish this resolution step from the
+        downstream addBlockedBy/removeBlockedBy mutation and restore the
+        specific "could not resolve issue node IDs" message (#321 item 5).
+        """
+        try:
+            data = run_gh(
+                [
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--repo",
+                    self.repo,
+                    "--json",
+                    "id",
+                ]
+            )
+        except GhInvocationError as e:
+            raise IssueResolutionError(f"could not resolve issue node IDs: {e}") from e
         return str(data["id"])
 
     # ------------------------------------------------------------------ #
     # WRITE methods (implemented in Task 4)                               #
     # ------------------------------------------------------------------ #
 
-    def recently_closed(self, *, days: int) -> list[dict[str, Any]]:
-        """Return issues closed in the last `days` days.
+    def recently_closed(self, *, days: int) -> list[ClosedItem]:
+        """Return issues closed in the last `days` days as neutral ClosedItems.
 
-        Uses `gh issue list --state closed --search "closed:>=DATE"` (same
-        query as the CLI's `_fetch_recently_closed`). Returns a list of
-        ``{"number", "title", "closedAt"}`` dicts, sorted by closedAt desc
-        (newest first). Empty list if none.
+        Uses `gh issue list --state closed --search "closed:>=DATE"`. The CLI's
+        `_fetch_recently_closed` is now a thin delegate to this method. Maps
+        gh's camelCase `closedAt` to ClosedItem.closed_at here — the GitHub key
+        never crosses the neutral boundary (#321 item 1). Sorted by closed_at
+        desc (newest first). Empty list if none.
 
         Raises GhInvocationError on silent-truncation at the 200-item cap.
         """
@@ -517,15 +518,51 @@ class GitHubProjectsProvider:
                 "number,title,closedAt",
             ]
         )
-        items: list[dict[str, Any]] = data if isinstance(data, list) else data.get("issues", [])
-        if len(items) == limit:
+        raw: list[dict[str, Any]] = data if isinstance(data, list) else data.get("issues", [])
+        if len(raw) == limit:
             raise GhInvocationError(
                 f"gh issue list --state closed returned exactly {limit} items "
                 f"in the last {days}d — likely truncated. Narrow the lookback "
                 f"window or paginate; do not trust this snapshot."
             )
-        items.sort(key=lambda c: c.get("closedAt") or "", reverse=True)
+        items = [
+            ClosedItem(
+                number=int(entry["number"]),
+                title=str(entry.get("title", "")),
+                closed_at=str(entry.get("closedAt") or ""),
+            )
+            for entry in raw
+        ]
+        items.sort(key=lambda c: c.closed_at, reverse=True)
         return items
+
+    def validate_fields(
+        self,
+        *,
+        priority: str,
+        status: str,
+        fields: list[tuple[str, str]] | None = None,
+    ) -> None:
+        """Pre-resolve Priority/Status/extra field+option IDs, raising
+        FieldNotFound/OptionNotFound on any miss — and returning nothing.
+
+        Resolved IDs stay private to the provider: the CLI learns only
+        pass/raise, never a field_id/option_id (that vocabulary was
+        deliberately removed from the CLI at the #314 fork-gate). The CLI calls
+        this at the very top of `jared file` so a bad --priority/--status/
+        --field fails fast (exit 1 via main()'s handler) BEFORE the read-only
+        milestone GET and the body PII scan run — restoring pre-#314 ordering
+        and the bad-field-beats-PII-body exit code (#321 item 4). file() also
+        calls it as its own fail-before-create fence (the two callers are
+        intentional — validating twice is cheap, both are pure dict lookups).
+        """
+        self._field_id("Priority")
+        self._option_id("Priority", priority)
+        self._field_id("Status")
+        self._option_id("Status", status)
+        for name, value in fields or []:
+            self._field_id(name)
+            self._option_id(name, value)
 
     def file(
         self,
@@ -562,13 +599,7 @@ class GitHubProjectsProvider:
         # Board.add_existing_to_board's "pre-resolve everything up front"
         # discipline). _add_existing re-resolves the same names — the duplication
         # is intentional: the pre-create check is the fail-before-create fence.
-        self._field_id("Priority")
-        self._option_id("Priority", priority)
-        self._field_id("Status")
-        self._option_id("Status", effective_status)
-        for name, value in fields or []:
-            self._field_id(name)
-            self._option_id(name, value)
+        self.validate_fields(priority=priority, status=effective_status, fields=fields)
 
         # Stage body in a temp file; gh issue create requires a file path.
         with tempfile.NamedTemporaryFile(
@@ -638,6 +669,9 @@ class GitHubProjectsProvider:
             priority=priority,
             labels=list(labels or []),
             milestone=milestone,
+            # Carry gh's actual create URL so the CLI can echo it verbatim
+            # instead of reconstructing one (diverges on GHE hosts — #321 item 3).
+            url=issue_url,
         )
 
     def add_to_board(

--- a/tests/test_cmd_blocked_by.py
+++ b/tests/test_cmd_blocked_by.py
@@ -78,3 +78,55 @@ def test_blocked_by_remove_edge(
     query_arg = next(a for a in gql if a.startswith("query="))
     assert "removeBlockedBy" in query_arg
     assert "addBlockedBy" not in query_arg
+
+
+def test_blocked_by_resolution_failure_reports_node_id_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A `gh issue view` (node-id resolution) failure reports the specific
+    'could not resolve issue node IDs' message, not the generic mutation
+    failure — restoring pre-#314 parity (#321 item 5)."""
+    board_md = write_minimal_board(tmp_path)
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        if "issue" in args and "view" in args:
+            return FakeGhResult(returncode=1, stderr="gh: issue not found")
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "blocked-by", "99", "42"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "could not resolve issue node IDs" in captured.err
+    # Must NOT be mislabeled as a mutation failure (the regression this fixes).
+    assert "addBlockedBy failed" not in captured.err
+
+
+def test_blocked_by_mutation_failure_reports_mutation_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When node-ids resolve but the addBlockedBy mutation fails, the error is
+    'addBlockedBy failed' — distinct from the resolution-failure message
+    (#321 item 5)."""
+    board_md = write_minimal_board(tmp_path)
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        joined = " ".join(args)
+        if "issue" in args and "view" in args:
+            idx = args.index("view")
+            num = args[idx + 1]
+            return FakeGhResult(stdout=f'{{"id": "I_{num}"}}')
+        if "graphql" in joined:
+            return FakeGhResult(returncode=1, stderr="gh: mutation rejected")
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(["--board", str(board_md), "blocked-by", "99", "42"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "addBlockedBy failed" in captured.err
+    assert "could not resolve issue node IDs" not in captured.err

--- a/tests/test_cmd_file.py
+++ b/tests/test_cmd_file.py
@@ -167,6 +167,52 @@ def test_file_with_custom_status_and_extra_field(
     )
 
 
+def test_file_echoes_real_create_url_not_reconstructed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The `URL:` line echoes gh's actual create URL, not a reconstructed
+    `https://github.com/{repo}/issues/{n}` (#321 item 3).
+
+    Uses a GitHub Enterprise host in the create output: a reconstructed
+    github.com URL would carry neither the enterprise host nor issue #77.
+    """
+    board_md = _write_full_board(tmp_path)
+    body_file = tmp_path / "body.md"
+    body_file.write_text("Body.")
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        joined = " ".join(args)
+        if "issue create" in joined:
+            return FakeGhResult(stdout="https://ghe.example.com/brockamer/findajob/issues/77\n")
+        if "item-add" in joined:
+            return FakeGhResult(stdout='{"id": "PVTI_new"}')
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "Enterprise issue",
+            "--body-file",
+            str(body_file),
+            "--priority",
+            "High",
+            "--no-milestone",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert "URL: https://ghe.example.com/brockamer/findajob/issues/77" in captured.out
+    # The reconstructed form (github.com host) must NOT appear on the URL line.
+    url_line = next(line for line in captured.out.splitlines() if line.startswith("URL:"))
+    assert "github.com" not in url_line
+
+
 def test_file_preserves_staged_body_on_create_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -764,6 +810,94 @@ def test_cmd_file_refuses_on_dirty_pre_flight_report(
     assert not any("issue" in c and "create" in c for c in calls), (
         f"redactor must short-circuit before gh; calls: {calls}"
     )
+
+
+def test_file_validates_fields_before_milestone_get(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A bad --status fails fast (exit 1) before the read-only milestone GET
+    even runs — restoring pre-#314 ordering (#321 item 4).
+
+    --status is the reachable free-form field path (--priority is argparse
+    choices-constrained, rejected at parse time). The milestone passed IS valid,
+    so on the buggy ordering the milestone REST lookup fired first (and would
+    have been recorded) before the field was ever validated. The discriminating
+    assertion is therefore the *absence* of the milestone GET, not the exit
+    code (which is 1 either way)."""
+    board_md = _write_full_board(tmp_path)
+    body_file = tmp_path / "body.md"
+    body_file.write_text("Body.")
+    calls = _routed_fake_with_milestones(monkeypatch, ["v1.0 — public install"])
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "T",
+            "--body-file",
+            str(body_file),
+            "--priority",
+            "Low",
+            "--status",
+            "Bogus",
+            "--milestone",
+            "v1.0 — public install",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1, captured.err
+    assert not any("milestones" in " ".join(c) and "api" in " ".join(c) for c in calls), (
+        "field validation must precede the milestone REST GET (#321 item 4)"
+    )
+    assert not any("issue" in c and "create" in c for c in calls)
+
+
+def test_file_bad_field_beats_pii_body_with_exit_1(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A bad --status exits 1 (field validation) even when the body would trip
+    the PII pre-flight scan — field validation runs first, restoring main's exit
+    code for the bad-field + dirty-body combo (#321 item 4).
+
+    Pre-fix, the PII scan ran before field validation, so this combo exited 2
+    and was reported as a redaction refusal rather than a bad field. (--status
+    is the reachable free-form path; --priority is argparse-constrained.)"""
+    board_md = _write_full_board(tmp_path)
+    leaky_phrase = "the deploy host is internal-foo-7.corp.example"
+    _git_init_with_claude_local(tmp_path, leaky_phrase + "\n")
+    monkeypatch.chdir(tmp_path)
+
+    from skills.jared.scripts.lib.board import _clear_pre_flight_cache
+
+    _clear_pre_flight_cache()
+
+    calls = _routed_fake(monkeypatch)
+
+    mod = import_cli()
+    rc = mod.main(
+        [
+            "--board",
+            str(board_md),
+            "file",
+            "--title",
+            "T",
+            "--body",
+            f"While testing I noticed {leaky_phrase} stops responding under load.",
+            "--priority",
+            "Low",
+            "--status",
+            "Bogus",
+            "--no-milestone",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1, captured.err
+    # The failure is the bad field, NOT the PII refusal.
+    assert "pre-flight redaction check failed" not in captured.err
+    assert not any("issue" in c and "create" in c for c in calls)
 
 
 def test_cmd_file_proceeds_on_clean_pre_flight_report(

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -2,7 +2,7 @@
 
 Mirrors the observable-data assertions in test_board_open_items.py and
 test_board_fetch_for_ties.py, but against the provider and the neutral
-dataclass shapes (BoardItem, Comment, Edge).
+dataclass shapes (BoardItem, Edge, ClosedItem).
 
 All gh/GraphQL calls flow through board.py's module-level subprocess seam so
 patch_gh / patch_gh_by_arg intercept them correctly.
@@ -19,7 +19,7 @@ from skills.jared.scripts.lib.board_provider import (
     BoardItem,
     BoardProvider,
     Capability,
-    Comment,
+    ClosedItem,
     Edge,
     Milestone,
 )
@@ -34,15 +34,22 @@ def _provider() -> GitHubProjectsProvider:
         owner="brockamer",
         repo="brockamer/findajob",
         field_ids={"Status": "F1", "Priority": "F2"},
+        # Distinctive multi-char option-ids (not single letters) so substring
+        # asserts like `"OID_PRIO_HIGH" in joined` can't pass by accident — a
+        # bare "H" matches "GitHub", a node-id, etc. (#321 item 6).
         field_options={
             "Status": {
-                "Backlog": "A",
-                "Up Next": "B",
-                "In Progress": "C",
-                "Blocked": "D",
-                "Done": "E",
+                "Backlog": "OID_STAT_BACKLOG",
+                "Up Next": "OID_STAT_UPNEXT",
+                "In Progress": "OID_STAT_INPROGRESS",
+                "Blocked": "OID_STAT_BLOCKED",
+                "Done": "OID_STAT_DONE",
             },
-            "Priority": {"High": "H", "Medium": "M", "Low": "L"},
+            "Priority": {
+                "High": "OID_PRIO_HIGH",
+                "Medium": "OID_PRIO_MEDIUM",
+                "Low": "OID_PRIO_LOW",
+            },
         },
     )
 
@@ -467,51 +474,6 @@ def test_get_body_returns_empty_string_on_missing(monkeypatch: pytest.MonkeyPatc
 
 
 # ------------------------------------------------------------------ #
-# list_comments                                                        #
-# ------------------------------------------------------------------ #
-
-
-def test_list_comments_returns_comment_objects(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Comments come back as Comment dataclass instances."""
-    patch_gh(
-        monkeypatch,
-        stdout=json.dumps(
-            {
-                "data": {
-                    "repository": {
-                        "i42": {
-                            "comments": {
-                                "nodes": [
-                                    {"body": "First comment", "createdAt": "2026-01-01T00:00:00Z"},
-                                    {"body": "Second comment", "createdAt": "2026-01-02T00:00:00Z"},
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        ),
-    )
-    comments = _provider().list_comments(42)
-    assert len(comments) == 2
-    assert all(isinstance(c, Comment) for c in comments)
-    assert comments[0].body == "First comment"
-    assert comments[0].created_at == "2026-01-01T00:00:00Z"
-    # author is absent from fetch_recent_comments_batch query → documented empty string
-    assert comments[0].author == ""
-    assert comments[1].body == "Second comment"
-
-
-def test_list_comments_empty_when_no_comments(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Issue with no comments → empty list."""
-    patch_gh(
-        monkeypatch,
-        stdout=json.dumps({"data": {"repository": {"i10": {"comments": {"nodes": []}}}}}),
-    )
-    assert _provider().list_comments(10) == []
-
-
-# ------------------------------------------------------------------ #
 # fetch_blocked_by_edges                                               #
 # ------------------------------------------------------------------ #
 
@@ -627,8 +589,8 @@ def test_field_id_raises_for_unknown_field() -> None:
 
 
 def test_option_id_returns_id_for_known_option() -> None:
-    assert _provider()._option_id("Status", "Done") == "E"
-    assert _provider()._option_id("Priority", "High") == "H"
+    assert _provider()._option_id("Status", "Done") == "OID_STAT_DONE"
+    assert _provider()._option_id("Priority", "High") == "OID_PRIO_HIGH"
 
 
 def test_option_id_raises_for_unknown_option() -> None:
@@ -639,6 +601,58 @@ def test_option_id_raises_for_unknown_option() -> None:
 
 
 # ------------------------------------------------------------------ #
+# validate_fields (#321 item 4)                                        #
+# ------------------------------------------------------------------ #
+
+
+def test_validate_fields_does_not_raise_for_known_values() -> None:
+    """No exception when Priority/Status/extra fields all resolve."""
+    provider = GitHubProjectsProvider(
+        project_number=7,
+        project_id="PVT_x",
+        owner="brockamer",
+        repo="brockamer/findajob",
+        field_ids={"Status": "F1", "Priority": "F2", "Size": "F3"},
+        field_options={
+            "Status": {"Backlog": "OID_STAT_BACKLOG"},
+            "Priority": {"High": "OID_PRIO_HIGH"},
+            "Size": {"Large": "OID_SIZE_LARGE"},
+        },
+    )
+    # Must not raise (returns None — asserting `is None` would trip mypy's
+    # func-returns-value lint on a -> None call).
+    provider.validate_fields(priority="High", status="Backlog", fields=[("Size", "Large")])
+
+
+def test_validate_fields_raises_optionnotfound_for_bad_priority() -> None:
+    from skills.jared.scripts.lib.board import OptionNotFound
+
+    with pytest.raises(OptionNotFound):
+        _provider().validate_fields(priority="Bogus", status="Backlog")
+
+
+def test_validate_fields_raises_fieldnotfound_for_unknown_extra_field() -> None:
+    from skills.jared.scripts.lib.board import FieldNotFound
+
+    with pytest.raises(FieldNotFound):
+        _provider().validate_fields(
+            priority="High", status="Backlog", fields=[("Nonexistent", "X")]
+        )
+
+
+def test_validate_fields_makes_no_gh_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pure dict lookups — never shells out. Lets the CLI call it as a cheap
+    pre-flight before the milestone GET, and file() call it again as a fence."""
+
+    def explode(*a: object, **k: object) -> object:
+        raise AssertionError("validate_fields must not invoke gh/subprocess")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", explode)
+    # Must not raise (and the explode guard proves no gh/subprocess call fired).
+    _provider().validate_fields(priority="High", status="Backlog")
+
+
+# ------------------------------------------------------------------ #
 # WRITE methods (Phase 1.4)                                           #
 # ------------------------------------------------------------------ #
 
@@ -646,9 +660,10 @@ def test_option_id_raises_for_unknown_option() -> None:
 # used in _provider() so assertions can be exact.
 #
 # field_ids:    Status → "F1",  Priority → "F2"
-# field_options Status: Backlog→"A", Up Next→"B", In Progress→"C",
-#                       Blocked→"D", Done→"E"
-#               Priority: High→"H", Medium→"M", Low→"L"
+# field_options Status: Backlog→"OID_STAT_BACKLOG", Up Next→"OID_STAT_UPNEXT",
+#                       In Progress→"OID_STAT_INPROGRESS", Blocked→"OID_STAT_BLOCKED",
+#                       Done→"OID_STAT_DONE"
+#               Priority: High→"OID_PRIO_HIGH", Medium→"OID_PRIO_MEDIUM", Low→"OID_PRIO_LOW"
 # project_id:   "PVT_x"
 # project_number: 7
 # owner:        "brockamer"
@@ -700,10 +715,10 @@ def test_add_to_board_calls_item_add_and_graphql_mutation(
     graphql_calls = [c for c in calls if "api" in c and "graphql" in c]
     assert graphql_calls, "expected graphql call for field mutations"
     joined = " ".join(" ".join(c) for c in graphql_calls)
-    # Priority resolved: F2 / H
-    assert "F2" in joined and "H" in joined
-    # Status resolved: F1 / A (Backlog)
-    assert "F1" in joined and "A" in joined
+    # Priority resolved: F2 / OID_PRIO_HIGH
+    assert "F2" in joined and "OID_PRIO_HIGH" in joined
+    # Status resolved: F1 / OID_STAT_BACKLOG
+    assert "F1" in joined and "OID_STAT_BACKLOG" in joined
     # updateProjectV2ItemFieldValue mutation present
     assert "updateProjectV2ItemFieldValue" in joined
     # No item-edit (field edits go through graphql in add_to_board path)
@@ -765,9 +780,9 @@ def test_add_to_board_extra_fields_emit_aliased_setextra_mutation(
         repo="brockamer/findajob",
         field_ids={"Status": "F1", "Priority": "F2", "Size": "F3"},
         field_options={
-            "Status": {"Backlog": "A"},
-            "Priority": {"High": "H"},
-            "Size": {"Large": "SL"},
+            "Status": {"Backlog": "OID_STAT_BACKLOG"},
+            "Priority": {"High": "OID_PRIO_HIGH"},
+            "Size": {"Large": "OID_SIZE_LARGE"},
         },
     )
     calls = patch_gh_by_arg(
@@ -786,8 +801,8 @@ def test_add_to_board_extra_fields_emit_aliased_setextra_mutation(
     assert "setPriority" in joined
     assert "setStatus" in joined
     assert "setExtra0" in joined
-    # Size resolved: field-id F3 / option-id SL
-    assert "F3" in joined and "SL" in joined
+    # Size resolved: field-id F3 / option-id OID_SIZE_LARGE
+    assert "F3" in joined and "OID_SIZE_LARGE" in joined
     # Single round-trip: all three fields must land in exactly ONE field-mutation call
     # (a regression to per-field separate mutations would produce 3+).
     mutation_calls = [c for c in graphql_calls if "updateProjectV2ItemFieldValue" in " ".join(c)]
@@ -829,8 +844,8 @@ def test_file_sequences_create_add_graphql(
     graphql_calls = [c for c in calls if "api" in c and "graphql" in c]
     joined = " ".join(" ".join(c) for c in graphql_calls)
     assert "updateProjectV2ItemFieldValue" in joined
-    assert "F2" in joined and "H" in joined  # Priority=High
-    assert "F1" in joined and "A" in joined  # Status=Backlog
+    assert "F2" in joined and "OID_PRIO_HIGH" in joined  # Priority=High
+    assert "F1" in joined and "OID_STAT_BACKLOG" in joined  # Status=Backlog
     # no item-edit (field mutations go through graphql)
     assert not any("item-edit" in " ".join(c) for c in calls)
 
@@ -840,6 +855,36 @@ def test_file_sequences_create_add_graphql(
     assert result.title == "New issue"
     assert result.status == "Backlog"
     assert result.priority == "High"
+    # url carries gh's actual create output (#321 item 3)
+    assert result.url == "https://github.com/brockamer/findajob/issues/99"
+
+
+def test_file_url_is_gh_create_output_not_reconstructed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """file() carries the URL gh emitted at create, verbatim — never a
+    reconstructed `https://github.com/{repo}/issues/{n}` (#321 item 3).
+
+    Proven with a GitHub Enterprise host in the create output: a reconstructed
+    github.com URL would NOT carry it, so this assertion can only pass if the
+    real create URL is threaded onto the BoardItem.
+    """
+    patch_gh_by_arg(
+        monkeypatch,
+        {
+            "issue create": "https://ghe.example.com/brockamer/findajob/issues/77\n",
+            "item-add": '{"id": "PVTI_new"}',
+            "api graphql": "{}",
+        },
+    )
+    result = _provider().file(
+        title="Enterprise issue",
+        body="Body.",
+        priority="High",
+        status="Backlog",
+    )
+    assert result.number == 77
+    assert result.url == "https://ghe.example.com/brockamer/findajob/issues/77"
 
 
 def test_file_passes_milestone_to_gh_create(
@@ -1046,7 +1091,7 @@ def test_set_field_emits_item_edit_with_resolved_ids(
     assert "PVT_x" in joined  # project_id
     assert "PVTI_aaa" in joined  # item_id
     assert "F2" in joined  # field_id for Priority
-    assert "H" in joined  # option_id for High
+    assert "OID_PRIO_HIGH" in joined  # option_id for High
 
 
 def test_set_field_emits_item_edit_not_graphql_mutation(
@@ -1093,7 +1138,7 @@ def test_move_delegates_to_set_field(
     assert edit_calls
     joined = " ".join(edit_calls[0])
     assert "F1" in joined  # Status field_id
-    assert "C" in joined  # In Progress option_id
+    assert "OID_STAT_INPROGRESS" in joined  # In Progress option_id
 
 
 # ------------------------------------------------------------------ #
@@ -1124,7 +1169,7 @@ def test_close_emits_gh_issue_close_then_sets_status_done(
     assert edit_calls, "expected gh project item-edit for Status=Done"
     joined = " ".join(edit_calls[0])
     assert "F1" in joined  # Status field_id
-    assert "E" in joined  # Done option_id
+    assert "OID_STAT_DONE" in joined  # Done option_id
 
 
 def test_close_with_comment_emits_comment_before_close(
@@ -1347,6 +1392,28 @@ def test_remove_blocked_by_emits_removeBlockedBy_mutation(
     assert "addBlockedBy" not in query_arg
 
 
+def test_add_blocked_by_raises_issue_resolution_error_on_view_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `gh issue view` failure during node-id resolution surfaces as
+    IssueResolutionError (distinguishable from a mutation failure), carrying
+    the 'could not resolve issue node IDs' message so the CLI can restore the
+    specific error (#321 item 5). The subclass relationship keeps it catchable
+    as GhInvocationError for any generic handler."""
+    from skills.jared.scripts.lib.github_provider import IssueResolutionError
+
+    def fake_run(args: list[str], **kw: object) -> FakeGhResult:
+        if "issue" in args and "view" in args:
+            return FakeGhResult(returncode=1, stderr="gh: not found")
+        return FakeGhResult(stdout="{}")
+
+    monkeypatch.setattr("skills.jared.scripts.lib.board.subprocess.run", fake_run)
+
+    assert issubclass(IssueResolutionError, GhInvocationError)
+    with pytest.raises(IssueResolutionError, match="could not resolve issue node IDs"):
+        _provider().add_blocked_by(99, 42)
+
+
 # ------------------------------------------------------------------ #
 # set_milestone                                                         #
 # ------------------------------------------------------------------ #
@@ -1463,3 +1530,38 @@ def test_item_add_raises_after_retry_still_missing_id(
 
     with pytest.raises(GhInvocationError, match="no id.*after retry"):
         _provider()._item_add(99)
+
+
+# ------------------------------------------------------------------ #
+# recently_closed (#321 item 1 — neutral ClosedItem, no closedAt leak) #
+# ------------------------------------------------------------------ #
+
+
+def test_recently_closed_maps_to_closeditem_sorted_desc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """recently_closed returns neutral ClosedItems (number/title/closed_at),
+    newest first — gh's camelCase `closedAt` is mapped at the boundary and
+    never escapes as a dict key (#321 item 1)."""
+    import json as _json
+
+    payload = _json.dumps(
+        [
+            {"number": 10, "title": "older", "closedAt": "2026-05-01T10:00:00Z"},
+            {"number": 20, "title": "newer", "closedAt": "2026-05-09T10:00:00Z"},
+        ]
+    )
+    patch_gh(monkeypatch, stdout=payload)
+
+    closed = _provider().recently_closed(days=7)
+
+    assert all(isinstance(c, ClosedItem) for c in closed)
+    # Sorted by closed_at descending (newest first).
+    assert [c.number for c in closed] == [20, 10]
+    assert closed[0].title == "newer"
+    assert closed[0].closed_at == "2026-05-09T10:00:00Z"
+
+
+def test_recently_closed_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    patch_gh(monkeypatch, stdout="[]")
+    assert _provider().recently_closed(days=7) == []


### PR DESCRIPTION
Resolves all six non-blocking residues filed from the PR #320 adversarial final review. **Closes #321.** Part of epic #313.

The advisor reframing on intake was the key call: "do it" means *close* #321, and closing requires resolving items 1–2 (resolve-now or retire-with-rationale) rather than deferring them to the future KanbanFlow design (#316) — deferral would leave the issue open. Both had cheap closing resolutions, so all six land here.

## What changed

**Refactor / interface-purity**
- **Item 1** — `recently_closed` returns a neutral `ClosedItem(number, title, closed_at)` instead of a raw dict keyed on GitHub-camelCase `closedAt` — the last provider key crossing the neutral boundary (it violated the contract's own docstring). Both CLI consumers (`_detect_stuck_closed_recent`, `_cmd_next_session_prompt`) migrate to attribute access.
- **Item 2** — Remove dead `list_comments` (no production consumer; the CLI uses the batched, cached `fetch_recent_comments_batch`) from the contract, impl, and tests; drop the now-orphaned `Comment` dataclass. No speculative interface surface.

**Bug fixes / strict-parity with main**
- **Item 3** — `jared file` echoes gh's actual create URL (new opaque `BoardItem.url`) instead of a reconstructed `github.com` URL that diverges on GitHub Enterprise hosts.
- **Item 4** — New `provider.validate_fields()` lets the CLI pre-validate Priority/Status/extra fields *before* the read-only milestone GET and the body PII scan, so a bad `--status`/`--field` fails fast (exit 1, not 2) without paying for that I/O or being mislabeled as a redaction refusal — **without** re-leaking `field_id`/`option_id` into the CLI (preserving the #314 fork-gate).
- **Item 5** — `IssueResolutionError(GhInvocationError)` distinguishes a node-id resolution failure from a mutation failure; `_cmd_blocked_by` restores the specific `could not resolve issue node IDs` message. The GitHub-specific phrasing lives in the provider's exception; the CLI stays free of node-id vocabulary.

**Test quality**
- **Item 6** — Distinctive multi-char `OID_*` option-ids in the provider test fixtures replace fragile single-char substring asserts (`"H" in joined`) that could pass by accident.

## Boundary note

This PR touches the **neutral contract** (`board_provider.py`): adds `ClosedItem` + `validate_fields`, removes `list_comments`/`Comment`. Reversible (reviewable here), and #321's AC explicitly delegated items 1–2 to judgment.

## Validation
- Full suite **650 passing** (+11 new: GHE-host URL parity, validate-before-milestone ordering + exit-1 parity, blocked-by resolution-vs-mutation messages, `ClosedItem` mapping, `validate_fields` units).
- `ruff check .` + `ruff format` (touched files) + `mypy --strict` all clean.
- Adversarial multi-agent review (5 dimensions — correctness, main-parity, interface-purity, test-quality, completeness — each finding adversarially refuted): **0 confirmed findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
