### PR TITLE
fix(dependency-graph): source Priority from project field, not labels (#299)

### DIFF
--- a/skills/jared/scripts/dependency-graph.py
+++ b/skills/jared/scripts/dependency-graph.py
@@ -34,6 +34,8 @@ from typing import Any, cast
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib.board import (  # type: ignore[import-not-found]  # noqa: E402
+    Board,
+    BoardConfigError,
     GhInvocationError,
 )
 from lib.board import (
@@ -83,6 +85,58 @@ def fetch_issue_state(repo: str, number: int) -> str:
     return cast(str, state)
 
 
+def fetch_field_priorities(repo: str, *, board: Board | None = None) -> dict[int, str]:
+    """Map open-issue number -> project-field Priority (e.g. "High").
+
+    Priority is a project **field** under jared doctrine; the `priority:` labels
+    this script used to read are stripped as legacy (`sweep.py`
+    `check_legacy_priority_labels`), so a label-based read always came back
+    empty on a doctrine board and `find_priority_inversions` could never fire
+    (#299). This sources Priority the way the rest of the CLI does — through the
+    parsed board snapshot.
+
+    Degrades to an empty map — priority check disabled, but the graph / cycle /
+    critical-path / orphaned analysis still runs — rather than crashing when:
+      - no board config doc is present (`BoardConfigError`),
+      - the board doc's repo != `repo` (`Board` reads its repo from the doc, not
+        from `--repo`; a join on mismatched issue numbers would manufacture
+        phantom inversions), or
+      - the open-items GraphQL call fails or overflows its 100-issue cap
+        (`GhInvocationError`).
+    """
+    if board is None:
+        try:
+            board = Board.from_default()
+        except BoardConfigError as e:
+            print(
+                f"dependency-graph: no board config ({e}); priority check disabled",
+                file=sys.stderr,
+            )
+            return {}
+    if board.repo != repo:
+        print(
+            f"dependency-graph: board doc repo {board.repo!r} != --repo {repo!r}; "
+            "priority check disabled",
+            file=sys.stderr,
+        )
+        return {}
+    try:
+        items = board.open_items()
+    except GhInvocationError as e:
+        print(
+            f"dependency-graph: open_items failed ({e}); priority check disabled",
+            file=sys.stderr,
+        )
+        return {}
+    priorities: dict[int, str] = {}
+    for item in items:
+        number = item.get("content", {}).get("number")
+        priority = item.get("priority")
+        if isinstance(number, int) and priority:
+            priorities[number] = priority
+    return priorities
+
+
 def fetch_all_native_dependencies(repo: str) -> dict[int, list[int]] | None:
     """Fetch native blockedBy edges for ALL open issues in one paginated call.
 
@@ -122,14 +176,6 @@ def parse_section_refs(body: str, section: str) -> list[int]:
 
 def body_dependencies(issue: dict[str, Any]) -> list[int]:
     return parse_section_refs(issue.get("body", "") or "", "Depends on")
-
-
-def issue_priority(issue: dict[str, Any]) -> str | None:
-    for label in issue.get("labels", []):
-        name: str = label.get("name", "").lower()
-        if name.startswith("priority:"):
-            return name.split(":", 1)[1].strip()
-    return None
 
 
 # ---------- Graph operations ----------
@@ -350,7 +396,6 @@ def main() -> int:
 
     # Build graph: N → set of issues N depends on
     graph: dict[int, set[int]] = defaultdict(set)
-    priorities: dict[int, str] = {}
 
     for issue in issues:
         n = issue["number"]
@@ -375,16 +420,16 @@ def main() -> int:
         # native == [] means "native says this issue has no deps" — don't
         # second-guess it with stale body text.
 
-        # Priority from label
-        p = issue_priority(issue)
-        if p:
-            priorities[n] = p
-
     if not graph:
         print("No dependencies found.", file=sys.stderr)
         return 0
 
     titles = {n: issues_by_number[n]["title"] for n in issues_by_number}
+
+    # Priority from the project field, not `priority:` labels (doctrine strips
+    # those, so the old label read was always empty — #299). Degrades to {} if
+    # the board can't be read; the rest of the analysis still runs.
+    priorities = fetch_field_priorities(args.repo)
 
     # Analyze
     topo, cycles = topological_sort(dict(graph))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,22 @@ def import_stage() -> ModuleType:
     return mod
 
 
+def import_dep() -> ModuleType:
+    """Load `dependency-graph.py` as a module. Same SourceFileLoader trick as the others.
+
+    The hyphen in the filename blocks a normal `import`; SourceFileLoader lets
+    tests exercise the graph helpers (and `fetch_field_priorities`) in-process
+    so monkeypatches on the shared `subprocess`/`Board` seam apply.
+    """
+    path = SKILL_SCRIPTS / "dependency-graph.py"
+    loader = SourceFileLoader("dependency_graph", str(path))
+    spec = importlib.util.spec_from_loader("dependency_graph", loader)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
 def write_minimal_board(tmp_path: Path) -> Path:
     """Write a minimal valid docs/project-board.md into tmp_path/docs/.
 

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,0 +1,115 @@
+"""Tests for dependency-graph.py — #299 field-sourced Priority.
+
+`dependency-graph.py` used to read priority from `priority:` labels, which
+jared doctrine strips, so `find_priority_inversions` could never fire on a
+doctrine-following board. #299 re-sources Priority from the project field
+(via `Board.open_items()`). These tests pin that behavior and its
+graceful-degradation paths.
+
+Board is injected into `fetch_field_priorities` so the test passes its own
+`Board` instance — sidestepping the dual-import-path gotcha (see the docstring
+atop conftest.py) entirely via duck typing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from skills.jared.scripts.lib.board import Board
+from tests.conftest import import_dep, patch_gh_multi, write_minimal_board
+
+
+def _board_with_open_items(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    statuses: dict[int, tuple[str, str]],
+    labels_by_number: dict[int, list[str]] | None = None,
+) -> Board:
+    """Build a Board from a minimal tmp doc (project 7) with open_items() faked.
+
+    `statuses` maps issue number -> (Status, Priority); patch_gh_multi feeds
+    those through the real `Board.open_items()` GraphQL parse.
+    """
+    write_minimal_board(tmp_path)
+    open_issues = [{"number": n, "title": f"issue {n}"} for n in statuses]
+    patch_gh_multi(
+        monkeypatch,
+        open_issues=open_issues,
+        statuses=statuses,
+        labels_by_number=labels_by_number or {},
+    )
+    return Board.from_path(tmp_path / "docs" / "project-board.md")
+
+
+def test_fetch_field_priorities_reads_project_field_not_labels(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # #1 carries a *misleading* priority:low label but a High Priority field;
+    # the field must win and the label must be ignored.
+    board = _board_with_open_items(
+        monkeypatch,
+        tmp_path,
+        statuses={1: ("Up Next", "High"), 2: ("Backlog", "Low")},
+        labels_by_number={1: ["priority:low"]},
+    )
+    dep = import_dep()
+
+    priorities = dep.fetch_field_priorities("brockamer/findajob", board=board)
+
+    assert priorities == {1: "High", 2: "Low"}
+
+
+def test_priority_inversion_fires_on_doctrine_board(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # AC#1: with field-sourced Priority, a High issue depending on a Low one
+    # is a real inversion the check can finally flag.
+    board = _board_with_open_items(
+        monkeypatch,
+        tmp_path,
+        statuses={1: ("Up Next", "High"), 2: ("Backlog", "Low")},
+    )
+    dep = import_dep()
+
+    priorities = dep.fetch_field_priorities("brockamer/findajob", board=board)
+    inversions = dep.find_priority_inversions({1: {2}}, priorities)
+
+    assert inversions == [(1, 2)]
+
+
+def test_fetch_field_priorities_degrades_on_repo_mismatch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Board doc repo (brockamer/findajob) != --repo: a silent join on
+    # mismatched numbers would manufacture phantom inversions, so degrade to {}.
+    board = _board_with_open_items(monkeypatch, tmp_path, statuses={1: ("Up Next", "High")})
+    dep = import_dep()
+
+    priorities = dep.fetch_field_priorities("brockamer/other-repo", board=board)
+
+    assert priorities == {}
+    assert capsys.readouterr().err  # warned, didn't silently no-op
+
+
+def test_fetch_field_priorities_degrades_on_missing_board_config(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # No board doc (board=None path): Board.from_default() raises
+    # BoardConfigError; the priority check disables rather than crashing the
+    # whole graph analysis.
+    dep = import_dep()
+
+    class _NoBoard:
+        @classmethod
+        def from_default(cls, project_root: object = None) -> object:
+            raise dep.BoardConfigError("no board doc")
+
+    monkeypatch.setattr(dep, "Board", _NoBoard)
+
+    priorities = dep.fetch_field_priorities("brockamer/jared")
+
+    assert priorities == {}
+    assert capsys.readouterr().err


### PR DESCRIPTION
Closes #299.

## Problem
`dependency-graph.py` read priority from `priority:` labels, which jared doctrine strips (`sweep.check_legacy_priority_labels`). On any doctrine-following board the `priorities` map was always empty, so `find_priority_inversions` could never fire — `/jared-groom` and `/jared-reshape` presented "Priority inversions: none" as a live check that was structurally incapable of firing: a clean bill it never earned.

## Fix
- Add `fetch_field_priorities(repo, *, board=None)` — sources Priority from the project **field** via `Board.open_items()`, keyed by issue number (the way `summary`/`next-session-prompt` already do).
- Wire it into `main()`; delete the label-based `issue_priority`.
- **Graceful degradation** to `{}` (priority check disabled, graph/cycle/critical-path/orphaned analysis intact) — never crashes — when: no board config (`BoardConfigError`); board-doc repo ≠ `--repo` (a cross-repo number join would manufacture phantom inversions); or `open_items()` overflows its 100-issue cap (`GhInvocationError`). Each path warns on stderr.

## Tests
New `tests/test_dependency_graph.py` (+ `import_dep` conftest helper):
- field-Priority sourcing, with a misleading `priority:low` label proven ignored;
- inversion fires on a doctrine board (AC#1);
- both degradation paths return `{}` and warn.

Board is injected for testability — duck typing sidesteps the dual-import-path gotcha (see conftest docstring).

## Validation
- `ruff` + `mypy --strict` clean; **693 unit tests pass**.
- Live smoke against `brockamer/jared`: `fetch_field_priorities` returns 13 field-sourced priorities (e.g. #316 High, #310 Low) — confirming the "none" result is now genuinely *earned*, not the empty-dict bug.
- Consumer-path check: `/jared-groom`/`/jared-reshape` invoke with `--repo <owner>/<repo>`, matching the board doc's `Repo:` (`owner/name`) — production hits the happy path, not the silent-disable guard.

## Acceptance criteria
- [x] `find_priority_inversions` operates on field-sourced Priority and can flag a real inversion on a doctrine board.
- [x] No reliance on `priority:` labels remains in `dependency-graph.py`.
- [x] `ruff` + `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)