### PR TITLE
fix(board): guard compute_velocity against silent --limit truncation (#303)

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -1691,6 +1691,14 @@ def compute_velocity(
     from statistics import median
 
     cutoff = (dt.datetime.now(dt.UTC) - dt.timedelta(days=days)).strftime("%Y-%m-%d")
+    # Guard against silent truncation: gh caps the result at --limit. An at-limit
+    # count means the window almost certainly overflowed, so the medians (and the
+    # milestone dates they anchor in /jared-audit) would compute over a capped
+    # snapshot and undercount velocity. Raise rather than trust it — mirrors
+    # GitHubProjectsProvider.recently_closed's guard (same limit). 200 sits well
+    # clear of this repo's real cadence (~90 closed / ~70 merged per 14d window),
+    # so it fires only on a genuine velocity anomaly, not the common path.
+    limit = 200
     issues_args = [
         "issue",
         "list",
@@ -1703,9 +1711,15 @@ def compute_velocity(
         "--json",
         "number,createdAt,closedAt",
         "--limit",
-        "100",
+        str(limit),
     ]
     closed = run_gh(issues_args, cache=cache) or []
+    if len(closed) == limit:
+        raise GhInvocationError(
+            f"gh issue list --state closed returned exactly {limit} items "
+            f"in the last {days}d — likely truncated. Velocity would undercount; "
+            f"narrow the window or paginate. Do not trust this snapshot."
+        )
 
     prs_args = [
         "pr",
@@ -1719,9 +1733,15 @@ def compute_velocity(
         "--json",
         "number,createdAt,mergedAt",
         "--limit",
-        "100",
+        str(limit),
     ]
     merged = run_gh(prs_args, cache=cache) or []
+    if len(merged) == limit:
+        raise GhInvocationError(
+            f"gh pr list --state merged returned exactly {limit} items "
+            f"in the last {days}d — likely truncated. Velocity would undercount; "
+            f"narrow the window or paginate. Do not trust this snapshot."
+        )
 
     def _days_between(start: str, end: str) -> float:
         s = dt.datetime.fromisoformat(start.replace("Z", "+00:00"))

--- a/tests/test_cmd_audit.py
+++ b/tests/test_cmd_audit.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from skills.jared.scripts.lib.board import compute_velocity
+from skills.jared.scripts.lib.board import GhInvocationError, compute_velocity
 from tests.conftest import patch_gh_by_arg
 
 EMPTY_BLOCKED_BY_PAYLOAD = json.dumps(
@@ -109,6 +109,61 @@ def test_compute_velocity_pr_duration(monkeypatch: pytest.MonkeyPatch) -> None:
     velocity = compute_velocity("brockamer/jared")
 
     assert velocity["median_pr_duration_days"] == 2.0
+
+
+def test_compute_velocity_raises_when_closures_hit_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A closed-issue list returned at exactly the gh --limit is treated as
+    truncated: compute_velocity raises rather than compute medians over a
+    silently-capped snapshot. Undercounting velocity skews proposed milestone
+    dates conservative — against this repo's documented aggressive-date pref.
+
+    The fixture size (200) must match the `--limit` in compute_velocity.
+    """
+    closed_at_limit = json.dumps(
+        [
+            {
+                "number": n,
+                "createdAt": "2026-05-10T00:00:00Z",
+                "closedAt": "2026-05-20T00:00:00Z",
+            }
+            for n in range(200)
+        ]
+    )
+    patch_gh_by_arg(
+        monkeypatch,
+        {"--state closed": closed_at_limit, "pr list": "[]"},
+    )
+
+    with pytest.raises(GhInvocationError, match="truncat"):
+        compute_velocity("brockamer/jared")
+
+
+def test_compute_velocity_raises_when_prs_hit_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The merged-PR list is guarded identically to the closed-issue list:
+    an at-limit result is treated as truncated and raises. Closed issues come
+    back under-limit here so the PR path is the one exercised.
+    """
+    merged_at_limit = json.dumps(
+        [
+            {
+                "number": n,
+                "createdAt": "2026-05-18T00:00:00Z",
+                "mergedAt": "2026-05-20T00:00:00Z",
+            }
+            for n in range(200)
+        ]
+    )
+    patch_gh_by_arg(
+        monkeypatch,
+        {"--state closed": "[]", "pr list": merged_at_limit},
+    )
+
+    with pytest.raises(GhInvocationError, match="truncat"):
+        compute_velocity("brockamer/jared")
 
 
 def test_fetch_audit_window_count_returns_oldest_first(


### PR DESCRIPTION
Closes #303.

## What

`compute_velocity` listed closed issues and merged PRs at a hardcoded `--limit 100` with no truncation guard, unlike its sibling `GitHubProjectsProvider.recently_closed`. When closures (or merges) in the window exceed the limit, `gh` caps the result silently and the medians compute over a truncated set — **undercounting velocity and skewing the milestone due-dates it anchors in `/jared-audit` conservative**, against this repo's documented aggressive-date preference.

This hoists the limit to one local (so the `--limit` arg and the guard check can't drift) and raises `GhInvocationError` when either list comes back at exactly the limit, mirroring `recently_closed`.

## Why limit = 200, not 100

The issue body said "add the same guard." I measured live cadence before committing to a value: **~87 closed / ~72 merged per 14d window** on this repo. With `limit=100` the closed-issue headroom is only ~13 — at ~6 closures/day the guard would trip on the **common path within days**, converting a silent undercount into a hard error. `200` matches the sibling, sits clear of real cadence, and fires only on a genuine velocity anomaly — exactly when the snapshot *should* be distrusted.

## Caller degradation (verified)

A raised `GhInvocationError` is caught by the CLI's top-level handler (`main`), which surfaces it as a clean, actionable stderr line (`jared: ... narrow the window or paginate`) and exit 1 — **no stack trace**. For the audit, where velocity is load-bearing (feeds default-staleness), failing cleanly with guidance is the correct degradation; the operator re-runs with a narrower window rather than getting a silently-wrong anchor.

## Tests

Two TDD tests cover the at-limit closed-issue and merged-PR paths (RED→GREEN verified), pinning the message with `match="truncat"` per the repo's truncation-guard test convention (`test_board_open_items.py`, `test_sweep_checks.py`).

## Acceptance criteria
- [x] `compute_velocity` raises instead of silently truncating at the limit
- [x] A unit test exercises the at-limit path (both `gh` calls)
- [x] `ruff` + `mypy --strict` clean; full suite **702 passed**

## Validation
- `pytest` → 702 passed, 1 deselected (integration)
- `ruff check .` → clean · `mypy` → clean (66 files)
- Adversarial multi-agent review of the diff (3 dimensions + skeptic verification) surfaced one confirmed finding (missing `match=`), now applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)