### PR TITLE
chore(reshape): milestone date doctrine + archive shipped Phase 2/3 plans

### DIFF
--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -95,18 +95,18 @@ Conventions:
 - **A one-sentence deliverable is required.** Put it in the milestone description.
   If you can't write the sentence that proves the milestone is done, it's a bag of
   issues, not a phase.
-- **Dates are optional.** A hard due date on a steady-state phase manufactures false
-  urgency. Add a soft target only if you want the Roadmap view to render a timeline.
+- **Carry a compressed soft target date.** Set a soft due date aligned to the repo's
+  actual cadence — this board ships fast, so calendar-conservative dates are themselves
+  drift. The date is a target, not a contract: it drives the Roadmap view and signals
+  intended sequencing. A genuinely externally-paced phase is the exception — flag it
+  rather than padding the date.
 
-**Surfacing the phase.** Group a **Table** or **Board** view by Milestone (view tab
-dropdown → Group by → Milestone) to see the active phase's items under one header.
-This is the dateless-compatible roadmap surface and matches the conventions above.
-
-Do **not** reach for GitHub's **Roadmap** view layout here: it is a date-driven
-Gantt timeline that plots bars only from date fields or a milestone *with a due date*.
-Because this board's milestones are intentionally dateless, a Roadmap view renders an
-empty timeline. Roadmap is the right layout only if you choose to add per-item target
-dates — which reintroduces the date-pinning the conventions above deliberately avoid.
+**Surfacing the phase.** Because milestones carry soft target dates, GitHub's
+**Roadmap** view layout renders a credible near-term timeline — it plots bars from the
+milestone due dates. For the at-a-glance checklist, group a **Table** or **Board** view
+by Milestone (view tab dropdown → Group by → Milestone) to see the active phase's items
+under one header. The Roadmap is the timeline; the grouped view is the checklist — both
+are valid surfaces.
 
 ## Labels
 

--- a/docs/superpowers/plans/archived/2026-06/2026-06-02-kanbanflow-rest-client.md
+++ b/docs/superpowers/plans/archived/2026-06/2026-06-02-kanbanflow-rest-client.md
@@ -1,4 +1,12 @@
+---
+**Shipped in #315 on 2026-06-03. Final decisions captured in issue body.**
+---
+
 # KanbanFlow REST client (#315, Phase 2) Implementation Plan
+
+## Issue
+
+- #315
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/superpowers/plans/archived/2026-06/2026-06-03-kanbanflow-provider.md
+++ b/docs/superpowers/plans/archived/2026-06/2026-06-03-kanbanflow-provider.md
@@ -1,4 +1,12 @@
+---
+**Shipped in #316 on 2026-06-03. Final decisions captured in issue body.**
+---
+
 # KanbanFlowProvider (Phase 3) Implementation Plan
+
+## Issue
+
+- #316
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 


### PR DESCRIPTION
Git-tracked half of the 2026-06-03 structural review (`/jared-reshape`). The board-side reshape (milestone, assignments, priority, dependency edges, epic checklist) was applied via the GitHub API and is already live; this PR carries only the repo changes.

## What's changed

**Doctrine**
- `project-board.md` milestone convention: date guidance moves from *"dateless by default"* to *"compressed soft target aligned to repo velocity"* — matches shipped `v0.21`/`v0.22`/`Phase 2` practice and the repo's fast cadence. The Roadmap-view guidance is reconciled accordingly (milestones now carry dates, so the Roadmap layout renders rather than showing an empty timeline). Theme-only milestone naming rule **recommitted** (unchanged — the `v0.x —` hybrids were the drift).

**Refactor / hygiene**
- Archive the two shipped KanbanFlow plans to `archived/2026-06/`: `2026-06-02-kanbanflow-rest-client.md` (#315, Phase 2) and `2026-06-03-kanbanflow-provider.md` (#316, Phase 3). Each was missing the `## Issue` back-reference section — the orphaned-plan drift `sweep.py` flagged — which is added here (also what the archiver keys on). The abstraction *spec* is intentionally left in place: phases 4–6 still reference it.

## Validation
- `pytest` — 743 passed, 1 deselected.
- `jared summary` parses the edited `project-board.md` cleanly (field block untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)