### PR TITLE
docs: reconcile command inventories + document add-to-board (#301, #302)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jared",
-  "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-groom, /jared-reshape, /jared-start, /jared-wrap, /jared-init.",
+  "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-start, /jared-stage, /jared-groom, /jared-audit, /jared-reshape, /jared-wrap, /jared-init.",
   "version": "0.28.0",
   "author": {
     "name": "Daniel Brock"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The batch scripts (`sweep.py`, `bootstrap-project.py`, `archive-plan.py`, `captu
 Any board operation picks the highest-precision tool available at runtime:
 
 1. **MCP first.** If the GitHub MCP server is loaded, prefer its typed tools for issues/projects. Conversational code should check `tool_search` before shelling out.
-2. **`jared` CLI second.** `skills/jared/scripts/jared` is a Python entry point (argparse) that orchestrates the multi-step GitHub operations that are error-prone to stitch together by hand — `file`, `move`, `set`, `close`, `comment`, `blocked-by`, `get-item`, `summary`. Each subcommand owns an invariant (e.g., `file` guarantees "issue on board AND Status set" atomically; `close` verifies auto-move to Done and falls back to explicit Status=Done).
+2. **`jared` CLI second.** `skills/jared/scripts/jared` is a Python entry point (argparse) that orchestrates the multi-step GitHub operations that are error-prone to stitch together by hand. The core surface is `file`, `move`, `set`, `close`, `comment`, `blocked-by`, `get-item`, `summary`, plus internal/automation helpers (`add-to-board`, `ties`, `next-session-prompt`, `wrap-state`, `session-resolve`, `session-lock-write`, `session-lock-clear`, `worktree-add`, `propose-partition`, `audit`) — ~18 subcommands in all. Each subcommand owns an invariant (e.g., `file` guarantees "issue on board AND Status set" atomically; `close` verifies auto-move to Done and falls back to explicit Status=Done).
 3. **Raw `gh` CLI fallback.** Documented in `skills/jared/references/operations.md` for cases the CLI doesn't cover.
 
 Python subprocesses can't call MCP tools, so batch scripts (`sweep.py` et al.) use `gh` directly. That's deliberate — interactive conversations choose MCP; batch jobs use `gh`.
@@ -86,8 +86,8 @@ These aren't just docs — the CLI validates them:
 
 ```
 .claude-plugin/           plugin.json + marketplace.json (self-hosted single-plugin marketplace)
-commands/                 Slash-command stubs (/jared, /jared-file, /jared-groom, /jared-init,
-                          /jared-reshape, /jared-stage, /jared-start, /jared-wrap)
+commands/                 Slash-command stubs (/jared, /jared-audit, /jared-file, /jared-groom,
+                          /jared-init, /jared-reshape, /jared-stage, /jared-start, /jared-wrap)
 skills/jared/
   SKILL.md                The skill contract — what Jared is, when to trigger, the discipline
   references/             Loaded on demand: operations.md, structural-review.md, board-sweep.md,

--- a/skills/jared/references/jared-cli.md
+++ b/skills/jared/references/jared-cli.md
@@ -210,6 +210,43 @@ leaves the issue in place for a human to reconcile.
 
 ---
 
+## `jared add-to-board <issue_number> --priority ... [--status ...] [--label ...] [--field ...]`
+
+**Purpose.** Add an *existing* issue to the board and set its required fields —
+Priority + Status (+ any extra single-select fields). Idempotent, so it is safe
+to re-run. Two uses: the **recovery path** when `jared file` fails *after* the
+issue is created (the issue exists but never made it onto the board), and a
+**standalone** add for issues created outside `jared file` (e.g. `gh issue
+create`, or an issue opened in the GitHub UI).
+
+```
+# Recovery / standalone add with the required Priority:
+jared add-to-board 42 --priority High
+
+# Land it directly in a column, with labels and an extra field:
+jared add-to-board 42 --priority Medium --status "Up Next" \
+  --label enhancement --field "Work Stream=Planning"
+```
+
+**Arguments:**
+
+| Flag | Required | Notes |
+|---|---|---|
+| `issue_number` | yes | Positional. The existing issue to add to the board. |
+| `--priority {High,Medium,Low}` | yes | Enforced — an issue added without Priority sorts to the bottom with null Status and effectively disappears. |
+| `--status` | no | Any Status column. Default: `Backlog`. |
+| `--label` | no | Repeatable issue label. |
+| `--field` | no | Repeatable `NAME=VALUE` for additional single-select fields (e.g. `Work Stream=Planning`). |
+
+**Why it exists.** `jared file` is create + add + set-fields as one atom; if it
+fails *after* the GitHub issue is created, the issue is stranded off the board.
+`add-to-board` is the idempotent re-entry point that finishes the job — which is
+why `sweep.py` and `references/board-sweep.md` hand it to the operator as
+paste-able recovery copy. It takes no `--milestone` flag; milestone assignment
+lives on `jared file` (or raw `gh issue edit --milestone`).
+
+---
+
 ## `jared blocked-by <dependent> <blocker> [--remove]`
 
 **Purpose.** Add or remove a native GitHub `blockedBy` edge between two


### PR DESCRIPTION
Bundles two docs-honesty items from the **Optimization & hardening** milestone — both are "keep the docs Claude reads honest" work, and both touch the command-surface inventories.

## #301 — command inventories agree
- `plugin.json` description and the `CLAUDE.md` Layout list now enumerate **all 9** slash commands (previously omitted `/jared-stage` + `/jared-audit` and `/jared-audit` respectively). README ↔ plugin.json ↔ CLAUDE.md now agree.
- `CLAUDE.md:48` softened: the 8-item CLI list now reads as the **core** surface, with internal/automation helpers named and a "~18 subcommands in all" clause, so it no longer implies exhaustiveness.

## #302 — add-to-board reference
- `references/jared-cli.md` gains a `## jared add-to-board` section, placed beside `jared file` (its documented recovery path), in the existing section format.

> [!IMPORTANT]
> **AC correction (please ratify at merge).** #302's acceptance criterion named flags `--priority/--status/--label/--milestone`. The shipped `add-to-board` subcommand has **no `--milestone` flag** — it has `--field` (repeatable `NAME=VALUE`). Documenting `--milestone` would have shipped exactly the doc-inaccuracy this milestone exists to kill, so I documented the **real** flags (`--priority/--status/--label/--field`) and noted that milestone assignment lives on `jared file`. The work satisfies #302's intent (reference completeness) over its literal-but-wrong wording.

## Verification
- All three inventories resolve to the identical 9-command set (scripted check, not eyeballed).
- Confirmed `marketplace.json` and `SKILL.md` carry no slash-command enumeration — the three-file scope is complete, nothing else drifts.
- `add-to-board` documented flags match the argparse parser exactly (`scripts/jared:223-247`).
- Full unit suite: **743 passed, 1 deselected**.

## Drift note
#301's body cited `CLAUDE.md:87-88` for the Layout list; the #321/#324 edits shifted it to `:89-90`. Scope intact — only the line anchor moved.

Closes #301
Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)