### PR TITLE
feat(jared): shared-new-module guard for parallel sessions (#332)

### DIFF
--- a/commands/jared-stage.md
+++ b/commands/jared-stage.md
@@ -66,27 +66,36 @@ Flow:
 
 2. **Capture stdout.** The CLI emits a per-session block showing `keep` (existing labels honored) and `add` (no existing label, partition proposes one), plus a `floats` block for candidates with no surface signal.
 
-3. **Display verbatim, voice-wrapped:**
+3. **Run the shared-new-module scan (conversational).** Before displaying, read the candidate bodies — the `floats` especially — and flag any pair that describes building the **same not-yet-existing module** in prose, even though neither cites a path (so the deterministic partitioner floated them apart). This is your judgment, not the CLI's; see **Shared-new-module scan** below. Render hits as a sub-block mirroring the `[llm, <label>]` shape. Empty is the common, expected answer.
+
+4. **Display verbatim, voice-wrapped:**
 
    > Looking at the partition for sessions 1 and 2 — here's what I'd propose based on file paths in the issue bodies:
    >
    > [verbatim CLI output]
    >
+   > [if the scan found anything, append:]
+   >
+   > Shared-new-module (advisory):
+   >   #984 ↔ #985 [llm, shared-new-module]   both describe a "probe helper" neither body cites as a path
+   >
    > Approve? (`y` to apply all additions / `edit #N session=K` to override / `skip` to leave everything as-is)
 
-4. **On `y`:** apply each `add` assignment with:
+5. **On `y`:** apply each `add` assignment with:
 
    ```bash
    gh issue edit <N> --add-label session-K --repo <owner>/<repo>
    ```
 
-5. **On `edit #N session=K`:** apply the operator's override for that issue, then continue applying the remaining `add` entries.
+6. **On `edit #N session=K`:** apply the operator's override for that issue, then continue applying the remaining `add` entries.
 
-6. **On `skip`:** do nothing; the partition is unchanged.
+7. **On `skip`:** do nothing; the partition is unchanged.
 
 **Honoring existing labels.** The partition algorithm never overrides an existing `session-N` label. To re-balance, the operator removes the label manually and re-runs `/jared-stage --sessions N`.
 
 **Single signal.** v1 uses only file paths cited in issue bodies. Two candidates whose bodies share a path are presumed to touch overlapping code. Issues with no paths in their body float (no label proposed) — they appear in the `floats` block for manual assignment.
+
+**Shared-new-module scan (conversational, #332).** The single deterministic signal is blind to a module that doesn't exist yet: when two candidates will both *create* the same new file, neither body cites its path, so both float and the partitioner scatters them across sessions. The duplicate then surfaces only as an add/add conflict at `/jared-wrap`, or a conflicting PR after one session's precursor merges. Because the active session already holds the candidate bodies, catch it here in conversation (step 3) rather than in a Python subprocess — read the `floats` for pairs whose prose describes the same not-yet-existing module (e.g. both say "a shared probe helper"), and surface them with the `[llm, shared-new-module]` tag. On a hit, the operator co-locates the pair into one session or extracts the module precursor-first. See `references/parallel-sessions.md` § "Same new module" for the remedies and the full rationale.
 
 ## Flags
 

--- a/commands/jared-start.md
+++ b/commands/jared-start.md
@@ -120,6 +120,7 @@ Flow:
 
    - **possibly-already-done** — another issue substantially covers the target's scope. Look at recent closures (last 7 days surfaced by `jared next-session-prompt`) and the active Backlog.
    - **semantic-overlap** — another open issue covers meaningfully overlapping scope (not merely milestone-mate or shared-label adjacency — those are deterministic-tier signals already covered).
+   - **shared-new-module** — another in-flight or staged issue describes building the same *new* module/file that neither body cites as a path yet, so the cohesion-first partitioner can't co-locate them. Distinct from semantic-overlap: the two issues may be entirely different features that nonetheless collide on a shared helper. Most relevant under parallel sessions; the remedy is to co-locate the pair into one session or extract the module precursor-first with `blocked-by` edges. See `references/parallel-sessions.md` § "Same new module".
 
    When something stands out, render it in a separate sub-block after the deterministic ties, mirroring the deterministic block's `[<confidence>, <label>]` shape with `llm` as the confidence tier:
 
@@ -127,9 +128,10 @@ Flow:
    Semantic ties (advisory):
      #N [llm, semantic-overlap]   <one-line rationale>
      #M [llm, possibly-already-done]   <one-line rationale>
+     #K [llm, shared-new-module]   both describe a new "<helper>" neither body cites as a path
    ```
 
-   Be strict — empty is the right and expected answer when nothing semantic stands out. The `llm` confidence value exists in `lib/ties.py`'s `Confidence` literal precisely so this prose-rendered tag stays consistent with the deterministic block's tagging convention.
+   Be strict — empty is the right and expected answer when nothing semantic stands out. The `llm` confidence value exists in `lib/ties.py`'s `Confidence` literal precisely so this prose-rendered tag stays consistent with the deterministic block's tagging convention; `shared_new_module` is a member of the `SignalName` literal for the same reason (#332).
 
    This intentionally lives in the conversational layer rather than as a Python LLM call inside `jared ties`. The active Claude session already has the full context; spending API tokens on a fresh subprocess to redo work the conversation can do natively is duplicative. See `references/llm-assistance.md` (when filed per #123) for the broader doctrine on LLM-in-CLI vs LLM-in-conversation.
 

--- a/skills/jared/references/parallel-sessions.md
+++ b/skills/jared/references/parallel-sessions.md
@@ -156,6 +156,40 @@ its argparse block), lift *that* region into a focused module as part of that
 issue's work. The monolith shrinks where it's hottest, with no dedicated
 big-bang split — which would itself be the kind of sprawl this project avoids.
 
+### Same new module: two sessions creating the same file
+
+The concession above is about an *existing* hot file. A sharper, harder-to-see
+variant is two in-flight or staged issues that will both create the **same new**
+module. The cohesion-first partitioner (`scripts/lib/partition.py`) can't
+co-locate them, because the path is in *neither* body yet — it doesn't exist, so
+both issues float (no surface signal) and scatter across sessions by load. The
+duplicate then surfaces only as an add/add merge conflict at `/jared-wrap`, or
+worse, as a conflicting PR after a sibling's precursor merges mid-session.
+(Motivating scar: findajob #984 / #985 both hand-built the same probe helper;
+the precursor that owned it, PR #1023, was created ~50h *after* the consumers,
+so no shared path and no `blocked-by` edge existed at staging time.)
+
+Two remedies, in preference order, for when you **recognize** the shared module:
+
+- **Precursor-first (preferred).** File the shared module as its own precursor
+  issue and add native `blocked-by` edges from the consumers. This is the only
+  remedy that yields a *mechanical* guard: `stage.has_no_open_blockers`
+  sequences the precursor first, and the consumers inherit the built module
+  instead of racing to create it.
+- **Name-the-path (lighter fallback).** If you can already name the concrete
+  file path, cite it in *both* consumer bodies. The cohesion-first partitioner
+  then co-locates them into one session automatically — no precursor issue
+  needed.
+
+The common case, though, is the one the episode's timing shows: you *didn't*
+foresee the shared module, so neither remedy was applied at filing. The net for
+that is a conversational **`shared-new-module` tie** — when two in-flight/staged
+bodies describe building the same not-yet-existing module in prose, `/jared-stage`
+and `/jared-start` surface the pair (advisory, `[llm, shared-new-module]`), and
+the operator co-locates them or applies a remedy retroactively. The scan is the
+only signal that fires at the decisive moment, because it reads prose, not paths
+or edges — see `/jared-stage` and `/jared-start` step 6 for where it runs.
+
 ## Triggers for the worktree default
 
 - Operator explicitly says "the other session is working #X, you start #Y."

--- a/skills/jared/scripts/lib/ties.py
+++ b/skills/jared/scripts/lib/ties.py
@@ -27,6 +27,11 @@ SignalName = Literal[
     # the announce so deterministic and semantic ties don't cross-contaminate.
     "possibly_already_done",
     "semantic_overlap",
+    # Same new module two in-flight/staged issues both describe building a
+    # not-yet-existing module/file that neither body cites as a path, so the
+    # cohesion-first partitioner can't co-locate them (#332). Conversational
+    # only — surfaced at /jared-stage and /jared-start, never computed here.
+    "shared_new_module",
 ]
 Confidence = Literal["strong", "medium", "weak", "llm"]
 # Threshold and Confidence model different roles (filter cutoff vs. signal
@@ -62,6 +67,7 @@ _SIGNAL_PRIORITY: dict[SignalName, int] = {
     "labels": 5,
     "possibly_already_done": 6,
     "semantic_overlap": 7,
+    "shared_new_module": 8,
 }
 
 # Score cap so a single candidate firing every signal doesn't dominate sorting.
@@ -417,6 +423,7 @@ _RELATIONSHIP_LABELS: dict[SignalName, str] = {
     # LLM-overlay labels mirror the SignalName for clarity in rendered output.
     "possibly_already_done": "possibly-already-done",
     "semantic_overlap": "semantic-overlap",
+    "shared_new_module": "shared-new-module",
 }
 
 


### PR DESCRIPTION
## What & why

Two in-flight/staged issues that both create the **same new module** collide late — an add/add conflict at `/jared-wrap`, or a conflicting PR after a sibling's precursor merges. The cohesion-first partitioner can't co-locate them because the path is in *neither* body yet (it doesn't exist), so both float and scatter across sessions by load. Motivating scar: findajob #984/#985 both hand-built the same probe helper; the precursor that owned it (PR #1023) landed ~50h *after* the consumers, so no shared path and no `blocked-by` edge existed at staging time.

## Direction A — doctrine + conversational

Chose the lightest altitude over deterministic lint (B) or lock-scope enforcement (C). The decisive constraint: at the moment the collision is preventable, the only signal present is **prose**, so anything keyed on literal paths or native edges is structurally incapable of catching it. Full rationale recorded in #332's `## Decisions`.

**Changes:**
- **`references/parallel-sessions.md`** — new "Same new module" subsection: two remedies (precursor-first preferred — the only *mechanical* guard via `blocked-by`; name-the-path as the lighter co-location fallback), plus the conversational tie as the net for the un-foreseen common case.
- **`commands/jared-stage.md`** — a `shared-new-module` scan over the `floats` bodies at staging, the collision's birth-point, surfaced *before* session assignment.
- **`commands/jared-start.md`** — `shared-new-module` as a third semantic-ties shape (step 6), the last line of defense.
- **`lib/ties.py`** — `shared_new_module` added to `SignalName` / `_SIGNAL_PRIORITY` / `_RELATIONSHIP_LABELS` for prose-tag type-consistency with the existing two LLM-overlay shapes. Not a parsed field — conversational only.

## Non-goals (deliberately not built)
No `claimed_paths` on the session `Lock`, no deterministic float-pair token-matcher, no LLM-in-CLI call, no separate `references/llm-assistance.md` (that's #123). Matches the doctrine-default discipline (CLAUDE.md § "Evolving Jared's discipline").

## Validation
`ruff check` clean · `ruff format` clean · `mypy --strict` success (71 files) · `pytest` 743 passed.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)