### PR TITLE
feat(317): init-time backend selection — KanbanFlow (Phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,13 @@ Python subprocesses can't call MCP tools, so batch scripts (`sweep.py` et al.) u
 
 **Board-provider abstraction (Phase 1, #314).** Board operations now go through a backend-neutral `BoardProvider` contract (`lib/board_provider.py`): semantic methods (`get_item`, `list_open_items`, `file`, `set_field`, `move`, `close`, `comment`, `add_blocked_by`, `set_milestone`, …) that speak the stable integer `IssueRef` and neutral dataclasses (`BoardItem`, `Edge`, `Milestone`, `ClosedItem`) — provider-internal IDs (GitHub node-ids, KanbanFlow `_id`) never cross the boundary. `GitHubProjectsProvider` (`lib/github_provider.py`) is the sole implementation; all `gh`/GraphQL/`field_id`/`option_id` live private inside it. `Board` is now the **config-parsing facade**: it parses `docs/project-board.md`, reads the `- backend:` selector (default `github`), and exposes `board.provider`. New CLI subcommands should call `board.provider.<method>` — the CLI file is free of raw `run_gh`/`field_id`/`option_id`. (The module-level `run_gh`/`run_gh_raw`/`run_graphql` in `board.py` remain the subprocess seam the provider and batch scripts route through.) Phase-1 boundary: a few batch/analytic surfaces still use `Board` methods directly — `sweep.py`/`stage.py` (`open_items`/`board_items`), `_cmd_ties`/`_cmd_propose_partition` (`fetch_open_issues_for_ties`). Those migrate when the KanbanFlow provider lands (epic #313, Phases 2–6).
 
+A KanbanFlow-backed `docs/project-board.md` carries `- backend: kanbanflow`, a `Repo:`
+bullet, a `Board ID:` / `Board URL:`, and a `### Status column map` block (canonical
+Status → the board's actual column name); it omits the GitHub Project identifiers and
+field/option-ID blocks (the provider resolves columns/options live from the API, with the
+board-scoped `KANBANFLOW_API_TOKEN` selecting the board). Init-time selection landed in #317
+(Phase 4 of epic #313).
+
 ## Dual import path — important gotcha
 
 The `Board` module is imported via two different paths in the same process tree:

--- a/commands/jared-init.md
+++ b/commands/jared-init.md
@@ -19,11 +19,22 @@ Flow:
 
    Wait for the user to respond before proceeding.
 
-2. **Run `${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/bootstrap-project.py`.**
-   ```bash
-   ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/bootstrap-project.py --url <project-url> --repo <owner>/<repo>
-   ```
-   This introspects the board's fields and emits `docs/project-board.md` with IDs filled in. For a fresh project, offers to create Status and Priority. Work Stream is optional — useful when the project has multiple distinct categories of work; skipped when it doesn't. For an existing convention doc, shows a diff.
+2. **Choose the backend, then run `bootstrap-project.py`.** Ask the operator
+   (voice ON — first impression): *GitHub Projects or KanbanFlow?*
+
+   - GitHub (default):
+     ```
+     ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/bootstrap-project.py --backend github --url <project-url> --repo <owner>/<repo>
+     ```
+   - KanbanFlow (requires `KANBANFLOW_API_TOKEN` in env; the board-scoped token
+     selects the board, so no `--url`). The script interviews the operator to map
+     jared's Status columns onto the board's existing columns:
+     ```
+     ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/bootstrap-project.py --backend kanbanflow --repo <owner>/<repo>
+     ```
+   Script output (including the column interview) stays voice-OFF / verbatim.
+
+   For **GitHub**, this introspects the board's fields and emits `docs/project-board.md` with IDs filled in. For a fresh project, offers to create Status and Priority. Work Stream is optional — useful when the project has multiple distinct categories of work; skipped when it doesn't. For an existing convention doc, shows a diff. For **KanbanFlow**, there are no field IDs to introspect: the script validates that a `Priority` dropdown (High/Medium/Low) exists, interviews to map Status columns, and writes the slim `### Status column map` doc — secrets stay in `KANBANFLOW_API_TOKEN`, never the doc.
 
    If the existing `docs/project-board.md` predates the machine-readable bullet block (URL only in a markdown link, Project ID in a code fence, no `- Project URL:` / `- Project number:` / `- Owner:` / `- Repo:` bullets), the script enters **patch mode**: it proposes inserting just the bullet block near the top of the file, preserving all prose and custom sections verbatim. See `references/new-board.md` → "Upgrading an older project-board.md".
 

--- a/docs/superpowers/plans/2026-06-04-phase4-init-backend-selection.md
+++ b/docs/superpowers/plans/2026-06-04-phase4-init-backend-selection.md
@@ -1,0 +1,881 @@
+# Phase 4 — Init-time Backend Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make jared's board backend selectable at `jared init` and make a KanbanFlow-backed `docs/project-board.md` parse and run, adapting to a board's existing columns via a Status→column map rather than mutating board structure.
+
+**Architecture:** Three pieces. (C-provider) `KanbanFlowProvider` gains a `status_column_map` applied at construction so all Status↔column translation is map-aware. (C-parse) `Board._parse` reads `backend` before validating required fields and validates per-backend. (A+B) `bootstrap-project.py` gains `--backend` and a read-only KanbanFlow bootstrap that maps columns (auto + interview), validates Priority, and writes a slim doc. Spec: `docs/superpowers/specs/2026-06-04-phase4-init-backend-selection-design.md`.
+
+**Tech Stack:** Python 3, argparse, stdlib-only KanbanFlow client (Phase 2/3), pytest, ruff, mypy --strict. Tests use `tests/fake_kanbanflow.py::FakeKanbanFlowClient` (no network).
+
+---
+
+## File Structure
+
+- `skills/jared/scripts/lib/kanbanflow_provider.py` — add `status_column_map` + `expected_board_id` to `KanbanFlowProvider.__init__`; build Status-keyed lookup dicts; route all translation sites through them. (Task 1)
+- `skills/jared/scripts/lib/board.py` — make GitHub-only dataclass fields optional; add `status_column_map` + `board_id` fields; reorder `_parse` to read `backend` first; backend-aware required-field validation; add `_parse_status_column_map`; pass map + board id into the KanbanFlow provider. (Task 2)
+- `skills/jared/scripts/bootstrap-project.py` — add `--backend`, make `--url` conditional, add the KanbanFlow bootstrap path (validate + interview + render). (Tasks 3, 4)
+- `commands/jared-init.md` — ask the backend and dispatch. (Task 5)
+- `CLAUDE.md` — note the KanbanFlow doc shape. (Task 5)
+- Tests: `tests/test_kanbanflow_provider.py` (Task 1), `tests/test_board.py` (Task 2), `tests/test_bootstrap_noninteractive.py` + new `tests/test_bootstrap_kanbanflow.py` (Tasks 3, 4).
+
+---
+
+## Task 1: Provider — `status_column_map` + Status-keyed translation
+
+**Files:**
+- Modify: `skills/jared/scripts/lib/kanbanflow_provider.py` (`__init__` ~94–110; `_column_id` ~117–123; `_item_from_task` ~172; `list_open_items` ~224; `close` ~351)
+- Test: `tests/test_kanbanflow_provider.py`
+
+- [ ] **Step 1: Write the failing test (non-identity Done mapping is the regression guard)**
+
+Add to `tests/test_kanbanflow_provider.py`:
+
+```python
+def _gtd_client() -> FakeKanbanFlowClient:
+    """A board whose columns are NOT jared's canonical names."""
+    from skills.jared.scripts.lib.kanbanflow_client import KfBoard, KfColumn, KfCustomFieldDef
+
+    board = KfBoard(
+        id="B1",
+        name="GTD",
+        columns=[
+            KfColumn(unique_id="c-someday", name="Someday"),
+            KfColumn(unique_id="c-soon", name="Planned Soon"),
+            KfColumn(unique_id="c-now", name="Doing Now"),
+            KfColumn(unique_id="c-blk", name="Blocked"),
+            KfColumn(unique_id="c-complete", name="Complete"),  # Done renamed
+        ],
+    )
+    fields = [
+        KfCustomFieldDef(id="cf-priority", name="Priority", field_type="dropdown",
+                         dropdown_options=["High", "Medium", "Low"]),
+    ]
+    return FakeKanbanFlowClient(board=board, field_defs=fields)
+
+
+_GTD_MAP = {
+    "Backlog": "Someday",
+    "Up Next": "Planned Soon",
+    "In Progress": "Doing Now",
+    "Blocked": "Blocked",
+    "Done": "Complete",
+}
+
+
+def test_status_map_move_writes_mapped_column(tmp_path: Path) -> None:
+    client = _gtd_client()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    provider = KanbanFlowProvider(
+        client=client, board=client.board, field_defs=client.field_defs,
+        index=index, status_column_map=_GTD_MAP,
+    )
+    task = client.create_task(name="x", column_id="c-someday", number_value=5)
+    provider._index.put(5, task.id)
+    provider.move(5, "In Progress")
+    assert client.get_task(task.id).column_id == "c-now"
+
+
+def test_status_map_get_item_reports_canonical_status(tmp_path: Path) -> None:
+    client = _gtd_client()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    provider = KanbanFlowProvider(
+        client=client, board=client.board, field_defs=client.field_defs,
+        index=index, status_column_map=_GTD_MAP,
+    )
+    task = client.create_task(name="x", column_id="c-now", number_value=6)
+    provider._index.put(6, task.id)
+    assert provider.get_item(6).status == "In Progress"
+
+
+def test_status_map_list_open_excludes_mapped_done(tmp_path: Path) -> None:
+    # The regression guard: Done is mapped from "Complete". A task there must
+    # be excluded from open items. An identity Done->Done fake would pass even
+    # with the map unwired — this renamed-Done case is what proves the wiring.
+    client = _gtd_client()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    provider = KanbanFlowProvider(
+        client=client, board=client.board, field_defs=client.field_defs,
+        index=index, status_column_map=_GTD_MAP,
+    )
+    done_task = client.create_task(name="done", column_id="c-complete", number_value=7)
+    open_task = client.create_task(name="open", column_id="c-now", number_value=8)
+    nums = {it.number for it in provider.list_open_items()}
+    assert 8 in nums
+    assert 7 not in nums
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_kanbanflow_provider.py -k status_map -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'status_column_map'`.
+
+- [ ] **Step 3: Add the constant and rewrite the constructor's column plumbing**
+
+In `kanbanflow_provider.py`, add a module-level constant near the top (after imports):
+
+```python
+_CANONICAL_STATUSES = ("Backlog", "Up Next", "In Progress", "Blocked", "Done")
+```
+
+Change `__init__` to accept the new params and build Status-keyed dicts. Replace the four `self._column_*` / `self._swimlane_*` assignment lines' column portion:
+
+```python
+    def __init__(
+        self,
+        *,
+        client: KanbanFlowClientLike,
+        board: KfBoard,
+        field_defs: list[KfCustomFieldDef],
+        index: KfNumberIndex,
+        status_column_map: dict[str, str] | None = None,
+        expected_board_id: str | None = None,
+    ) -> None:
+        self._client = client
+        self._board = board
+        self._index = index
+        self._status_column_map = status_column_map or {}
+        # Raw board column maps — kept only for the "available columns" error message.
+        self._column_id_by_name = {c.name: c.unique_id for c in board.columns}
+        self._column_name_by_id = {c.unique_id: c.name for c in board.columns}
+        # Status-keyed maps — every Status<->column translation goes through these,
+        # so a renamed column (e.g. Done<-"Complete") stays correct on read AND write.
+        self._column_id_by_status: dict[str, str] = {}
+        self._status_by_column_id: dict[str, str] = {}
+        for status in _CANONICAL_STATUSES:
+            col_name = self._status_column_map.get(status, status)  # identity fallback
+            col_id = self._column_id_by_name.get(col_name)
+            if col_id is not None:
+                self._column_id_by_status[status] = col_id
+                self._status_by_column_id[col_id] = status
+        self._swimlane_id_by_name = {s.name: s.unique_id for s in board.swimlanes}
+        self._swimlane_name_by_id = {s.unique_id: s.name for s in board.swimlanes}
+        self._field_def_by_name = {d.name: d for d in field_defs}
+        self._field_name_by_id = {d.id: d.name for d in field_defs}
+        if expected_board_id is not None and board.id != expected_board_id:
+            print(
+                f"WARNING: KanbanFlow token points at board '{board.id}' but the doc "
+                f"records '{expected_board_id}'. Operating on '{board.id}'.",
+                file=sys.stderr,
+            )
+```
+
+Add `import sys` at the top of the file if not already present.
+
+- [ ] **Step 4: Route the three resolution sites through the Status-keyed dicts**
+
+`_column_id` (resolve a canonical Status to a column id):
+
+```python
+    def _column_id(self, status: str) -> str:
+        if status not in self._column_id_by_status:
+            available = ", ".join(sorted(self._column_id_by_name)) or "(none)"
+            raise FieldNotFound(
+                f"Status column for '{status}' not on the board. Available columns: {available}"
+            )
+        return self._column_id_by_status[status]
+```
+
+`_item_from_task` — change the `status=` line (~172) from `self._column_name_by_id.get(...)` to:
+
+```python
+            status=self._status_by_column_id.get(task.column_id) if task.column_id else None,
+```
+
+`list_open_items` — change the Done lookup (~224) from `self._column_id_by_name.get("Done")` to:
+
+```python
+        done_id = self._column_id_by_status.get("Done")
+```
+
+(`close()` at ~351 already calls `self._column_id("Done")`, so it is now map-aware with no further change.)
+
+- [ ] **Step 5: Run the new tests + the full provider suite**
+
+Run: `pytest tests/test_kanbanflow_provider.py -v`
+Expected: PASS — new `status_map` tests pass AND all pre-existing tests still pass (they use a canonically-named fake board, so identity mapping reproduces prior behavior).
+
+- [ ] **Step 6: Type-check and commit**
+
+Run: `mypy && ruff check skills/jared/scripts/lib/kanbanflow_provider.py`
+Expected: clean.
+
+```bash
+git add skills/jared/scripts/lib/kanbanflow_provider.py tests/test_kanbanflow_provider.py
+git commit -m "feat(316): KanbanFlowProvider status_column_map + board-id verify (Phase 4.1)"
+```
+
+---
+
+## Task 2: Board — backend-aware parse + status map + provider wiring
+
+**Files:**
+- Modify: `skills/jared/scripts/lib/board.py` (dataclass fields ~62–86; `_parse` ~129–213; add `_parse_status_column_map`; `provider` property ~394–425)
+- Test: `tests/test_board.py`
+
+- [ ] **Step 1: Write the failing tests (a KanbanFlow doc parses; a broken one fails; GitHub still works)**
+
+Add to `tests/test_board.py`:
+
+```python
+_KF_DOC = """# Project Board
+
+- Backend: kanbanflow
+- Board URL: https://kanbanflow.com/board/p9vK6cR
+- Board ID: p9vK6cR
+- Board name: Jared Test
+- Repo: brockamer/jared
+
+### Status column map
+- Backlog: Planned One Day
+- Up Next: Planned This Week
+- In Progress: Doing Now
+- Blocked: Blocked
+- Done: Done
+
+## Jared config
+- backend: kanbanflow
+"""
+
+
+def test_parse_kanbanflow_doc(tmp_path: Path) -> None:
+    p = tmp_path / "project-board.md"
+    p.write_text(_KF_DOC)
+    board = Board.from_path(p)
+    assert board.backend == "kanbanflow"
+    assert board.repo == "brockamer/jared"
+    assert board.owner == "brockamer"  # derived from repo
+    assert board.board_id == "p9vK6cR"
+    assert board.status_column_map["In Progress"] == "Doing Now"
+
+
+def test_kanbanflow_doc_missing_repo_fails(tmp_path: Path) -> None:
+    p = tmp_path / "project-board.md"
+    p.write_text(_KF_DOC.replace("- Repo: brockamer/jared\n", ""))
+    with pytest.raises(BoardConfigError, match="Repo"):
+        Board.from_path(p)
+
+
+def test_kanbanflow_doc_missing_status_map_fails(tmp_path: Path) -> None:
+    p = tmp_path / "project-board.md"
+    body = _KF_DOC.split("### Status column map")[0] + "## Jared config\n- backend: kanbanflow\n"
+    p.write_text(body)
+    with pytest.raises(BoardConfigError, match="Status column map"):
+        Board.from_path(p)
+```
+
+`BoardConfigError` is already imported in `test_board.py` (it is used by `test_missing_file_raises_board_config_error`); if not, add it to the existing `from skills.jared.scripts.lib.board import ...` line.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_board.py -k kanbanflow -v`
+Expected: FAIL — the GitHub-required-field gate rejects the doc (`missing required field(s): Project URL, Project ID, Project number`) before `backend` is read.
+
+- [ ] **Step 3: Make GitHub-only dataclass fields optional + add new fields**
+
+In the `Board` dataclass, change the five leading required fields to carry defaults and add two fields (place `status_column_map` and `board_id` alongside `backend`):
+
+```python
+    project_number: int | None = None
+    project_id: str = ""
+    owner: str = ""
+    repo: str = ""
+    project_url: str = ""
+```
+
+And near the `backend` field:
+
+```python
+    # KanbanFlow Status->column map (canonical Status -> board column name).
+    # Empty for GitHub boards. Parsed from the `### Status column map` block.
+    status_column_map: dict[str, str] = field(default_factory=dict)
+    # KanbanFlow board id (from `- Board ID:`); None for GitHub. Used for the
+    # provider's board-identity soft-verify.
+    board_id: str | None = None
+```
+
+(All fields after `project_number` already have defaults, so dataclass ordering stays valid.)
+
+- [ ] **Step 4: Add the status-map parser**
+
+Add as a `@staticmethod` on `Board` (near `_parse_jared_config`):
+
+```python
+    @staticmethod
+    def _parse_status_column_map(text: str) -> dict[str, str]:
+        """Parse the optional `### Status column map` block into {Status: column}."""
+        m = re.search(
+            r"^### Status column map\s*\n(.*?)(?=^#{2,3}\s|\Z)",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        if not m:
+            return {}
+        result: dict[str, str] = {}
+        for line in m.group(1).splitlines():
+            bm = re.match(r"\s*-\s*([^:]+):\s*(.+?)\s*$", line)
+            if bm:
+                result[bm.group(1).strip()] = bm.group(2).strip()
+        return result
+```
+
+- [ ] **Step 5: Reorder `_parse` to be backend-aware**
+
+In `_parse`, move the backend read above the missing-fields gate and branch validation. Replace the block from the `missing: list[str] = []` gate through the `return cls(...)` with:
+
+```python
+        jared_config = cls._parse_jared_config(text)
+        backend = jared_config.get("backend", "github")
+        session_handoff_prompt = jared_config.get("session-handoff-prompt", "ask")
+        session_start_checks = cls._parse_session_start_checks(text)
+        operator_docs, code_surface = cls._parse_operator_docs(text)
+
+        if backend == "kanbanflow":
+            status_column_map = cls._parse_status_column_map(text)
+            board_id = find_optional(r"Board ID:\s*(\S+)")
+            missing = []
+            if repo is None:
+                missing.append("Repo")
+            if not status_column_map:
+                missing.append("Status column map")
+            if missing:
+                raise BoardConfigError(
+                    f"{source} (backend=kanbanflow) missing: {', '.join(missing)}. "
+                    "Run /jared-init to bootstrap or patch the file."
+                )
+            assert repo is not None
+            return cls(
+                owner=repo.split("/")[0],
+                repo=repo,
+                backend="kanbanflow",
+                status_column_map=status_column_map,
+                board_id=board_id,
+                session_handoff_prompt=session_handoff_prompt,
+                session_start_checks=session_start_checks,
+                operator_docs=operator_docs,
+                code_surface=code_surface,
+                _raw_doc=text,
+            )
+
+        # backend == "github" (default): GitHub Project identifiers required.
+        missing = []
+        if project_url is None:
+            missing.append("Project URL")
+        if project_id is None:
+            missing.append("Project ID")
+        if project_number_val is None:
+            missing.append("Project number")
+        if owner is None:
+            missing.append("Owner")
+        if repo is None:
+            missing.append("Repo")
+        if missing:
+            raise BoardConfigError(
+                f"{source} missing required field(s): {', '.join(missing)}. "
+                "Run /jared-init to bootstrap or patch the file."
+            )
+        assert project_url is not None
+        assert project_id is not None
+        assert project_number_val is not None
+        assert owner is not None
+        assert repo is not None
+
+        field_ids, field_options = cls._parse_field_blocks(text)
+        return cls(
+            project_number=project_number_val,
+            project_id=project_id,
+            owner=owner,
+            repo=repo,
+            project_url=project_url,
+            _field_ids=field_ids,
+            _field_options=field_options,
+            session_handoff_prompt=session_handoff_prompt,
+            session_start_checks=session_start_checks,
+            operator_docs=operator_docs,
+            code_surface=code_surface,
+            _raw_doc=text,
+            backend=backend,
+        )
+```
+
+(Delete the now-superseded original `missing`-gate block and the single `return cls(...)` that followed it, so the GitHub path is the branch above.)
+
+- [ ] **Step 6: Wire the map + board id into the provider**
+
+In the `provider` property, the `kanbanflow` branch — pass the new args:
+
+```python
+                self._provider = KanbanFlowProvider(
+                    client=client,
+                    board=kf_board,
+                    field_defs=field_defs,
+                    index=index,
+                    status_column_map=self.status_column_map,
+                    expected_board_id=self.board_id,
+                )
+```
+
+In the `github` branch, narrow the now-optional `project_number` for mypy — add before constructing `GitHubProjectsProvider`:
+
+```python
+                assert self.project_number is not None  # github docs always carry it
+```
+
+- [ ] **Step 7: Run the KanbanFlow tests + the FULL board suite (GitHub must stay green)**
+
+Run: `pytest tests/test_board.py -v`
+Expected: PASS — new `kanbanflow` tests pass AND every pre-existing GitHub-doc test passes unchanged. **If any existing test needs editing, STOP** — per the Phase-1 gate that is a behavior regression to surface, not absorb.
+
+- [ ] **Step 8: Full suite + type-check + commit**
+
+Run: `pytest -m 'not integration' -q && mypy && ruff check .`
+Expected: all clean, no conftest signature change.
+
+```bash
+git add skills/jared/scripts/lib/board.py tests/test_board.py
+git commit -m "feat(316): backend-aware Board._parse + KanbanFlow status map (Phase 4.2)"
+```
+
+---
+
+## Task 3: Bootstrap — `--backend` flag + conditional `--url`
+
+**Files:**
+- Modify: `skills/jared/scripts/bootstrap-project.py` (`build_parser` ~707–746; top of `main` ~747–760)
+- Test: `tests/test_bootstrap_noninteractive.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_bootstrap_noninteractive.py`:
+
+```python
+import importlib.util
+from pathlib import Path
+
+
+def _load_bootstrap():
+    spec = importlib.util.spec_from_file_location(
+        "bootstrap_project", Path("skills/jared/scripts/bootstrap-project.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def test_url_with_kanbanflow_is_rejected() -> None:
+    # --url + kanbanflow is enforced in main() via parser.error (SystemExit),
+    # not at parse time; parse the args then assert the cross-field guard fires.
+    b = _load_bootstrap()
+    parser = b.build_parser()
+    args = parser.parse_args(["--backend", "kanbanflow", "--repo", "o/r", "--url", "https://x"])
+    assert args.backend == "kanbanflow" and args.url == "https://x"
+    # The guard lives at the top of main(); confirm it raises SystemExit.
+    with pytest.raises(SystemExit):
+        b.main_guard(args, parser)  # see Step 3 — extract the cross-field check
+
+
+def test_backend_defaults_to_github() -> None:
+    b = _load_bootstrap()
+    args = b.build_parser().parse_args(
+        ["--url", "https://github.com/users/o/projects/4", "--repo", "o/r"]
+    )
+    assert args.backend == "github"
+```
+
+Reuse this `_load_bootstrap()` helper (importlib, since `bootstrap-project.py` carries a `.py` extension) in any later bootstrap test that needs the module. Note: to make the cross-field rule unit-testable without running the full `main()`, Step 3 extracts it into a small `main_guard(args, parser)` helper that `main()` calls.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_bootstrap_noninteractive.py -k "backend or kanbanflow" -v`
+Expected: FAIL — `--backend` is not a known argument.
+
+- [ ] **Step 3: Add the flag and make `--url` conditional**
+
+In `build_parser`, change `--url` to not be unconditionally required and add `--backend`:
+
+```python
+    parser.add_argument("--url", required=False, help="GitHub Project v2 URL (required for --backend github)")
+    parser.add_argument(
+        "--backend",
+        choices=["github", "kanbanflow"],
+        default="github",
+        help="Board backend. 'kanbanflow' uses KANBANFLOW_API_TOKEN; 'github' needs --url.",
+    )
+```
+
+Extract the cross-field rule into a testable helper above `main`, and call it at the top of `main()`:
+
+```python
+def main_guard(args, parser) -> None:
+    """Enforce backend/url cross-field rules. Raises SystemExit via parser.error."""
+    if args.backend == "kanbanflow" and args.url:
+        parser.error("--url is not valid with --backend kanbanflow (the board-scoped token selects the board)")
+    if args.backend == "github" and not args.url:
+        parser.error("--url is required for --backend github")
+```
+
+At the very top of `main()`, after `args = parser.parse_args()`:
+
+```python
+    main_guard(args, parser)
+    if args.backend == "kanbanflow":
+        return bootstrap_kanbanflow(args)  # added in Task 4
+```
+
+(`bootstrap_kanbanflow` is stubbed to `raise NotImplementedError` for now so Task 3 compiles; Task 4 implements it. Add `def bootstrap_kanbanflow(args): raise NotImplementedError` temporarily above `main`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_bootstrap_noninteractive.py -k "backend or kanbanflow" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/jared/scripts/bootstrap-project.py tests/test_bootstrap_noninteractive.py
+git commit -m "feat(317): bootstrap --backend flag + conditional --url (Phase 4.3)"
+```
+
+---
+
+## Task 4: Bootstrap — KanbanFlow validate + interview + render
+
+**Files:**
+- Modify: `skills/jared/scripts/bootstrap-project.py` (implement `bootstrap_kanbanflow`; add `map_status_columns`, `validate_priority_field`, `render_kanbanflow_doc`)
+- Test: Create `tests/test_bootstrap_kanbanflow.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_bootstrap_kanbanflow.py`:
+
+```python
+"""Unit tests for the KanbanFlow bootstrap path (Phase 4, #317)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from skills.jared.scripts.lib.kanbanflow_client import KfBoard, KfColumn, KfCustomFieldDef
+from tests.fake_kanbanflow import FakeKanbanFlowClient
+
+
+def _load_bootstrap():
+    spec = importlib.util.spec_from_file_location(
+        "bootstrap_project", Path("skills/jared/scripts/bootstrap-project.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _gtd_board() -> KfBoard:
+    return KfBoard(
+        id="p9vK6cR", name="Jared Test",
+        columns=[
+            KfColumn(unique_id="c1", name="Maybe Never?"),
+            KfColumn(unique_id="c2", name="Planned One Day"),
+            KfColumn(unique_id="c3", name="Planned This Week"),
+            KfColumn(unique_id="c4", name="Will Do Today"),
+            KfColumn(unique_id="c5", name="Doing Now"),
+            KfColumn(unique_id="c6", name="Blocked"),
+            KfColumn(unique_id="c7", name="Done"),
+        ],
+    )
+
+
+def test_map_status_columns_auto_and_interview(monkeypatch) -> None:
+    b = _load_bootstrap()
+    # Auto: Blocked, Done. Interview answers for Backlog/Up Next/In Progress:
+    answers = iter(["Planned One Day", "Planned This Week", "Doing Now"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    mapping, unmapped = b.map_status_columns(_gtd_board())
+    assert mapping == {
+        "Backlog": "Planned One Day", "Up Next": "Planned This Week",
+        "In Progress": "Doing Now", "Blocked": "Blocked", "Done": "Done",
+    }
+    assert set(unmapped) == {"Maybe Never?", "Will Do Today"}
+
+
+def test_validate_priority_field_missing_hard_stops() -> None:
+    b = _load_bootstrap()
+    with pytest.raises(SystemExit):
+        b.validate_priority_field([])  # no custom fields => hard stop
+
+
+def test_validate_priority_field_present_ok() -> None:
+    b = _load_bootstrap()
+    defs = [KfCustomFieldDef(id="x", name="Priority", field_type="dropdown",
+                             dropdown_options=["High", "Medium", "Low"])]
+    b.validate_priority_field(defs)  # no raise
+
+
+def test_render_kanbanflow_doc_shape() -> None:
+    b = _load_bootstrap()
+    doc = b.render_kanbanflow_doc(
+        board=_gtd_board(),
+        repo="brockamer/jared",
+        status_map={"Backlog": "Planned One Day", "Up Next": "Planned This Week",
+                    "In Progress": "Doing Now", "Blocked": "Blocked", "Done": "Done"},
+    )
+    assert "- backend: kanbanflow" in doc
+    assert "### Status column map" in doc
+    assert "- In Progress: Doing Now" in doc
+    assert "- Board ID: p9vK6cR" in doc
+    # Secrets stay in env: the doc documents the env-var NAME as guidance, and
+    # render_kanbanflow_doc never receives the token value, so it cannot leak it.
+    assert "KANBANFLOW_API_TOKEN" in doc
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_bootstrap_kanbanflow.py -v`
+Expected: FAIL — `map_status_columns` / `validate_priority_field` / `render_kanbanflow_doc` not defined.
+
+- [ ] **Step 3: Implement the three helpers + `bootstrap_kanbanflow`**
+
+In `bootstrap-project.py`, add (replacing the temporary `bootstrap_kanbanflow` stub):
+
+```python
+import sys
+
+_CANONICAL_STATUSES = ("Backlog", "Up Next", "In Progress", "Blocked", "Done")
+
+
+def map_status_columns(board) -> tuple[dict[str, str], list[str]]:
+    """Auto-map exact column-name matches; interview for the rest. 1:1.
+
+    Returns (status->column map, leftover-unmapped-column-names).
+    """
+    col_names = [c.name for c in board.columns]
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+    for status in _CANONICAL_STATUSES:
+        if status in col_names:
+            mapping[status] = status
+            used.add(status)
+    for status in _CANONICAL_STATUSES:
+        if status in mapping:
+            continue
+        choices = [n for n in col_names if n not in used]
+        print(f'\nWhich column is "{status}"?')
+        for i, n in enumerate(choices, 1):
+            print(f"  [{i}] {n}")
+        raw = input(f'Column for "{status}" (name or number): ').strip()
+        chosen = choices[int(raw) - 1] if raw.isdigit() else raw
+        if chosen not in col_names:
+            print(f"bootstrap: '{chosen}' is not a column on this board", file=sys.stderr)
+            raise SystemExit(1)
+        mapping[status] = chosen
+        used.add(chosen)
+    unmapped = [n for n in col_names if n not in used]
+    return mapping, unmapped
+
+
+def validate_priority_field(field_defs) -> None:
+    """Hard-stop unless a 'Priority' dropdown with High/Medium/Low exists."""
+    pri = next((d for d in field_defs if d.name == "Priority"), None)
+    needed = {"High", "Medium", "Low"}
+    if pri is None or not needed.issubset(set(pri.dropdown_options)):
+        print(
+            "bootstrap: no 'Priority' custom field with options High, Medium, Low. "
+            "jared requires it. Create a dropdown custom field named 'Priority' "
+            "(options: High, Medium, Low) in the KanbanFlow board's "
+            "Settings -> Custom fields, then re-run.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
+def render_kanbanflow_doc(*, board, repo: str, status_map: dict[str, str]) -> str:
+    rows = "\n".join(f"- {s}: {status_map[s]}" for s in _CANONICAL_STATUSES)
+    return f"""# Project Board — How It Works
+
+- Backend: kanbanflow
+- Board URL: https://kanbanflow.com/board/{board.id}
+- Board ID: {board.id}
+- Board name: {board.name}
+- Repo: {repo}
+
+Auth: set `KANBANFLOW_API_TOKEN` in your environment (board-scoped token from
+KanbanFlow Settings -> API). The token is never stored in this file.
+
+### Status column map
+{rows}
+
+### Priority
+- Field name: Priority
+- Options: High, Medium, Low
+
+## Jared config
+- backend: kanbanflow
+- voice: enabled
+"""
+
+
+def bootstrap_kanbanflow(args) -> int:
+    from lib.kanbanflow_client import KanbanFlowClient
+
+    try:
+        client = KanbanFlowClient.from_env()
+        board = client.get_board()
+        field_defs = client.list_custom_field_defs()
+    except Exception as e:  # noqa: BLE001 - surface any connect/auth failure
+        print(f"bootstrap: KanbanFlow connect failed: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Connected to KanbanFlow board: {board.name} ({board.id})")
+    status_map, unmapped = map_status_columns(board)
+    validate_priority_field(field_defs)  # hard-stop if missing
+
+    if unmapped:
+        print(
+            f"NOTE: columns not mapped to a jared Status — items there are invisible "
+            f"to jared: {', '.join(unmapped)}",
+            file=sys.stderr,
+        )
+    if not board.swimlanes:
+        print(
+            "NOTE: no swimlanes on this board — milestones map to swimlanes and are "
+            "unavailable; jared's dateless milestone convention degrades gracefully.",
+            file=sys.stderr,
+        )
+
+    doc = render_kanbanflow_doc(board=board, repo=args.repo, status_map=status_map)
+    out = Path(args.output)
+    if out.exists() and not args.force:
+        print(f"bootstrap: {out} exists; pass --force to overwrite", file=sys.stderr)
+        return 1
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(doc)
+    print(f"Wrote {out}")
+    return 0
+```
+
+(`args.output` and `args.force` already exist in `build_parser`. The `from lib.kanbanflow_client import ...` import matches how the CLI imports lib modules — bootstrap runs with `scripts/` on `sys.path`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_bootstrap_kanbanflow.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + lint + type-check**
+
+Run: `pytest -m 'not integration' -q && ruff check . && ruff format --check . && mypy`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/jared/scripts/bootstrap-project.py tests/test_bootstrap_kanbanflow.py
+git commit -m "feat(317): KanbanFlow bootstrap — map/validate/render (Phase 4.4)"
+```
+
+---
+
+## Task 5: `/jared-init` dispatch + CLAUDE.md note
+
+**Files:**
+- Modify: `commands/jared-init.md` (the bootstrap-invocation step)
+- Modify: `CLAUDE.md` (Board helper / Architecture section)
+
+- [ ] **Step 1: Update the `/jared-init` stub**
+
+In `commands/jared-init.md`, at the bootstrap-invocation step (~step 2), add a backend-selection instruction before the command, and document both invocations:
+
+```markdown
+2. **Choose the backend, then run `bootstrap-project.py`.** Ask the operator
+   (voice ON — first impression): *GitHub Projects or KanbanFlow?*
+
+   - GitHub (default):
+     ```
+     ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/bootstrap-project.py --backend github --url <project-url> --repo <owner>/<repo>
+     ```
+   - KanbanFlow (requires `KANBANFLOW_API_TOKEN` in env; the token selects the
+     board, so no `--url`). The script interviews the operator to map jared's
+     Status columns onto the board's existing columns:
+     ```
+     ${CLAUDE_PLUGIN_ROOT}/skills/jared/scripts/bootstrap-project.py --backend kanbanflow --repo <owner>/<repo>
+     ```
+   Script output (including the column interview) stays voice-OFF / verbatim.
+```
+
+- [ ] **Step 2: Add a CLAUDE.md note on the KanbanFlow doc shape**
+
+In `CLAUDE.md`, under "The `Board` helper" / "Board-provider abstraction", append a sentence noting the KanbanFlow doc shape:
+
+```markdown
+A KanbanFlow-backed `docs/project-board.md` carries `- backend: kanbanflow`, a `Repo:`
+bullet, a `Board ID:` / `Board URL:`, and a `### Status column map` block (canonical
+Status → the board's actual column name); it omits the GitHub Project identifiers and
+field/option-ID blocks (the provider resolves columns/options live from the API, with the
+board-scoped `KANBANFLOW_API_TOKEN` selecting the board). Init-time selection lands in #317
+(Phase 4 of epic #313).
+```
+
+- [ ] **Step 3: Commit (docs only, no test)**
+
+```bash
+git add commands/jared-init.md CLAUDE.md
+git commit -m "docs(317): /jared-init backend dispatch + KanbanFlow doc shape (Phase 4.5)"
+```
+
+---
+
+## Task 6: Live end-to-end verification + backfill #317 acceptance criteria
+
+**Files:** none (verification + board op). Uses the live board `p9vK6cR` and `KANBANFLOW_API_TOKEN`.
+
+- [ ] **Step 1: Bootstrap the live board into a throwaway doc**
+
+Run (worktree-resident script; token in env — never echoed into a tracked file):
+
+```bash
+KANBANFLOW_API_TOKEN=<token> /home/brockamer/Code/jared-317/skills/jared/scripts/bootstrap-project.py \
+  --backend kanbanflow --repo brockamer/jared --output /tmp/kf-board.md --force
+```
+
+Complete the column interview (`Planned One Day`→Backlog, `Planned This Week`→Up Next, `Doing Now`→In Progress). Expect a NOTE about the unmapped `Maybe Never?` / `Will Do Today` columns and — if Priority isn't set up yet — a hard stop telling you to create the `Priority` field. If it hard-stops, create the field in the KanbanFlow UI and re-run.
+Expected: `/tmp/kf-board.md` written with the slim KanbanFlow shape.
+
+- [ ] **Step 2: Exercise a real board cycle against the live board**
+
+Point a jared command at the throwaway doc and run a `file → summary → move → close` cycle (worktree-resident script). Use `--board /tmp/kf-board.md` if supported, else copy it to the worktree's `docs/project-board.md` temporarily (do NOT commit it):
+
+```bash
+KANBANFLOW_API_TOKEN=<token> /home/brockamer/Code/jared-317/skills/jared/scripts/jared \
+  --board /tmp/kf-board.md summary
+```
+
+Expected: connects, lists items by their mapped Status. Then `file` a throwaway task, `move` it through columns, `summary` to confirm placement, `close` it.
+
+- [ ] **Step 3: Clean up**
+
+Delete the throwaway task from the live board (KanbanFlow UI or `jared close` then UI-delete). Confirm no `/tmp/kf-board.md` or `cache_dir/kf-index-p9vK6cR.json` got committed (the index lives outside the repo by design).
+
+- [ ] **Step 4: Backfill #317 acceptance criteria from this plan**
+
+The issue was filed as a stub ("spec + plan when activated"). Now that both exist, write real acceptance criteria onto #317 (matching this plan's Task-level outcomes), so the board reflects a pullable, well-specified issue:
+
+```bash
+/home/brockamer/Code/jared-317/skills/jared/scripts/jared set 317 ... # or jared comment / gh issue edit to add ## Acceptance criteria
+```
+
+Acceptance criteria to record: bootstrap `--backend kanbanflow` maps columns (auto+interview), validates Priority (hard-stop), warns on unmapped/swimlanes, writes a slim doc; `Board._parse` parses a KanbanFlow doc (backend-first, repo+map required); `KanbanFlowProvider` honors the map on read+write; live `file→move→summary→close` succeeds; full suite green with no GitHub-test/conftest changes.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git -C /home/brockamer/Code/jared-317 push -u origin feature/317-add-init-time-backend-selection-phase-4
+gh pr create --title "feat(317): init-time backend selection (Phase 4)" --body "<summary + Refs #317, epic #313>"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Piece A → Tasks 3, 5. Piece B → Task 4. Piece C-provider → Task 1. Piece C-parse → Task 2. Board-id verify → Task 1 (`expected_board_id`) + Task 2 (parse + wire). Live e2e → Task 6. Non-goals (no structure creation, no swimlane/Priority mapping, no migration/capability-enforcement) are respected — no task implements them.
+- **Regression guard:** Task 1 Step 1's renamed-Done test is the guard the advisor flagged; Task 2 Step 7 enforces "no GitHub-test changes."
+- **Type consistency:** `status_column_map` (Status→column name) and `expected_board_id` are used identically across Tasks 1–2; `_CANONICAL_STATUSES` is defined in both the provider (Task 1) and bootstrap (Task 4) — intentional (separate modules), same tuple value.

--- a/docs/superpowers/specs/2026-06-04-phase4-init-backend-selection-design.md
+++ b/docs/superpowers/specs/2026-06-04-phase4-init-backend-selection-design.md
@@ -1,0 +1,303 @@
+# Phase 4 — Init-time backend selection (design)
+
+Epic #313 ("Make jared board-backend-agnostic"), Phase 4 of 6. Issue #317.
+
+Predecessors (shipped): Phase 1 (#314, `BoardProvider` extraction), Phase 2 (#315,
+KanbanFlow REST client), Phase 3 (#316, `KanbanFlowProvider`). This phase makes the
+backend **selectable at init** and makes a KanbanFlow-backed `docs/project-board.md`
+**parse**. Phases 5 (#318, `jared migrate`) and 6 (#319, capability declaration) are
+unblocked by this one and run in parallel after it lands.
+
+## Problem
+
+The plumbing to steward a KanbanFlow board exists end-to-end (verified this session:
+the Phase 2/3 client reads the operator's live board `Jared Test` / `p9vK6cR`
+cleanly). But there is **no way to choose KanbanFlow**, and two concrete blockers
+stand between "the provider works" and "a project runs on it":
+
+1. **`jared init` is GitHub-only.** `bootstrap-project.py` requires `--url` (a GitHub
+   Project URL) and its `main()` immediately calls `parse_url()` then GraphQL field
+   introspection. There is no `--backend` switch and no KanbanFlow bootstrap path.
+
+2. **A KanbanFlow doc cannot parse — chicken-and-egg.** `Board._parse`
+   (`lib/board.py`) reads the `backend` selector at the **end** (line ~195), *after*
+   it hard-requires the GitHub fields `Project URL / Project ID / Project number /
+   Owner` (line ~180). So a doc that says `- backend: kanbanflow` and omits the
+   GitHub Project identifiers raises `BoardConfigError` before `backend` is ever read.
+
+3. **Real boards don't use jared's column names.** The provider maps Status → column
+   by **exact name** (`{column.name: column.unique_id}`), but the operator's board has
+   GTD-style columns (`Maybe Never?`, `Planned One Day`, `Planned This Week`, `Will
+   Do Today`, `Doing Now`, `Blocked`, `Done`). Only `Blocked` and `Done` match
+   canonical. Forcing a rename is hostile; the board structure is also **read-only via
+   the API** (Phase-1 Appendix A, frozen 2026-06-02), so jared cannot create/rename
+   columns even if it wanted to. The board must be adapted to via a **mapping**, not a
+   mutation.
+
+## Goals
+
+- Add `--backend github|kanbanflow` to `bootstrap-project.py` (default `github`), with
+  an interactive prompt fallback, mirroring the `--yes`/`--work-streams` non-interactive
+  pattern from #268. `/jared-init` selects/asks.
+- Give the KanbanFlow path a **read-only bootstrap**: connect via env token, fetch the
+  live columns + custom-field defs, **auto-map** exact name matches, **interview** the
+  operator for the rest, **warn** on what can't be mapped (unmapped columns, missing
+  `Priority` field, absent swimlanes), and write a slim KanbanFlow-shaped doc.
+- Make `Board._parse` **backend-aware**: read `backend` first, then apply
+  backend-specific required-field validation. KanbanFlow requires `Repo` + a Status
+  column map; not the GitHub Project identifiers.
+- Teach `KanbanFlowProvider` a `status_column_map` (canonical Status → board column
+  name), defaulting to identity so a canonically-named board needs no map.
+- Preserve every existing GitHub-doc test green; add KanbanFlow-doc parse/provider tests.
+- Verify end-to-end against the operator's live board.
+
+## Non-goals (Phase 4)
+
+- **No board-structure creation.** Columns and swimlanes are read-only via the API
+  (Appendix A). Missing structure is **validated and guided**, never created. The user's
+  "offer to create" intent is honored only where the API allows it — which, for board
+  structure, is nowhere. Mapping replaces creation.
+- **No Priority-field creation, no Priority name/value mapping.** A `Priority` dropdown
+  with `High/Medium/Low` is *validated*; if absent or mis-optioned, bootstrap guides the
+  operator to fix it in the KanbanFlow UI. The field must be named `Priority` with
+  canonical options (the provider resolves it by exact name and validates the option).
+  Mapping a differently-named Priority field is a deliberate future extension, not this
+  phase.
+- **No swimlane / milestone mapping.** The board has no swimlanes; `MILESTONE_STATE` is
+  an already-declared KanbanFlow degradation. Bootstrap notes it; milestone-on-KF support
+  is out of scope here.
+- **No number-index work.** `KanbanFlowProvider` self-seeds the `number ↔ _id` index
+  lazily (`_ensure_seeded`/`_reseed_index`, persisted to `cache_dir/kf-index-<board>.json`
+  outside the repo). Bootstrap touches none of it.
+- **No migration** (`jared migrate` is Phase 5 / #318) and **no capability enforcement**
+  across slash-command surfaces (Phase 6 / #319). The KanbanFlow provider already
+  advertises its reduced capability set; Phase 4 only makes the board selectable and
+  parseable.
+- **No change to the repo/git axis.** PRs, worktrees, session locks, wrap-state, plan
+  archival are backend-independent and untouched (Phase-1 axis split).
+
+## Architecture
+
+### Piece A — init-time selection
+
+`bootstrap-project.py`:
+
+- Add `--backend {github,kanbanflow}` (default `github`). When omitted and the session is
+  interactive, prompt (`prompt_*` machinery, like `prompt_work_streams`); `--yes` defaults
+  to `github` for non-interactive runs.
+- Make `--url` **conditionally required**: required for `github`; passing it with
+  `--backend kanbanflow` is a hard argparse error (a KanbanFlow board has no GitHub
+  Project URL — it's selected by the board-scoped token), not a silent no-op. `--repo`
+  stays **required for both** (the git/PR axis is backend-independent).
+- Branch `main()` at the top: `github` keeps today's GraphQL-introspection path verbatim;
+  `kanbanflow` enters the new bootstrap path below and never calls `parse_url`/`fetch_fields`.
+
+`/jared-init` stub (`commands/jared-init.md`): ask which backend on a fresh project (voice
+ON for the question, per the stub's first-impression rule), then invoke
+`bootstrap-project.py --backend <choice> --repo <owner>/<repo> [--url <project-url>]`.
+Script output stays voice-OFF / verbatim, including the interview prompts.
+
+### Piece B — KanbanFlow bootstrap (read-only)
+
+New path in `bootstrap-project.py`, all reads (no board writes):
+
+1. **Connect.** `KanbanFlowClient.from_env()` (reads `KANBANFLOW_API_TOKEN`; errors with
+   guidance if unset). The token is board-scoped, so the token *is* the board selector.
+2. **Fetch** `client.get_board()` (columns, swimlanes, board id/name) and
+   `client.list_custom_field_defs()`.
+3. **Auto-map** canonical Status → column where the column name matches exactly
+   (`Blocked`, `Done` on this board).
+4. **Interview** for each unmapped canonical Status, offering the board's remaining
+   columns as choices:
+   > `Which column is "Up Next"?  [1] Maybe Never?  [2] Planned One Day  [3] Planned This Week  [4] Will Do Today  [5] Doing Now`
+   Each canonical Status maps to **exactly one** column (the write target). `--yes`
+   short-circuits the interview only when every Status auto-mapped; otherwise a
+   non-interactive run with unmapped Statuses fails with the list of what needs mapping.
+5. **Warn** (precise, actionable — the "guide the user" intent):
+   - Leftover columns not chosen for any Status:
+     `NOTE: columns not mapped to a jared Status — items there are invisible to jared: Maybe Never?, Will Do Today`
+   - Missing/mis-optioned Priority field (validated by reading the field def's
+     `dropdown_options: list[str]` — the same attribute the provider's `_check_option`
+     enforces at write time, so bootstrap validates exactly what the provider requires):
+     `WARNING: no 'Priority' custom field with options High, Medium, Low. jared requires it. Create a dropdown custom field named 'Priority' (options: High, Medium, Low) at https://kanbanflow.com/board/<id> → Settings → Custom fields, then re-run.`
+   - Absent swimlanes:
+     `NOTE: no swimlanes on this board — milestones (which map to swimlanes) are unavailable; jared's dateless milestone convention degrades gracefully.`
+6. **Write** the slim doc (see *Doc format* below). Missing Priority is a **hard stop**
+   (exit non-zero, no doc written) because jared requires Priority; unmapped leftover
+   columns and absent swimlanes are **soft** (doc still written).
+
+### Piece C — backend-aware parse + provider
+
+**`Board._parse` reordering (correctness-critical, test-guarded):**
+
+- Parse `backend` from `## Jared config` **before** the required-field gate.
+- Split required-field validation by backend:
+  - `github` (default): unchanged — `Project URL / ID / number / Owner / Repo`.
+  - `kanbanflow`: require `Repo` and a non-empty Status column map; derive `owner` from
+    `repo.split("/")[0]`; `Project URL / ID / number` are **not** required (left `None`/
+    unused — they are GitHub-provider construction args only).
+- Parse the Status column map (new `### Status column map` block) into a
+  `status_column_map: dict[str, str]` field on `Board`. A dedicated parser
+  (`_parse_status_column_map`) reads it; the generic `_parse_field_blocks` tolerates the
+  block's presence (it is only consulted for the GitHub provider's field/option IDs, which
+  a KanbanFlow doc does not carry).
+- Record board identity for KanbanFlow: `Board ID`, `Board name`, `Board URL` bullets
+  (human reference + safety check below).
+
+**`KanbanFlowProvider` — route *all* status↔column translation through the map.**
+
+The constructor gains `status_column_map: dict[str, str] | None = None` (canonical Status →
+board column name). The map must be applied **at construction**, not bolted onto one or two
+methods — every place the provider translates between a Status name and a column is a site,
+and missing one silently breaks open/closed detection. Today's lookup dicts are keyed by raw
+board column name (`{c.name: c.unique_id}`); rebuild them **canonical-Status-keyed** so all
+existing call sites become map-aware for free:
+
+- `_column_id_by_status = {status: column_unique_id}` — built by resolving each canonical
+  Status through the map (identity fallback) to its board column. `_column_id(status)` and
+  the default-`"Backlog"` write path (line ~284) read this.
+- `_status_by_column_id = {column_unique_id: status}` — the inverse, used by `_item_from_task`
+  (line ~172) to report a task's Status. A task in an **unmapped** column (e.g. `Maybe
+  Never?`) has no entry → reports `None` Status, which is exactly why bootstrap warns those
+  items are invisible.
+
+**Enumerated sites that must use the map-applied dicts** (grep `kanbanflow_provider.py`):
+`__init__` dict construction (105–106); `_column_id` (118–123); `_item_from_task` Status
+report (172); **`list_open_items` Done-detection (224) — currently a hardcoded
+`_column_id_by_name.get("Done")` that bypasses any map**; the default-`"Backlog"` write
+(284); `close()` → `_column_id("Done")` (351). All resolve correctly once the dicts are
+Status-keyed. Swimlane dicts (107–108, 176) are **not** remapped — milestones are out of
+scope this phase (no swimlanes on the board).
+
+- `Board.provider` passes the parsed `status_column_map` into the constructor.
+- **Board-identity soft verify:** `Board._parse` records the doc's `Board ID`;
+  `Board.provider` passes it to the constructor as `expected_board_id`. On construction
+  the provider compares the live `board.id` to `expected_board_id`; on mismatch it emits a
+  warning (the token points at a different board than the doc describes — a real footgun)
+  but does not hard-fail (the token is authoritative; the doc may be stale). When
+  `expected_board_id` is absent (e.g. a hand-written doc) the check is skipped.
+
+### Doc format (KanbanFlow)
+
+Concrete shape for the operator's board (machine-readable bullets first, narrative after,
+mirroring the GitHub doc's contract):
+
+```markdown
+# Project Board — How It Works
+
+- Backend: kanbanflow
+- Board URL: https://kanbanflow.com/board/p9vK6cR
+- Board ID: p9vK6cR
+- Board name: Jared Test
+- Repo: brockamer/jared
+
+### Status column map
+- Backlog: Planned One Day
+- Up Next: Planned This Week
+- In Progress: Doing Now
+- Blocked: Blocked
+- Done: Done
+
+### Priority
+- Field name: Priority
+- Options: High, Medium, Low
+
+## Jared config
+- backend: kanbanflow
+- voice: enabled
+```
+
+Notes:
+- The token is **never** written to the doc. Auth is via `KANBANFLOW_API_TOKEN` in the
+  environment; the doc carries a one-line reminder of this in its narrative section.
+- `- backend: kanbanflow` appears under `## Jared config` (where `Board._parse` reads it
+  today). The top-of-file `- Backend:` bullet is human-facing redundancy; the parsed
+  source of truth is the `## Jared config` bullet, unchanged from Phase 1.
+- The GitHub field/option-ID blocks (`### Status` with `OPTION_…`, `### Priority` with
+  option ids) are **absent** — a KanbanFlow board resolves columns and field options live.
+- The `### Priority` block shown above is **human-facing documentation only** — it is *not*
+  machine-parsed in Phase 4 (the provider resolves the field by the hardcoded name
+  `Priority` and validates the option live). It is included so a person reading the doc
+  knows the board contract; per CLAUDE.md's "don't parse a field nothing reads" rule, no
+  parser consumes it. If a future phase adds Priority name-mapping, this block becomes its
+  source of truth.
+
+## Data flow
+
+```
+/jared-init  ──asks──▶  bootstrap-project.py --backend kanbanflow --repo o/r
+                              │
+                              ├─ KanbanFlowClient.from_env()  (KANBANFLOW_API_TOKEN)
+                              ├─ get_board() + list_custom_field_defs()
+                              ├─ auto-map exact + interview operator
+                              ├─ validate Priority (hard) / warn unmapped+swimlanes (soft)
+                              └─ write docs/project-board.md  (slim KF shape)
+
+jared <any board cmd>  ──▶  Board.from_default()
+                              ├─ _parse: read backend FIRST
+                              ├─ backend==kanbanflow → require Repo + status map
+                              ├─ parse status_column_map
+                              └─ .provider → KanbanFlowProvider(status_column_map=…)
+                                              └─ _column_id(status)=map→name→id
+```
+
+## Testing & verification
+
+**Unit (offline, must stay the default suite):**
+- `Board._parse` backend-aware gate: a KanbanFlow doc (no GitHub Project fields) parses;
+  a KanbanFlow doc missing `Repo` or the Status map fails with a clear message; **every
+  existing GitHub-doc test stays green, no conftest signature change** (Phase-1 gate — if
+  a GitHub test must change, that is a regression to surface, not absorb).
+- `_parse_status_column_map`: round-trips the example block; tolerates `Blocked`/`Done`
+  identity rows; rejects a malformed/empty map.
+- `KanbanFlowProvider` with a `status_column_map` via `FakeKanbanFlowClient`, using a
+  **non-identity Done mapping** (e.g. a fake board where `Done` maps from a column named
+  `Complete`): `move` writes the mapped column id; `get_item` reports the mapped Status;
+  **`list_open_items` correctly excludes tasks in the mapped Done column** (this is the
+  regression guard — an identity `Done`→`Done` fake would pass even with the map unwired,
+  so the test *must* use a renamed Done); an item in an unmapped column reports `None`
+  Status. Also cover the default-identity construction (no map) to prove canonically-named
+  boards are unaffected.
+- Bootstrap KanbanFlow path with `FakeKanbanFlowClient` + mocked `input()`: auto-maps
+  exact matches, interviews for the rest, hard-stops on missing Priority, writes the
+  expected doc; board-id mismatch warns.
+
+**Live end-to-end (operator's board, token available this session):**
+- Run bootstrap against `p9vK6cR`, complete the interview, write the doc.
+- Run a real `jared file → move → summary → close` cycle against the live board; confirm
+  the task lands in the mapped columns and `#N` numbering works.
+- **Cleanup:** delete the test task afterward; note the `cache_dir/kf-index-p9vK6cR.json`
+  index file is created outside the repo (no commit).
+- **Worktree caveat:** run the **worktree-resident** `jared` script
+  (`/home/brockamer/Code/jared-317/skills/jared/scripts/jared`), not the main-repo one —
+  the main script always imports the main repo's `lib/board.py` regardless of CWD.
+
+## Acceptance criteria
+
+- `bootstrap-project.py --backend kanbanflow --repo <o/r>` connects via the env token,
+  maps Status columns (auto + interview), validates Priority (hard-stop if absent), warns
+  on unmapped columns + absent swimlanes, and writes a KanbanFlow-shaped
+  `docs/project-board.md`. `--backend github` is unchanged and default.
+- `Board.from_default()` parses a KanbanFlow doc: `backend` read before validation;
+  `Repo` + Status map required, GitHub Project identifiers not; `status_column_map`
+  populated; `owner` derived from `repo`.
+- `KanbanFlowProvider` honors `status_column_map` for both write (`move`) and read
+  (Status reporting); defaults to identity without a map; warns on board-id mismatch.
+- A real `file → move → summary → close` cycle succeeds against the live board.
+- `pytest -m 'not integration'` green with **no GitHub-doc test changes and no conftest
+  signature change**; new KanbanFlow tests added. `ruff check .`, `ruff format .`,
+  `mypy --strict` clean.
+- `/jared-init` asks the backend and dispatches correctly; docs updated
+  (`docs/project-board.md` convention doc gains a KanbanFlow section; CLAUDE.md notes the
+  KanbanFlow doc shape if warranted).
+
+## Open questions / deferred
+
+- **Priority field name mapping.** Deferred — Phase 4 requires the field be named
+  `Priority`. Revisit if a real board can't accommodate that.
+- **Pre-populated boards.** A board with tasks created in the KF UI (no jared `number`)
+  has invisible items by design (`list_open_items` skips un-numbered tasks). jared assumes
+  it owns numbering on its board; mixed-use boards are out of scope.
+- **Many-to-one read mapping.** Rejected for Phase 4 (operator chose 1:1 + warn). The
+  `status_column_map` shape (Status → one column) does not preclude a future inverse
+  multi-map if needed.

--- a/docs/superpowers/specs/2026-06-04-phase4-init-backend-selection-design.md
+++ b/docs/superpowers/specs/2026-06-04-phase4-init-backend-selection-design.md
@@ -287,9 +287,11 @@ jared <any board cmd>  ──▶  Board.from_default()
 - `pytest -m 'not integration'` green with **no GitHub-doc test changes and no conftest
   signature change**; new KanbanFlow tests added. `ruff check .`, `ruff format .`,
   `mypy --strict` clean.
-- `/jared-init` asks the backend and dispatches correctly; docs updated
-  (`docs/project-board.md` convention doc gains a KanbanFlow section; CLAUDE.md notes the
-  KanbanFlow doc shape if warranted).
+- `/jared-init` asks the backend and dispatches correctly; docs updated:
+  `commands/jared-init.md` documents both invocations, `CLAUDE.md` notes the KanbanFlow
+  doc shape, and `render_kanbanflow_doc` is the source of truth for the doc's shape. (No
+  KanbanFlow section is added to jared's own `docs/project-board.md` — that board is
+  GitHub-backed; a KF section there would be incongruous.)
 
 ## Open questions / deferred
 

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -770,10 +770,15 @@ def main_guard(args: argparse.Namespace, parser: argparse.ArgumentParser) -> Non
 _CANONICAL_STATUSES = ("Backlog", "Up Next", "In Progress", "Blocked", "Done")
 
 
-def map_status_columns(board: KfBoard) -> tuple[dict[str, str], list[str]]:
+def map_status_columns(
+    board: KfBoard, *, assume_yes: bool = False
+) -> tuple[dict[str, str], list[str]]:
     """Auto-map exact column-name matches; interview for the rest. 1:1.
 
-    Returns (status->column map, leftover-unmapped-column-names).
+    Returns (status->column map, leftover-unmapped-column-names). When
+    `assume_yes` is set (non-interactive run) and some Status has no exact-name
+    column, fails cleanly listing what needs mapping rather than blocking on
+    input().
     """
     col_names = [c.name for c in board.columns]
     mapping: dict[str, str] = {}
@@ -782,9 +787,16 @@ def map_status_columns(board: KfBoard) -> tuple[dict[str, str], list[str]]:
         if status in col_names:
             mapping[status] = status
             used.add(status)
-    for status in _CANONICAL_STATUSES:
-        if status in mapping:
-            continue
+    needs_interview = [s for s in _CANONICAL_STATUSES if s not in mapping]
+    if needs_interview and assume_yes:
+        print(
+            "bootstrap: cannot map non-interactively — these Statuses have no "
+            f"exact-name column and need mapping: {', '.join(needs_interview)}. "
+            "Re-run without --yes to map them, or rename the board's columns to match.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    for status in needs_interview:
         choices = [n for n in col_names if n not in used]
         print(f'\nWhich column is "{status}"?')
         for i, n in enumerate(choices, 1):
@@ -798,8 +810,11 @@ def map_status_columns(board: KfBoard) -> tuple[dict[str, str], list[str]]:
             chosen = choices[n - 1]
         else:
             chosen = raw
-        if chosen not in col_names:
-            print(f"bootstrap: '{chosen}' is not a column on this board", file=sys.stderr)
+        if chosen not in col_names or chosen in used:
+            print(
+                f"bootstrap: '{chosen}' is not an available (unused) column on this board",
+                file=sys.stderr,
+            )
             raise SystemExit(1)
         mapping[status] = chosen
         used.add(chosen)
@@ -860,7 +875,7 @@ def bootstrap_kanbanflow(args: argparse.Namespace) -> int:
         return 1
 
     print(f"Connected to KanbanFlow board: {board.name} ({board.id})")
-    status_map, unmapped = map_status_columns(board)
+    status_map, unmapped = map_status_columns(board, assume_yes=args.yes)
     validate_priority_field(field_defs)
 
     if unmapped:

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -11,6 +11,7 @@ Usage:
   bootstrap-project.py --url https://github.com/users/brockamer/projects/1 --repo brockamer/findajob
   bootstrap-project.py --url <url> --repo <repo> --output docs/project-board.md
   bootstrap-project.py --url <url> --repo <repo> --no-create  # don't offer to create missing fields
+  bootstrap-project.py --backend kanbanflow --repo <repo>  # KanbanFlow (token in env)
 
 The output file will not be overwritten if it already exists unless --force is
 passed; instead, the script writes to <output>.new and shows a diff.

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -706,7 +706,15 @@ def render_doc(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    parser.add_argument("--url", required=True, help="GitHub Project v2 URL")
+    parser.add_argument(
+        "--url", required=False, help="GitHub Project v2 URL (required for --backend github)"
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["github", "kanbanflow"],
+        default="github",
+        help="Board backend. 'kanbanflow' uses KANBANFLOW_API_TOKEN; 'github' needs --url.",
+    )
     parser.add_argument(
         "--repo",
         required=True,
@@ -744,9 +752,28 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def main_guard(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Enforce backend/url cross-field rules. Raises SystemExit via parser.error."""
+    if args.backend == "kanbanflow" and args.url:
+        parser.error(
+            "--url is not valid with --backend kanbanflow"
+            " (the board-scoped token selects the board)"
+        )
+    if args.backend == "github" and not args.url:
+        parser.error("--url is required for --backend github")
+
+
+def bootstrap_kanbanflow(args: argparse.Namespace) -> int:
+    raise NotImplementedError  # implemented in Task 4
+
+
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
+
+    main_guard(args, parser)
+    if args.backend == "kanbanflow":
+        return bootstrap_kanbanflow(args)
 
     try:
         owner_type, owner, number = parse_url(args.url)

--- a/skills/jared/scripts/bootstrap-project.py
+++ b/skills/jared/scripts/bootstrap-project.py
@@ -25,7 +25,10 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from lib.kanbanflow_client import KfBoard, KfCustomFieldDef  # type: ignore[import-not-found]
 
 # Make sibling lib/ importable regardless of cwd — same pattern as the jared CLI.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -763,8 +766,124 @@ def main_guard(args: argparse.Namespace, parser: argparse.ArgumentParser) -> Non
         parser.error("--url is required for --backend github")
 
 
+_CANONICAL_STATUSES = ("Backlog", "Up Next", "In Progress", "Blocked", "Done")
+
+
+def map_status_columns(board: KfBoard) -> tuple[dict[str, str], list[str]]:
+    """Auto-map exact column-name matches; interview for the rest. 1:1.
+
+    Returns (status->column map, leftover-unmapped-column-names).
+    """
+    col_names = [c.name for c in board.columns]
+    mapping: dict[str, str] = {}
+    used: set[str] = set()
+    for status in _CANONICAL_STATUSES:
+        if status in col_names:
+            mapping[status] = status
+            used.add(status)
+    for status in _CANONICAL_STATUSES:
+        if status in mapping:
+            continue
+        choices = [n for n in col_names if n not in used]
+        print(f'\nWhich column is "{status}"?')
+        for i, n in enumerate(choices, 1):
+            print(f"  [{i}] {n}")
+        raw = input(f'Column for "{status}" (name or number): ').strip()
+        if raw.isdigit():
+            n = int(raw)
+            if not (1 <= n <= len(choices)):
+                print(f"bootstrap: '{raw}' is out of range (1-{len(choices)})", file=sys.stderr)
+                raise SystemExit(1)
+            chosen = choices[n - 1]
+        else:
+            chosen = raw
+        if chosen not in col_names:
+            print(f"bootstrap: '{chosen}' is not a column on this board", file=sys.stderr)
+            raise SystemExit(1)
+        mapping[status] = chosen
+        used.add(chosen)
+    unmapped = [n for n in col_names if n not in used]
+    return mapping, unmapped
+
+
+def validate_priority_field(field_defs: list[KfCustomFieldDef]) -> None:
+    """Hard-stop unless a 'Priority' dropdown with High/Medium/Low exists."""
+    pri = next((d for d in field_defs if d.name == "Priority"), None)
+    needed = {"High", "Medium", "Low"}
+    if pri is None or not needed.issubset(set(pri.dropdown_options)):
+        print(
+            "bootstrap: no 'Priority' custom field with options High, Medium, Low. "
+            "jared requires it. Create a dropdown custom field named 'Priority' "
+            "(options: High, Medium, Low) in the KanbanFlow board's "
+            "Settings -> Custom fields, then re-run.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
+def render_kanbanflow_doc(*, board: KfBoard, repo: str, status_map: dict[str, str]) -> str:
+    rows = "\n".join(f"- {s}: {status_map[s]}" for s in _CANONICAL_STATUSES)
+    return f"""# Project Board — How It Works
+
+- Backend: kanbanflow
+- Board URL: https://kanbanflow.com/board/{board.id}
+- Board ID: {board.id}
+- Board name: {board.name}
+- Repo: {repo}
+
+Auth: set `KANBANFLOW_API_TOKEN` in your environment (board-scoped token from
+KanbanFlow Settings -> API). The token is never stored in this file.
+
+### Status column map
+{rows}
+
+### Priority
+- Field name: Priority
+- Options: High, Medium, Low
+
+## Jared config
+- backend: kanbanflow
+- voice: enabled
+"""
+
+
 def bootstrap_kanbanflow(args: argparse.Namespace) -> int:
-    raise NotImplementedError  # implemented in Task 4
+    from lib.kanbanflow_client import KanbanFlowClient  # noqa: PLC0415
+
+    try:
+        client = KanbanFlowClient.from_env()
+        board = client.get_board()
+        field_defs = client.list_custom_field_defs()
+    except Exception as e:  # noqa: BLE001
+        print(f"bootstrap: KanbanFlow connect failed: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Connected to KanbanFlow board: {board.name} ({board.id})")
+    status_map, unmapped = map_status_columns(board)
+    validate_priority_field(field_defs)
+
+    if unmapped:
+        print(
+            f"NOTE: columns not mapped to a jared Status — items there are invisible "
+            f"to jared: {', '.join(unmapped)}",
+            file=sys.stderr,
+        )
+    if not board.swimlanes:
+        print(
+            "NOTE: no swimlanes on this board — milestones map to swimlanes and are "
+            "unavailable; jared's dateless milestone convention degrades gracefully.",
+            file=sys.stderr,
+        )
+
+    doc = render_kanbanflow_doc(board=board, repo=args.repo, status_map=status_map)
+    out = Path(args.output)
+    if out.exists() and not args.force:
+        print(f"bootstrap: {out} exists; pass --force to overwrite", file=sys.stderr)
+        return 1
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(doc)
+    print(f"Wrote {out}")
+    return 0
 
 
 def main() -> int:

--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -54,11 +54,11 @@ class Board:
         ".github/project-board.md",
     )
 
-    project_number: int
-    project_id: str
-    owner: str
-    repo: str
-    project_url: str
+    project_number: int | None = None
+    project_id: str = ""
+    owner: str = ""
+    repo: str = ""
+    project_url: str = ""
     _field_ids: dict[str, str] = field(default_factory=dict)
     _field_options: dict[str, dict[str, str]] = field(default_factory=dict)
     session_handoff_prompt: str = "ask"
@@ -81,6 +81,12 @@ class Board:
     # Backend selector — defaults to "github". Parsed from the optional
     # `- backend: <x>` bullet under `## Jared config` in project-board.md.
     backend: str = "github"
+    # KanbanFlow Status->column map (canonical Status -> board column name).
+    # Empty for GitHub boards. Parsed from the `### Status column map` block.
+    status_column_map: dict[str, str] = field(default_factory=dict)
+    # KanbanFlow board id (from `- Board ID:`); None for GitHub. Used for the
+    # provider's board-identity soft-verify.
+    board_id: str | None = None
     # Cached provider instance, lazily populated by the `provider` property.
     _provider: BoardProvider | None = field(default=None, repr=False)
 
@@ -166,23 +172,56 @@ class Board:
 
         repo = find_optional(r"Repo:\s*(\S+)") or repo_fallback
 
-        missing: list[str] = []
+        jared_config = cls._parse_jared_config(text)
+        backend = jared_config.get("backend", "github")
+        session_handoff_prompt = jared_config.get("session-handoff-prompt", "ask")
+        session_start_checks = cls._parse_session_start_checks(text)
+        operator_docs, code_surface = cls._parse_operator_docs(text)
+
+        if backend == "kanbanflow":
+            status_column_map = cls._parse_status_column_map(text)
+            board_id = find_optional(r"Board ID:\s*(\S+)")
+            missing: list[str] = []
+            if repo is None:
+                missing.append("Repo")
+            if not status_column_map:
+                missing.append("Status column map")
+            if missing:
+                raise BoardConfigError(
+                    f"{source} (backend=kanbanflow) missing: {', '.join(missing)}. "
+                    "Run /jared-init to bootstrap or patch the file."
+                )
+            assert repo is not None
+            return cls(
+                owner=repo.split("/")[0],
+                repo=repo,
+                backend="kanbanflow",
+                status_column_map=status_column_map,
+                board_id=board_id,
+                session_handoff_prompt=session_handoff_prompt,
+                session_start_checks=session_start_checks,
+                operator_docs=operator_docs,
+                code_surface=code_surface,
+                _raw_doc=text,
+            )
+
+        # backend == "github" (default): GitHub Project identifiers required.
+        missing_gh: list[str] = []
         if project_url is None:
-            missing.append("Project URL")
+            missing_gh.append("Project URL")
         if project_id is None:
-            missing.append("Project ID")
+            missing_gh.append("Project ID")
         if project_number_val is None:
-            missing.append("Project number")
+            missing_gh.append("Project number")
         if owner is None:
-            missing.append("Owner")
+            missing_gh.append("Owner")
         if repo is None:
-            missing.append("Repo")
-        if missing:
+            missing_gh.append("Repo")
+        if missing_gh:
             raise BoardConfigError(
-                f"{source} missing required field(s): {', '.join(missing)}. "
+                f"{source} missing required field(s): {', '.join(missing_gh)}. "
                 "Run /jared-init to bootstrap or patch the file."
             )
-        # Narrow Optional types after the missing-fields check for mypy.
         assert project_url is not None
         assert project_id is not None
         assert project_number_val is not None
@@ -190,12 +229,6 @@ class Board:
         assert repo is not None
 
         field_ids, field_options = cls._parse_field_blocks(text)
-        jared_config = cls._parse_jared_config(text)
-        session_handoff_prompt = jared_config.get("session-handoff-prompt", "ask")
-        backend = jared_config.get("backend", "github")
-        session_start_checks = cls._parse_session_start_checks(text)
-        operator_docs, code_surface = cls._parse_operator_docs(text)
-
         return cls(
             project_number=project_number_val,
             project_id=project_id,
@@ -345,6 +378,23 @@ class Board:
 
         return docs, surface
 
+    @staticmethod
+    def _parse_status_column_map(text: str) -> dict[str, str]:
+        """Parse the optional `### Status column map` block into {Status: column}."""
+        m = re.search(
+            r"^### Status column map\s*\n(.*?)(?=^#{2,3}\s|\Z)",
+            text,
+            re.MULTILINE | re.DOTALL,
+        )
+        if not m:
+            return {}
+        result: dict[str, str] = {}
+        for line in m.group(1).splitlines():
+            bm = re.match(r"\s*-\s*([^:]+):\s*(.+?)\s*$", line)
+            if bm:
+                result[bm.group(1).strip()] = bm.group(2).strip()
+        return result
+
     def field_id(self, name: str) -> str:
         if name not in self._field_ids:
             available = ", ".join(sorted(self._field_ids)) or "(none)"
@@ -402,6 +452,7 @@ class Board:
             if self.backend == "github":
                 from .github_provider import GitHubProjectsProvider
 
+                assert self.project_number is not None  # github docs always carry it
                 self._provider = GitHubProjectsProvider(
                     project_number=self.project_number,
                     project_id=self.project_id,
@@ -420,7 +471,12 @@ class Board:
                 field_defs = client.list_custom_field_defs()
                 index = KfNumberIndex.for_board(kf_board.id)
                 self._provider = KanbanFlowProvider(
-                    client=client, board=kf_board, field_defs=field_defs, index=index
+                    client=client,
+                    board=kf_board,
+                    field_defs=field_defs,
+                    index=index,
+                    status_column_map=self.status_column_map,
+                    expected_board_id=self.board_id,
                 )
         return self._provider
 
@@ -445,6 +501,7 @@ class Board:
 
         Opt-out: `JARED_NO_CACHE=1` skips both cache layers.
         """
+        assert self.project_number is not None  # github-only method
         if self._items is not None:
             return self._items
         no_cache = os.environ.get("JARED_NO_CACHE") == "1"
@@ -480,19 +537,30 @@ class Board:
         return self._items
 
     def invalidate_items(self) -> None:
-        """Drop both in-process and on-disk snapshot caches."""
+        """Drop both in-process and on-disk snapshot caches.
+
+        No-op on backends without a gh item-list cache (e.g. KanbanFlow,
+        project_number is None) — the core mutation commands call this
+        unconditionally after a write, so it must be safe on any backend.
+        """
+        if self.project_number is None:
+            return
         self._items = None
         cache.invalidate_item_list(self.project_number)
 
     def invalidate_closed_items(self) -> None:
         """Drop the on-disk closed-items snapshot (#186).
 
-        Called from `_cmd_set` when field_name=='Status' — Status mutations
-        are the only first-party path that can move an item into or out of
-        the closed set, so the invalidation is gated on field, not on every
-        mutation. Non-Status writes (Priority, Work Stream) leave the cache
-        intact to avoid a wasted full-board refetch on next sweep.
+        Called from `_cmd_set` when field_name=='Status'. No-op on backends
+        without a gh closed-items cache (KanbanFlow, project_number is None).
+
+        Status mutations are the only first-party path that can move an item
+        into or out of the closed set, so the invalidation is gated on field,
+        not on every mutation. Non-Status writes (Priority, Work Stream) leave
+        the cache intact to avoid a wasted full-board refetch on next sweep.
         """
+        if self.project_number is None:
+            return
         cache.invalidate_closed_items(self.project_number)
 
     _OPEN_ITEMS_QUERY = """
@@ -542,6 +610,7 @@ class Board:
         Raises GhInvocationError if there are >100 open issues — pagination
         is not implemented and a silent truncation would mis-report status.
         """
+        assert self.project_number is not None  # github-only method
         owner, repo_name = self.repo.split("/", 1)
         data = self.run_graphql(
             self._OPEN_ITEMS_QUERY,

--- a/skills/jared/scripts/lib/kanbanflow_client.py
+++ b/skills/jared/scripts/lib/kanbanflow_client.py
@@ -456,7 +456,9 @@ class KanbanFlowClient:
         if labels:
             body["labels"] = [{"name": label.name, "pinned": label.pinned} for label in labels]
         raw = self._request("POST", "/tasks", body=body)
-        return _parse_task(raw)  # type: ignore[arg-type]
+        # POST /tasks returns {"taskId": ..., "taskNumber": ...}, NOT a full task;
+        # fetch the created task to get its full shape (incl. _id).
+        return self.get_task(str(raw["taskId"]))  # type: ignore[index]
 
     def update_task(
         self,
@@ -485,8 +487,9 @@ class KanbanFlowClient:
             body["color"] = color
         if responsible_user_id is not None:
             body["responsibleUserId"] = responsible_user_id
-        raw = self._request("POST", f"/tasks/{task_id}", body=body)
-        return _parse_task(raw)  # type: ignore[arg-type]
+        # POST /tasks/{id} (update) returns null, NOT a full task; re-fetch.
+        self._request("POST", f"/tasks/{task_id}", body=body)
+        return self.get_task(task_id)
 
     def delete_task(self, task_id: str) -> None:
         self._request("DELETE", f"/tasks/{task_id}")

--- a/skills/jared/scripts/lib/kanbanflow_provider.py
+++ b/skills/jared/scripts/lib/kanbanflow_provider.py
@@ -12,6 +12,7 @@ design spec for the per-capability rationale.
 from __future__ import annotations
 
 import contextlib
+import sys
 from typing import Protocol
 
 from .board import FieldNotFound, ItemNotFound, OptionNotFound
@@ -25,6 +26,8 @@ from .kf_number_index import KfNumberIndex
 # until their task and trip ruff F401).
 
 _BLOCKED_BY_PREFIX = "blocked-by:"
+
+_CANONICAL_STATUSES = ("Backlog", "Up Next", "In Progress", "Blocked", "Done")
 
 # KanbanFlow advertises the full Capability set MINUS these. The remainder is
 # empty: KF supports only the core board loop. See the design spec.
@@ -98,16 +101,35 @@ class KanbanFlowProvider:
         board: KfBoard,
         field_defs: list[KfCustomFieldDef],
         index: KfNumberIndex,
+        status_column_map: dict[str, str] | None = None,
+        expected_board_id: str | None = None,
     ) -> None:
         self._client = client
         self._board = board
         self._index = index
+        self._status_column_map = status_column_map or {}
+        # Raw board column maps — kept only for the "available columns" error message.
         self._column_id_by_name = {c.name: c.unique_id for c in board.columns}
-        self._column_name_by_id = {c.unique_id: c.name for c in board.columns}
+        # Status-keyed maps — every Status<->column translation goes through these,
+        # so a renamed column (e.g. Done<-"Complete") stays correct on read AND write.
+        self._column_id_by_status: dict[str, str] = {}
+        self._status_by_column_id: dict[str, str] = {}
+        for status in _CANONICAL_STATUSES:
+            col_name = self._status_column_map.get(status, status)  # identity fallback
+            col_id = self._column_id_by_name.get(col_name)
+            if col_id is not None:
+                self._column_id_by_status[status] = col_id
+                self._status_by_column_id[col_id] = status
         self._swimlane_id_by_name = {s.name: s.unique_id for s in board.swimlanes}
         self._swimlane_name_by_id = {s.unique_id: s.name for s in board.swimlanes}
         self._field_def_by_name = {d.name: d for d in field_defs}
         self._field_name_by_id = {d.id: d.name for d in field_defs}
+        if expected_board_id is not None and board.id != expected_board_id:
+            print(
+                f"WARNING: KanbanFlow token points at board '{board.id}' but the doc "
+                f"records '{expected_board_id}'. Operating on '{board.id}'.",
+                file=sys.stderr,
+            )
 
     # --- introspection ---
     def capabilities(self) -> frozenset[Capability]:
@@ -115,12 +137,12 @@ class KanbanFlowProvider:
 
     # --- private resolution helpers ---
     def _column_id(self, status: str) -> str:
-        if status not in self._column_id_by_name:
+        if status not in self._column_id_by_status:
             available = ", ".join(sorted(self._column_id_by_name)) or "(none)"
             raise FieldNotFound(
-                f"Status column '{status}' not on the board. Available: {available}"
+                f"Status column for '{status}' not on the board. Available columns: {available}"
             )
-        return self._column_id_by_name[status]
+        return self._column_id_by_status[status]
 
     def _swimlane_id(self, name: str) -> str:
         if name not in self._swimlane_id_by_name:
@@ -166,10 +188,12 @@ class KanbanFlowProvider:
                 priority = str(cf.value)
             else:
                 fields[field_name] = str(cf.value)
+        # A task in an unmapped column has no canonical Status -> None (by design:
+        # such columns are intentionally invisible to jared; bootstrap warns about them).
         return BoardItem(
             number=task.number_value or 0,
             title=task.name,
-            status=self._column_name_by_id.get(task.column_id) if task.column_id else None,
+            status=self._status_by_column_id.get(task.column_id) if task.column_id else None,
             priority=priority,
             body=task.description,
             labels=[n for n in label_names if not n.startswith(_BLOCKED_BY_PREFIX)],
@@ -221,7 +245,7 @@ class KanbanFlowProvider:
         return self._item_from_task(task)
 
     def list_open_items(self) -> list[BoardItem]:
-        done_id = self._column_id_by_name.get("Done")
+        done_id = self._column_id_by_status.get("Done")
         # Skip un-numbered tasks (e.g. created in the KF UI without a jared
         # number): they have no stable #N handle, so they're already invisible
         # to ref-resolution and edge-building (_reseed_index,

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1596,9 +1596,68 @@ def test_board_provider_returns_kanbanflow_provider(
         - Owner: brockamer
         - Repo: brockamer/findajob
 
+        ### Status column map
+        - Backlog: Backlog
+        - Up Next: Up Next
+        - In Progress: In Progress
+        - Blocked: Blocked
+        - Done: Done
+
         ## Jared config
         - backend: kanbanflow
         """)
     )
     board = Board.from_path(board_md)
     assert isinstance(board.provider, KanbanFlowProvider)
+
+
+_KF_DOC = """# Project Board
+
+- Backend: kanbanflow
+- Board URL: https://kanbanflow.com/board/p9vK6cR
+- Board ID: p9vK6cR
+- Board name: Jared Test
+- Repo: brockamer/jared
+
+### Status column map
+- Backlog: Planned One Day
+- Up Next: Planned This Week
+- In Progress: Doing Now
+- Blocked: Blocked
+- Done: Done
+
+## Jared config
+- backend: kanbanflow
+"""
+
+
+def test_parse_kanbanflow_doc(tmp_path: Path) -> None:
+    from skills.jared.scripts.lib.board import Board
+
+    p = tmp_path / "project-board.md"
+    p.write_text(_KF_DOC)
+    board = Board.from_path(p)
+    assert board.backend == "kanbanflow"
+    assert board.repo == "brockamer/jared"
+    assert board.owner == "brockamer"  # derived from repo
+    assert board.board_id == "p9vK6cR"
+    assert board.status_column_map["In Progress"] == "Doing Now"
+
+
+def test_kanbanflow_doc_missing_repo_fails(tmp_path: Path) -> None:
+    from skills.jared.scripts.lib.board import Board, BoardConfigError
+
+    p = tmp_path / "project-board.md"
+    p.write_text(_KF_DOC.replace("- Repo: brockamer/jared\n", ""))
+    with pytest.raises(BoardConfigError, match="Repo"):
+        Board.from_path(p)
+
+
+def test_kanbanflow_doc_missing_status_map_fails(tmp_path: Path) -> None:
+    from skills.jared.scripts.lib.board import Board, BoardConfigError
+
+    p = tmp_path / "project-board.md"
+    body = _KF_DOC.split("### Status column map")[0] + "## Jared config\n- backend: kanbanflow\n"
+    p.write_text(body)
+    with pytest.raises(BoardConfigError, match="Status column map"):
+        Board.from_path(p)

--- a/tests/test_bootstrap_kanbanflow.py
+++ b/tests/test_bootstrap_kanbanflow.py
@@ -110,3 +110,31 @@ def test_map_status_columns_zero_number_hard_stops(monkeypatch: MonkeyPatch) -> 
     monkeypatch.setattr("builtins.input", lambda _prompt="": "0")
     with pytest.raises(SystemExit):
         b.map_status_columns(_gtd_board())
+
+
+def test_map_status_columns_non_interactive_unmapped_hard_stops() -> None:
+    b = _load_bootstrap()
+    # GTD board: only Blocked/Done auto-map; Backlog/Up Next/In Progress need the
+    # interview, so a non-interactive (--yes) run must fail cleanly, not EOFError.
+    with pytest.raises(SystemExit):
+        b.map_status_columns(_gtd_board(), assume_yes=True)
+
+
+def test_map_status_columns_non_interactive_canonical_ok() -> None:
+    from tests.fake_kanbanflow import FakeKanbanFlowClient
+
+    b = _load_bootstrap()
+    # A board whose columns ARE the canonical names auto-maps fully -> no interview
+    # needed -> assume_yes succeeds.
+    mapping, unmapped = b.map_status_columns(FakeKanbanFlowClient().board, assume_yes=True)
+    assert mapping == {s: s for s in ("Backlog", "Up Next", "In Progress", "Blocked", "Done")}
+    assert unmapped == []
+
+
+def test_map_status_columns_free_text_collision_hard_stops(monkeypatch: MonkeyPatch) -> None:
+    b = _load_bootstrap()
+    # Backlog -> "Doing Now", then Up Next -> "Doing Now" again (already used) must hard-stop.
+    answers = iter(["Doing Now", "Doing Now"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    with pytest.raises(SystemExit):
+        b.map_status_columns(_gtd_board())

--- a/tests/test_bootstrap_kanbanflow.py
+++ b/tests/test_bootstrap_kanbanflow.py
@@ -1,0 +1,112 @@
+"""Unit tests for the KanbanFlow bootstrap path (Phase 4, #317)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+
+from skills.jared.scripts.lib.kanbanflow_client import KfBoard, KfColumn, KfCustomFieldDef
+
+
+def _load_bootstrap() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "bootstrap_project", Path("skills/jared/scripts/bootstrap-project.py")
+    )
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _gtd_board() -> KfBoard:
+    return KfBoard(
+        id="p9vK6cR",
+        name="Jared Test",
+        columns=[
+            KfColumn(unique_id="c1", name="Maybe Never?"),
+            KfColumn(unique_id="c2", name="Planned One Day"),
+            KfColumn(unique_id="c3", name="Planned This Week"),
+            KfColumn(unique_id="c4", name="Will Do Today"),
+            KfColumn(unique_id="c5", name="Doing Now"),
+            KfColumn(unique_id="c6", name="Blocked"),
+            KfColumn(unique_id="c7", name="Done"),
+        ],
+    )
+
+
+def test_map_status_columns_auto_and_interview(monkeypatch: MonkeyPatch) -> None:
+    b = _load_bootstrap()
+    answers = iter(["Planned One Day", "Planned This Week", "Doing Now"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    mapping, unmapped = b.map_status_columns(_gtd_board())
+    assert mapping == {
+        "Backlog": "Planned One Day",
+        "Up Next": "Planned This Week",
+        "In Progress": "Doing Now",
+        "Blocked": "Blocked",
+        "Done": "Done",
+    }
+    assert set(unmapped) == {"Maybe Never?", "Will Do Today"}
+
+
+def test_validate_priority_field_missing_hard_stops() -> None:
+    b = _load_bootstrap()
+    with pytest.raises(SystemExit):
+        b.validate_priority_field([])
+
+
+def test_validate_priority_field_present_ok() -> None:
+    b = _load_bootstrap()
+    defs = [
+        KfCustomFieldDef(
+            id="x",
+            name="Priority",
+            field_type="dropdown",
+            dropdown_options=["High", "Medium", "Low"],
+        )
+    ]
+    b.validate_priority_field(defs)  # no raise
+
+
+def test_render_kanbanflow_doc_shape() -> None:
+    b = _load_bootstrap()
+    doc = b.render_kanbanflow_doc(
+        board=_gtd_board(),
+        repo="brockamer/jared",
+        status_map={
+            "Backlog": "Planned One Day",
+            "Up Next": "Planned This Week",
+            "In Progress": "Doing Now",
+            "Blocked": "Blocked",
+            "Done": "Done",
+        },
+    )
+    assert "- backend: kanbanflow" in doc
+    assert "### Status column map" in doc
+    assert "- In Progress: Doing Now" in doc
+    assert "- Board ID: p9vK6cR" in doc
+    # Secrets stay in env: the doc documents the env-var NAME as guidance, and
+    # render_kanbanflow_doc never receives the token value, so it cannot leak it.
+    assert "KANBANFLOW_API_TOKEN" in doc
+
+
+def test_map_status_columns_out_of_range_number_hard_stops(monkeypatch: MonkeyPatch) -> None:
+    b = _load_bootstrap()
+    # First interview prompt is Backlog; the GTD board offers 5 unmapped choices,
+    # so "9" is out of range and must hard-stop rather than IndexError.
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "9")
+    with pytest.raises(SystemExit):
+        b.map_status_columns(_gtd_board())
+
+
+def test_map_status_columns_zero_number_hard_stops(monkeypatch: MonkeyPatch) -> None:
+    b = _load_bootstrap()
+    # "0" must hard-stop, NOT silently select choices[-1] (the old bug).
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "0")
+    with pytest.raises(SystemExit):
+        b.map_status_columns(_gtd_board())

--- a/tests/test_bootstrap_noninteractive.py
+++ b/tests/test_bootstrap_noninteractive.py
@@ -10,6 +10,8 @@ input() raises EOFError. Two flags make the script usable non-interactively:
 Both are optional; omitting them leaves the script interactive.
 """
 
+import pytest
+
 from tests.conftest import import_bootstrap
 
 
@@ -39,3 +41,22 @@ def test_parse_work_streams_empty_is_empty_list() -> None:
     mod = import_bootstrap()
     assert mod.parse_work_streams("") == []
     assert mod.parse_work_streams("  ,  ,") == []
+
+
+def test_url_with_kanbanflow_is_rejected() -> None:
+    # --url + kanbanflow is enforced in main_guard() via parser.error (SystemExit),
+    # not at parse time; parse the args then assert the cross-field guard fires.
+    b = import_bootstrap()
+    parser = b.build_parser()
+    args = parser.parse_args(["--backend", "kanbanflow", "--repo", "o/r", "--url", "https://x"])
+    assert args.backend == "kanbanflow" and args.url == "https://x"
+    with pytest.raises(SystemExit):
+        b.main_guard(args, parser)
+
+
+def test_backend_defaults_to_github() -> None:
+    b = import_bootstrap()
+    args = b.build_parser().parse_args(
+        ["--url", "https://github.com/users/o/projects/4", "--repo", "o/r"]
+    )
+    assert args.backend == "github"

--- a/tests/test_cmd_move.py
+++ b/tests/test_cmd_move.py
@@ -88,6 +88,13 @@ def test_move_on_kanbanflow_backend_routes_status_to_column(
         - Owner: brockamer
         - Repo: brockamer/findajob
 
+        ### Status column map
+        - Backlog: Backlog
+        - Up Next: Up Next
+        - In Progress: In Progress
+        - Blocked: Blocked
+        - Done: Done
+
         ## Jared config
         - backend: kanbanflow
     """)

--- a/tests/test_kanbanflow_client.py
+++ b/tests/test_kanbanflow_client.py
@@ -250,9 +250,17 @@ def test_get_task_returns_single(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_create_task_always_sends_explicit_number(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = patch_kf(
+    calls = _make_routing_fake(
         monkeypatch,
-        body=json.dumps({"_id": "T1", "name": "n", "columnId": "C1", "number": {"value": 7}}),
+        {
+            ("POST", "/tasks"): {"taskId": "T1", "taskNumber": {"value": 7}},
+            ("GET", "/tasks/T1"): {
+                "_id": "T1",
+                "name": "n",
+                "columnId": "C1",
+                "number": {"value": 7},
+            },
+        },
     )
     task = _client().create_task(name="n", column_id="C1", number_value=7)
     sent = json.loads(cast(bytes, calls[0]["data"]))
@@ -264,9 +272,12 @@ def test_create_task_always_sends_explicit_number(monkeypatch: pytest.MonkeyPatc
 def test_update_task_uses_post_and_includes_only_given_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls = patch_kf(
+    calls = _make_routing_fake(
         monkeypatch,
-        body=json.dumps({"_id": "T1", "name": "renamed", "columnId": "C2"}),
+        {
+            ("POST", "/tasks/T1"): None,
+            ("GET", "/tasks/T1"): {"_id": "T1", "name": "renamed", "columnId": "C2"},
+        },
     )
     _client().update_task("T1", name="renamed", column_id="C2")
     assert calls[0]["method"] == "POST"
@@ -441,9 +452,17 @@ def test_429_exhaustion_raises_rate_limit_error(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_create_task_serializes_labels(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = patch_kf(
+    calls = _make_routing_fake(
         monkeypatch,
-        body=json.dumps({"_id": "T1", "name": "n", "columnId": "C1", "number": {"value": 7}}),
+        {
+            ("POST", "/tasks"): {"taskId": "T1", "taskNumber": {"value": 7}},
+            ("GET", "/tasks/T1"): {
+                "_id": "T1",
+                "name": "n",
+                "columnId": "C1",
+                "number": {"value": 7},
+            },
+        },
     )
     _client().create_task(
         name="n", column_id="C1", number_value=7, labels=[KfLabel(name="Priority", pinned=True)]
@@ -453,7 +472,13 @@ def test_create_task_serializes_labels(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_update_task_wraps_number_value(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = patch_kf(monkeypatch, body=json.dumps({"_id": "T1", "name": "n", "columnId": "C1"}))
+    calls = _make_routing_fake(
+        monkeypatch,
+        {
+            ("POST", "/tasks/T1"): None,
+            ("GET", "/tasks/T1"): {"_id": "T1", "name": "n", "columnId": "C1"},
+        },
+    )
     _client().update_task("T1", number_value=9)
     sent = json.loads(cast(bytes, calls[0]["data"]))
     assert sent["number"] == {"value": 9}
@@ -518,8 +543,105 @@ def test_500_then_success_retries(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_update_task_sends_swimlane_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = patch_kf(monkeypatch, status=200, body=json.dumps({"_id": "T1", "name": "x"}))
+    calls = _make_routing_fake(
+        monkeypatch,
+        {
+            ("POST", "/tasks/T1"): None,
+            ("GET", "/tasks/T1"): {"_id": "T1", "name": "x", "columnId": "C1"},
+        },
+    )
     _client().update_task("T1", swimlane_id="SW2")
     # The POST body must carry swimlaneId.
-    sent = json.loads(cast(bytes, calls[-1]["data"]))
+    sent = json.loads(cast(bytes, calls[0]["data"]))
     assert sent["swimlaneId"] == "SW2"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: create_task and update_task live write-endpoint shapes
+# ---------------------------------------------------------------------------
+
+_FULL_TASK_T1 = {
+    "_id": "T1",
+    "name": "My Task",
+    "columnId": "C1",
+    "number": {"value": 5},
+}
+
+
+def _make_routing_fake(
+    monkeypatch: pytest.MonkeyPatch,
+    routes: dict[tuple[str, str], object],
+) -> list[dict[str, object]]:
+    """Patch _raw_http to dispatch by (method, path-suffix) from `routes`.
+
+    Each key is (METHOD, url_suffix) e.g. ("POST", "/tasks") or ("GET", "/tasks/T1").
+    The value is the response body (any JSON-serialisable object, including None).
+    Returns a list of recorded call dicts for assertions.
+    """
+    import skills.jared.scripts.lib.kanbanflow_client as _kf
+
+    calls: list[dict[str, object]] = []
+
+    def fake(
+        method: str, url: str, hdrs: dict[str, str], data: bytes | None
+    ) -> tuple[int, dict[str, str], bytes]:
+        calls.append({"method": method, "url": url, "headers": hdrs, "data": data})
+        for (route_method, suffix), body_obj in routes.items():
+            if method == route_method and url.endswith(suffix):
+                encoded = json.dumps(body_obj).encode() if body_obj is not None else b""
+                return 200, {}, encoded
+        raise AssertionError(f"Unexpected request: {method} {url}")
+
+    monkeypatch.setattr(_kf, "_raw_http", fake)
+    monkeypatch.setattr(_kf, "_sleep", lambda _s: None)
+    monkeypatch.setattr(_kf, "_now", lambda: 1_000_000)
+    return calls
+
+
+def test_create_task_follows_up_with_get_after_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /tasks returns {taskId, taskNumber}, not a full task.
+
+    create_task must re-fetch via GET /tasks/{id} and return the parsed KfTask.
+    """
+    calls = _make_routing_fake(
+        monkeypatch,
+        {
+            ("POST", "/tasks"): {"taskId": "T1", "taskNumber": {"value": 5}},
+            ("GET", "/tasks/T1"): _FULL_TASK_T1,
+        },
+    )
+    task = _client().create_task(name="My Task", column_id="C1", number_value=5)
+
+    assert isinstance(task, KfTask)
+    assert task.id == "T1"
+    assert task.name == "My Task"
+    assert task.column_id == "C1"
+    assert task.number_value == 5
+
+    methods = [str(c["method"]) for c in calls]
+    assert methods == ["POST", "GET"], "create_task must POST to /tasks then GET the created task"
+
+
+def test_update_task_follows_up_with_get_after_null_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /tasks/{id} (update) returns null, not a full task.
+
+    update_task must re-fetch via GET /tasks/{id} and return the parsed KfTask
+    without crashing on the null update response.
+    """
+    calls = _make_routing_fake(
+        monkeypatch,
+        {
+            ("POST", "/tasks/T1"): None,
+            ("GET", "/tasks/T1"): {**_FULL_TASK_T1, "columnId": "C2"},
+        },
+    )
+    task = _client().update_task("T1", column_id="C2")
+
+    assert isinstance(task, KfTask)
+    assert task.id == "T1"
+    assert task.column_id == "C2"
+
+    methods = [str(c["method"]) for c in calls]
+    assert methods == ["POST", "GET"], (
+        "update_task must POST to /tasks/{id} then GET the updated task"
+    )

--- a/tests/test_kanbanflow_provider.py
+++ b/tests/test_kanbanflow_provider.py
@@ -304,3 +304,121 @@ def test_get_item_reseeds_index_on_cold_miss(tmp_path: Path) -> None:
     item = provider.get_item(7)
     assert item is not None and item.number == 7
     assert provider._index.get(7) is not None
+
+
+def _gtd_client() -> FakeKanbanFlowClient:
+    """A board whose columns are NOT jared's canonical names."""
+    from skills.jared.scripts.lib.kanbanflow_client import KfBoard, KfColumn, KfCustomFieldDef
+
+    board = KfBoard(
+        id="B1",
+        name="GTD",
+        columns=[
+            KfColumn(unique_id="c-someday", name="Someday"),
+            KfColumn(unique_id="c-soon", name="Planned Soon"),
+            KfColumn(unique_id="c-now", name="Doing Now"),
+            KfColumn(unique_id="c-blk", name="Blocked"),
+            KfColumn(unique_id="c-complete", name="Complete"),  # Done renamed
+        ],
+    )
+    fields = [
+        KfCustomFieldDef(
+            id="cf-priority",
+            name="Priority",
+            field_type="dropdown",
+            dropdown_options=["High", "Medium", "Low"],
+        ),
+    ]
+    return FakeKanbanFlowClient(board=board, field_defs=fields)
+
+
+_GTD_MAP = {
+    "Backlog": "Someday",
+    "Up Next": "Planned Soon",
+    "In Progress": "Doing Now",
+    "Blocked": "Blocked",
+    "Done": "Complete",
+}
+
+
+def test_status_map_move_writes_mapped_column(tmp_path: Path) -> None:
+    client = _gtd_client()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    provider = KanbanFlowProvider(
+        client=client,
+        board=client.board,
+        field_defs=client.field_defs,
+        index=index,
+        status_column_map=_GTD_MAP,
+    )
+    task = client.create_task(name="x", column_id="c-someday", number_value=5)
+    provider._index.put(5, task.id)
+    provider.move(5, "In Progress")
+    assert client.get_task(task.id).column_id == "c-now"
+
+
+def test_status_map_get_item_reports_canonical_status(tmp_path: Path) -> None:
+    client = _gtd_client()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    provider = KanbanFlowProvider(
+        client=client,
+        board=client.board,
+        field_defs=client.field_defs,
+        index=index,
+        status_column_map=_GTD_MAP,
+    )
+    task = client.create_task(name="x", column_id="c-now", number_value=6)
+    provider._index.put(6, task.id)
+    assert provider.get_item(6).status == "In Progress"  # type: ignore[union-attr]
+
+
+def test_status_map_list_open_excludes_mapped_done(tmp_path: Path) -> None:
+    # The regression guard: Done is mapped from "Complete". A task there must
+    # be excluded from open items. An identity Done->Done fake would pass even
+    # with the map unwired — this renamed-Done case is what proves the wiring.
+    client = _gtd_client()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    provider = KanbanFlowProvider(
+        client=client,
+        board=client.board,
+        field_defs=client.field_defs,
+        index=index,
+        status_column_map=_GTD_MAP,
+    )
+    client.create_task(name="done", column_id="c-complete", number_value=7)
+    client.create_task(name="open", column_id="c-now", number_value=8)
+    nums = {it.number for it in provider.list_open_items()}
+    assert 8 in nums
+    assert 7 not in nums
+
+
+def test_expected_board_id_mismatch_warns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    client = FakeKanbanFlowClient()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    KanbanFlowProvider(
+        client=client,
+        board=client.board,
+        field_defs=client.field_defs,
+        index=index,
+        expected_board_id="some-other-board",
+    )
+    assert "some-other-board" in capsys.readouterr().err
+
+
+def test_status_map_missing_mapped_column_raises_on_move(tmp_path: Path) -> None:
+    client = _gtd_client()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    bad_map = dict(_GTD_MAP, Done="No Such Column")
+    provider = KanbanFlowProvider(
+        client=client,
+        board=client.board,
+        field_defs=client.field_defs,
+        index=index,
+        status_column_map=bad_map,
+    )
+    task = client.create_task(name="x", column_id="c-now", number_value=9)
+    provider._index.put(9, task.id)
+    with pytest.raises(FieldNotFound):
+        provider.move(9, "Done")


### PR DESCRIPTION
## What this does

Phase 4 of epic #313 — makes jared's board backend **selectable at init**, so a project can be stewarded on **KanbanFlow** instead of GitHub Projects. The key design choice: **map jared's Status columns onto a board's existing columns** (interviewed at `init`), rather than forcing a rename or mutating board structure — the KanbanFlow API is read-only for columns/swimlanes.

**Three pieces:**
- **Selection** — `bootstrap-project.py --backend github|kanbanflow` (default `github`); `/jared-init` asks. `--url` is rejected with `kanbanflow` (the board-scoped token selects the board).
- **KanbanFlow bootstrap** (read-only) — connect via `KANBANFLOW_API_TOKEN`, auto-map exact-name Status columns, interview for the rest (1:1, bounds-checked), validate a `Priority` dropdown (High/Medium/Low) with a hard-stop if absent, warn on unmapped columns + absent swimlanes, write a slim doc.
- **Parse + provider** — `Board._parse` reads `backend` before the required-field gate (KanbanFlow needs `Repo` + a `### Status column map`, not GitHub Project identifiers); `KanbanFlowProvider` applies a `status_column_map` at construction so **all** Status↔column translation (read + write) is map-aware.

## Validation

- **Live end-to-end against the real board** (`Jared Test` / `p9vK6cR`): `bootstrap → file → move → close` round-trips correctly — `file` lands in the mapped Backlog column, `get-item` reports canonical Status (mapped back), `move`/`close` write the mapped In Progress/Done columns, Priority + `#N` numbering work. Test task cleaned up after.
- **762 → 764 unit tests passing**, `mypy --strict` + `ruff` clean throughout. **No GitHub-doc test or `conftest` change** (the Phase-1 safety invariant); two Phase-3 KanbanFlow fixtures gained identity status-maps.
- Render→parse round-trip verified: the doc bootstrap writes parses back through the new parser and drives the provider.

## Bug found by the live run (Phase 4.7)

The live e2e exposed a latent **Phase-3 client bug** the in-memory fake masked: KanbanFlow write endpoints return `{taskId, taskNumber}` (create) and `null` (update), not a full task, so `_parse_task` raised `KeyError '_id'` / `TypeError` — breaking `file`/`move`/`set`/`close` on any real board. Both now re-fetch via `get_task`; regression tests mock the real two-step POST→GET shapes (proven to fail without the fix).

## Commit trail

`feat`/`fix`/`docs` Phase 4.0–4.7 (spec → plan → provider map → backend-aware parse → bootstrap flag → KF bootstrap → init dispatch → review reconciliation → live-found client fix). Merge with `--merge` to preserve the phase trail.

## Known boundaries (by design, not bugs)

`summary`/`ties`/`sweep`/`stage` remain GitHub-only this phase (documented Phase-1 boundary); milestone handling on KanbanFlow is out of scope (no swimlanes); the `file` success message prints a github.com URL on a KanbanFlow board (cosmetic). Migration (#318) and capability enforcement (#319) are unblocked by this and follow.

Closes #317
Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

