### PR TITLE
release: v0.29.0 — KanbanFlow backend (Phases 2–4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jared",
   "description": "Jared — steward a GitHub Projects v2 board as the single source of truth. Files, moves, grooms, and structurally reviews issues with discipline. Includes /jared, /jared-file, /jared-start, /jared-stage, /jared-groom, /jared-audit, /jared-reshape, /jared-wrap, /jared-init.",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "author": {
     "name": "Daniel Brock"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Format: each entry starts with `## v<x.y.z> — YYYY-MM-DD`, followed by terse b
 
 Convention is documented in [CLAUDE.md](CLAUDE.md) § Versioning. Pre-`v0.2.0` history is omitted — `v0.2.0` is the level-up release that established the current Jared shape.
 
+## v0.29.0 — 2026-06-05
+
+**Features**
+- **KanbanFlow as a board backend, end to end.** A project can now be stewarded on a KanbanFlow board instead of GitHub Projects. `bootstrap-project.py --backend kanbanflow` (and `/jared-init`) connects via `KANBANFLOW_API_TOKEN`, maps jared's Status columns onto the board's *existing* columns (auto-match + interview, no board-structure mutation — the API is read-only there), validates a `Priority` dropdown, and writes a slim convention doc; `Board._parse` is backend-aware and `KanbanFlowProvider` honors the Status→column map on read and write. Shipped across epic #313's Phases 2–4: the stdlib-only REST client (#325), the provider over it (#329), and init-time selection (#334). Verified end-to-end against a live board.
+- `jared` guards against two parallel sessions both creating the same new module. (#333)
+
+**Bug fixes**
+- KanbanFlow `create_task`/`update_task` re-fetch the full task after a write — the live API returns `{taskId}` / `null` rather than a task object, which had broken file/move/close on a real board (caught by the Phase-4 live e2e). (#334)
+- `compute_velocity` guards against silent `gh`-query `--limit` truncation. (#328)
+- `dependency-graph` sources Priority from the project field, not `priority:` labels. (#326)
+
+**Refactor**
+- Phase-3 interface-purity / strict-parity cleanup of the provider seam (residues from the #320 review). (#321)
+- Added test coverage for `dependency-graph`'s graph algorithms — topo-sort, critical path, orphan detection. (#327)
+
+**Doctrine**
+- Reconciled the `/jared-stage` + `/jared-audit` command inventories and documented `jared add-to-board`. (#331)
+- Clarified the milestone soft-date doctrine and archived the shipped Phase 2/3 plans. (#330)
+
 ## v0.28.0 — 2026-06-02
 
 **Refactor**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jared"
-version = "0.28.0"
+version = "0.29.0"
 description = "Jared — GitHub Projects v2 board steward (Claude Code plugin)"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Cuts **v0.29.0**. Bumps `plugin.json` + `pyproject.toml` to 0.29.0 and lands the CHANGELOG entry in the same PR (per the release discipline).

Covers everything merged since v0.28.0:
- **KanbanFlow backend, end to end** — REST client (#325), provider (#329), init-time selection (#334), verified live.
- Parallel-session same-new-module guard (#333).
- Fixes: `compute_velocity` truncation guard (#328), dependency-graph Priority source (#326); dependency-graph test coverage (#327); Phase-3 cleanup (#321).
- Doctrine: command-inventory reconciliation (#331), milestone date doctrine + plan archival (#330).

Tag `v0.29.0` + GitHub Release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)