### PR TITLE
chore(313): archive Phase 4 docs, draft Phase 5/6 specs

### DIFF
--- a/docs/superpowers/plans/archived/2026-06/2026-06-04-phase4-init-backend-selection.md
+++ b/docs/superpowers/plans/archived/2026-06/2026-06-04-phase4-init-backend-selection.md
@@ -1,6 +1,14 @@
+---
+**Shipped in #317 on 2026-06-05. Final decisions captured in issue body.**
+---
+
 # Phase 4 — Init-time Backend Selection Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## Issue
+
+- #317
 
 **Goal:** Make jared's board backend selectable at `jared init` and make a KanbanFlow-backed `docs/project-board.md` parse and run, adapting to a board's existing columns via a Status→column map rather than mutating board structure.
 

--- a/docs/superpowers/specs/2026-06-09-phase5-jared-migrate-design.md
+++ b/docs/superpowers/specs/2026-06-09-phase5-jared-migrate-design.md
@@ -1,0 +1,101 @@
+# `jared migrate` between backends — Phase 5: migration command (design)
+
+**Issue:** #318 (Phase 5). Parent epic: #313.
+**Date:** 2026-06-09
+**Status:** Design — not yet started. Drafted during the 2026-06-09 structural review; **open design questions below are unresolved and must be settled (with the operator) before a plan is written.**
+**Related references:** `skills/jared/scripts/lib/board_provider.py`, `lib/github_provider.py`, `lib/kanbanflow_provider.py`, `docs/superpowers/specs/archived/2026-06/2026-06-02-board-provider-abstraction-design.md` (§ "Appendix A — Migration fidelity"), `docs/project-board.md`.
+
+## Context — the larger feature
+
+Epic #313 makes jared's board backend pluggable. Phases 1–4 shipped: the backend-neutral `BoardProvider` contract (#314), the KanbanFlow REST client (#315), `KanbanFlowProvider` (#316), and init-time backend selection persisted in the convention doc (#317). With Phase 4 landed, a project can be *stood up* on either GitHub Projects v2 or KanbanFlow — but it cannot yet *move* from one to the other.
+
+Phase 5 adds `jared migrate`: a one-shot, operator-confirmed command that reads a project's board from its current backend and re-creates it on the other, surfacing the **named, accepted lossiness** of that specific direction before it writes anything. Phase 5 and Phase 6 (#319) are independent and run in parallel after Phase 4.
+
+## Problem
+
+The two backends are not symmetric, and the asymmetries are exactly where a naïve copy loses data silently. The migration must make every loss explicit and confirmed *before* the first write. The constraints are frozen in Appendix A of the Phase 1 spec; restated here as the problem surface:
+
+- **`#N` is settable on KanbanFlow but auto-assigned on GitHub.** GitHub→KF can preserve every issue number exactly. KF→GitHub **cannot** — GitHub assigns its own numbers, so that direction *renumbers*, breaking every `#N` cross-reference in bodies, comments, and session history unless they are rewritten against an old→new map.
+- **blocked-by representation differs.** GitHub stores native relation edges; KanbanFlow relations are read-only via API, so jared emulates them with `blocked-by:<N>` labels + the Blocked column. Migration must translate the representation in both directions — and a translated edge is only correct once the *target* numbers exist, so edge re-establishment is a second pass after item creation.
+- **Closed-state asymmetry.** GitHub has a real closed state; KanbanFlow has only a Done column (`CLOSED_STATE` capability absent). Migrating history (every Done/closed item) is both expensive under KF's quota and of questionable value.
+- **Milestones vs swimlanes.** GitHub milestones carry name + description + open/close state + due date; KanbanFlow swimlanes carry only name + description. GH→KF drops milestone state and due dates; KF→GitHub loses any swimlane structure not mapped back to a milestone.
+- **Markdown vs plain text.** GitHub bodies are markdown; KanbanFlow `description` is plain text. jared's `## section` parsing round-trips (it is text-based), but rendering is lost — a representation loss, not a data loss.
+- **Board structure is read-only on KanbanFlow.** Columns, swimlanes, and custom-field *definitions* must pre-exist in the KanbanFlow UI before a GH→KF migration can write into them (the same Phase-4 `init` prerequisite). Migration validates the target's structure up front and refuses with a clear list if it is missing.
+- **KanbanFlow write amplification + quota.** `file` is ≥2 calls (task create, then per-field custom-field POST, then per-comment POST), against a 1,000 req/hr / token-locks-at-5,000-day budget. A whole-board migration of a real project can approach or exceed that — so throttling, batching, and (open question) resumability are first-class concerns, not afterthoughts.
+
+## Goals
+
+- A `jared migrate` subcommand that moves a board from its current backend to the other, expressed **entirely** through `BoardProvider` semantic methods on both sides — no GitHub node-id or KanbanFlow `_id` crosses the command. The command instantiates a *source* provider (the project's configured backend) and a *target* provider, and copies item-by-item.
+- **Lossiness is surfaced and confirmed before any write.** The command computes a direction- and dataset-specific lossiness report ("N native edges → label-markers; M items will be renumbered; K closed items will/won't migrate; milestone due-dates dropped") and requires explicit operator confirmation. **Dry-run is the default**; writing requires an explicit `--apply`.
+- **GitHub→KanbanFlow preserves `#N` exactly.** **KanbanFlow→GitHub emits an authoritative old→new number map** as a durable artifact of the run.
+- **blocked-by edges are semantically preserved** across the renumber, in both representations.
+- The migration is **safe to abort and re-run**: a partially-applied migration leaves the target in a state the next run can reconcile rather than duplicate (mechanism is an open question — see below).
+- Existing tests stay green; new tests cover the lossiness report and the translation passes against a capability-restricted fake — **plus a live round-trip against a real KanbanFlow board** (see Acceptance).
+
+## Non-goals (Phase 5)
+
+- **No continuous / two-way sync.** `migrate` is a one-shot directional copy, not a mirror. There is no ongoing reconciliation daemon.
+- **No board-structure creation on KanbanFlow.** Columns / swimlanes / custom-field definitions must pre-exist; `migrate` validates and refuses if absent, it does not create them (the API can't).
+- **No change to the repo/git axis.** Branches, PRs, worktrees, session locks, wrap-state, plan archival are backend-independent and untouched — a migrated board points at the same repo.
+- **No capability-degradation logic** — that is Phase 6 (#319). Phase 5 may *consume* `capabilities()` to compute the lossiness report, but it does not wire command-surface degradation.
+
+## Architecture
+
+### Shape of the command
+
+```
+jared migrate --to <github|kanbanflow> [--apply] [--include-closed] [--out <map.json>]
+```
+
+- The **source** is the project's currently-configured backend (parsed from `docs/project-board.md`); `--to` names the target. Refuse if `--to` equals the current backend.
+- How the **target board identity** is supplied (a second convention doc? inline flags? a pre-seeded target `docs/project-board.md`?) is an **open question** — see below.
+- Default run is a **dry-run**: it reads the source, validates the target structure, computes the lossiness report, prints it, and stops. `--apply` performs the writes after confirmation.
+
+### Pipeline (read source → report → confirm → write target)
+
+1. **Read the full source board** via the provider: `list_open_items()` (+ closed items only under `--include-closed`), `get_body()`, `fetch_blocked_by_edges()`, `list_milestones()`. **Contract gap:** the shipped `BoardProvider` has no comment-*read* method — `comment()` is write-only, and the `list_comments()` the Phase 1 spec sketched did **not** ship. Porting session-note history therefore requires extending the contract first (see Open question 7).
+2. **Validate the target** (KanbanFlow target: columns for every Status, dropdown custom fields for Priority/Work-Stream/custom selects, swimlanes for every milestone). Refuse with a precise missing-structure list.
+3. **Compute the lossiness report** for this direction + dataset, driven by the *difference* between source and target `capabilities()` plus the structural mappings.
+4. **Surface and confirm.** Print the report; require `--apply` + an interactive confirmation (or `--yes`) to proceed.
+5. **Write the target in dependency-safe order:**
+   a. Create every item (`file(...)`), preserving `#N` on GH→KF / accumulating an old→new map on KF→GH.
+   b. Apply Status (`move`), Priority/fields (`set_field`), milestone (`set_milestone`).
+   c. **Second pass:** re-establish blocked-by edges (`add_blocked_by`) now that all target numbers exist, translating through the number map.
+   d. Port comments / session notes — **gated on the contract gaining a comment-read method** (Open question 7); when available, write via `comment()`, backdating where the target supports it.
+6. **Emit the run artifact:** the old→new number map and a human-readable migration report (what moved, what was lost), written to `--out` (default a timestamped file).
+
+### The number map is the spine
+
+Every later pass keys off the old→new map produced in 5a. On GH→KF it is the identity map (numbers preserved) and exists only to make edge/cross-ref translation uniform. On KF→GitHub it is the load-bearing artifact: edges, and (open question) in-body / in-comment `#N` cross-references, are rewritten through it.
+
+### Quota-aware writes (KanbanFlow target)
+
+Writes batch and throttle to respect the 1,000 req/hr budget; the command estimates total calls up front (items × per-item call count + edges + comments) and includes that estimate in the dry-run report so the operator knows whether a run fits the window. Resumability under quota exhaustion is an open question.
+
+## Open design questions — settle before writing the plan
+
+1. **Migrate closed/Done history, or the live board only?** Default to live-board-only (cheap, high-value) with `--include-closed` opt-in (expensive, lossy on KF where there is no closed state)? Or the reverse?
+2. **KF→GitHub cross-reference rewriting.** When renumbering, do we *automatically rewrite* `#N` references inside bodies and comments via the number map, or only emit the map and warn that prose cross-refs now point at the old numbers? Auto-rewrite is correct-but-risky (false positives on `#N` that isn't an issue ref); warn-only is safe-but-leaves-rot.
+3. **Resumability.** For boards large enough to exceed the KF hourly quota mid-run, do we checkpoint (a resume file mapping completed items) so a re-run continues, or document a hard size ceiling and refuse above it?
+4. **Does `migrate` flip `docs/project-board.md`'s backend selector** to the target on success, or leave the convention doc to the operator (so the source board stays authoritative until they switch)?
+5. **How is the target board identified?** Inline flags vs a pre-seeded target convention doc vs an interactive `init`-style interview for the target. This couples to Phase 4's `init` flow.
+6. **Comment author attribution.** KanbanFlow comments are authored by the API token's user, so GH→KF loses original authorship. Accept as a named loss, or prepend `(originally @author)` into the comment text?
+7. **Comment/session-note portage needs a contract extension.** The provider can *write* comments (`comment()`) but cannot *read* them — there is no `list_comments()` in the shipped contract (Phase 1 proposed it; it did not ship). Phase 5 must either add a comment-read method to `BoardProvider` + both providers (a prerequisite sub-task) or scope session-note migration out of v1 as a named loss. Given how much jared invests in session continuity, migrating a board *without* its note history is a material fidelity loss — lean toward the contract extension.
+
+## Acceptance criteria
+
+- `jared migrate` reads the source and writes the target **only** through `BoardProvider` methods; a grep proves no `gh`/GraphQL/`field_id`/`option_id`/KanbanFlow `_id` in the command file.
+- Dry-run is the default; no write occurs without `--apply` **and** confirmation. The dry-run prints the full lossiness report and a KanbanFlow call-count estimate.
+- GH→KF preserves every `#N`; KF→GitHub emits a complete old→new number map artifact.
+- blocked-by edges are semantically preserved across the renumber (verified by re-reading the target's edges and comparing the dependency graph to the source's).
+- Each named loss from Appendix A is itemized in the report before writing.
+- **Live verification (required, not fake-only):** a real GitHub↔KanbanFlow round-trip is exercised against a **real KanbanFlow board**, not just `FakeKanbanFlowClient`. The fake returns full task objects where the live API returns `{taskId}` on create / `null` on update, so a fake-only green run hides the real write contract — this is the lesson from #317 / PR #334 and the reason migration's write path must be confirmed live.
+- `pytest -m 'not integration'` green (new unit tests for the report + translation passes via a capability-restricted fake provider); `ruff check .`, `ruff format .`, `mypy` clean.
+
+## Documentation Impact
+
+- `docs/project-board.md` — document backend-switching via `jared migrate` and the named lossiness per direction; note the KanbanFlow target-structure prerequisite.
+- `CLAUDE.md` — add `migrate` to the CLI surface inventory (the "~18 subcommands" count) and the three-tier operations note.
+- `skills/jared/references/operations.md` — the `migrate` operation, dry-run/apply discipline, and quota guidance.
+- `CHANGELOG.md` + GitHub Release — at ship, under **Features**.
+- A new implementation plan in `docs/superpowers/plans/` at activation, citing `## Issue: #318`.

--- a/docs/superpowers/specs/2026-06-09-phase6-capability-declaration-design.md
+++ b/docs/superpowers/specs/2026-06-09-phase6-capability-declaration-design.md
@@ -1,0 +1,86 @@
+# Capability declaration + graceful degradation — Phase 6 (design)
+
+**Issue:** #319 (Phase 6). Parent epic: #313.
+**Date:** 2026-06-09
+**Status:** Design — not yet started. Drafted during the 2026-06-09 structural review; **open design questions below are unresolved and must be settled (with the operator) before a plan is written.**
+**Related references:** `skills/jared/scripts/lib/board_provider.py` (the `Capability` enum), `lib/github_provider.py`, `lib/kanbanflow_provider.py`, `docs/superpowers/specs/archived/2026-06/2026-06-02-board-provider-abstraction-design.md` (§ "`Capability` enum", § "Appendix A — Capabilities KanbanFlow will omit"), the slash-command stubs under `commands/`, `skills/jared/SKILL.md`, `skills/jared/references/operations.md`.
+
+## Context — the larger feature
+
+Epic #313 makes jared's board backend pluggable. Phase 1 (#314) defined a `Capability` enum and had `GitHubProjectsProvider` advertise the **full** set; Phase 3 (#316) built `KanbanFlowProvider`, which by design omits several capabilities (Appendix A). But nothing yet *acts* on the enum — every command still assumes GitHub's full feature set. On a KanbanFlow board, a command that reaches for a milestone's due date or an issue's closed-at timestamp gets nothing, or worse, wrong output.
+
+Phase 6 closes that gap: each capability-dependent surface checks the active provider's capabilities and **degrades with a documented note** instead of failing or lying. This is where "capability-based parity" — core board loop works on both backends, GitHub-only richness degrades gracefully — becomes user-visible. Phase 6 is independent of Phase 5 and runs in parallel after Phase 4.
+
+## Problem
+
+The capabilities KanbanFlow omits, and the surfaces that depend on them (from Appendix A):
+
+| Capability | What it gates | Surfaces that assume it |
+|---|---|---|
+| `MILESTONE_STATE` | milestone open/close + due dates | `/jared-reshape` (Roadmap, milestone dates), `/jared-audit` (date-gate heuristics), `milestones-and-roadmap` reference |
+| `VELOCITY_TIMESTAMPS` | created / closed / transition times | `sweep.py` (aging, stale-In-Progress, stale-High), velocity-calibrated audit window, `/jared-groom` aging checks |
+| `NATIVE_DEPENDENCIES` | a real relation edge vs. a `blocked-by:<N>` label-marker | `dependency-graph.py`, `jared blocked-by`, sweep's native-dependency hygiene |
+| `MARKDOWN_BODY` | rendered markdown vs. plain text | issue-body templates, `human-readable-board` reference |
+| `CLOSED_STATE` | a real closed state vs. "in the Done column" | `jared close`, sweep's "stuck closed item" check, Done semantics |
+| `MCP_TIER` | the MCP-first operations tier | `references/operations.md` three-tier model |
+| `SUB_ISSUES` | native sub-issue links | epic/sub-issue surfaces |
+
+Today each of these would, on KanbanFlow, either error (calling a method the provider can't fulfil) or silently produce misleading output (an aging report computed from absent timestamps). Neither is acceptable. The discipline the operator already holds elsewhere — **no silent caps; log what was dropped** — is exactly the bar here: a degraded surface must *say so*, in one clear line, not quietly omit.
+
+## Goals
+
+- Every capability-dependent surface (the table above, enumerated exhaustively during planning) checks `provider.capabilities()` and, when the required capability is absent, **degrades with a consistent, documented note** rather than failing or emitting wrong output.
+- A **single degradation helper** produces that note in one format, so the behavior is uniform across surfaces instead of re-invented per command. Shape: `degraded: <feature> unavailable on <backend> — <what happens instead>`.
+- **GitHub backend behavior is unchanged** — it advertises the full set, so no surface degrades; this is the regression bar.
+- The capability set is **resolved once** per invocation (it is static per backend), not re-queried per call.
+- Degradation is **tested** per capability using a capability-restricted fake provider, **and** the user-visible path is confirmed live against a real KanbanFlow board (see Acceptance).
+
+## Non-goals (Phase 6)
+
+- **No new capabilities and no provider changes** beyond what Phase 1/3 defined — Phase 6 *consumes* the enum, it doesn't extend the contract. (If planning reveals a missing capability, that is a finding to surface, not silently add.)
+- **No migration logic** — that is Phase 5 (#318).
+- **No repo/git-axis changes** — PRs, worktrees, session locks, wrap-state, plan archival are backend-independent and never gated by board capabilities.
+- **No attempt to *emulate* a missing capability beyond what already shipped.** blocked-by's label-marker emulation landed with `KanbanFlowProvider`; Phase 6 makes the dependency surfaces *aware* that they are reading emulated edges, it does not build new emulations.
+
+## Architecture
+
+### Two layers gate differently
+
+1. **Python surfaces (CLI subcommands + batch scripts).** Straightforward: read `board.provider.capabilities()`, branch, and route the note through the degradation helper. `sweep.py`'s velocity section, `dependency-graph.py`'s edge source, `jared close`'s Done semantics — each guards its capability-dependent block.
+
+2. **Markdown surfaces (slash-command stubs + SKILL.md + references).** These can't "check" at runtime — they are prose Claude reads. The mechanism must therefore *surface* the capability set to Claude so the rendered behavior adapts. The leading candidate (open question) is a small **`jared capabilities`** subcommand that prints the active backend and its capability set, which the relevant slash-command stubs instruct Claude to consult and degrade against (e.g., `/jared-reshape` skips the Roadmap-date section with a note when `MILESTONE_STATE` is absent). This parallels how the voice kill-switch is surfaced today: doctrine instructs the reader to check a value and branch.
+
+### The degradation helper is the consistency anchor
+
+A single function (Python) + a single documented note phrasing (doctrine) so that "this feature degraded because the backend lacks X" reads identically whether it surfaces from `sweep.py`, `jared close`, or a slash command. Without this anchor, each surface invents its own wording and the degradation becomes noise.
+
+### Default posture: skip-with-note, not error
+
+A missing capability degrades to a soft skip with a one-line note by default. Whether *any* surface is meaningless enough without its capability to warrant a hard error (rather than a skip) is an open question — but the default is soft.
+
+## Open design questions — settle before writing the plan
+
+1. **How do markdown surfaces become capability-aware?** A `jared capabilities` subcommand + per-stub doctrine instructing Claude to consult it and branch? Or bake conditional capability notes directly into each stub's prose? The former centralizes; the latter avoids a runtime call but scatters the logic.
+2. **Soft-skip vs hard-error per surface.** Is there any surface where degrading silently-ish is worse than refusing outright (e.g., a velocity report that would be actively misleading)? Default soft; enumerate exceptions.
+3. **Should `jared` / `jared summary` print a standing backend + degraded-features header**, so the operator always knows which surface they're on and what's unavailable — rather than discovering it per command?
+4. **`SUB_ISSUES`** — Phase 1 anticipated it but Appendix A's omission list doesn't name it for KanbanFlow. Confirm whether KanbanFlow's subtasks satisfy it (KF tasks embed `subTasks`) or whether epic/sub-issue surfaces degrade too.
+5. **Granularity of the note.** One note per degraded *command*, or one per degraded *check within* a command (e.g., sweep has several timestamp-dependent sections)? Per-check is more honest but noisier.
+
+## Acceptance criteria
+
+- Each capability-dependent surface from the table checks the provider's capability set and degrades with a documented note instead of failing or emitting wrong output; the enumeration is complete (a grep/inventory in the plan proves no capability-assuming surface was missed).
+- A single degradation-note format is used across all surfaces (one helper, one phrasing).
+- **GitHub backend: zero behavior change** — full capability set means no surface degrades. The existing unit suite passes untouched on the GitHub path.
+- New unit tests assert the degraded path for each capability using a capability-restricted fake provider (advertise a subset, assert the note + the skipped behavior).
+- **Live verification (required, not fake-only):** capability resolution **and at least one degraded surface** are exercised against a **real KanbanFlow board**, not just `FakeKanbanFlowClient`. The fake can mask the live capability-response shape the same way it masked write-path returns in #317 / PR #334 — so the user-visible degradation must be confirmed live.
+- `ruff check .`, `ruff format .`, `mypy` clean.
+
+## Documentation Impact
+
+- Each slash-command stub that degrades (`/jared-reshape`, `/jared-audit`, `/jared-groom`, others found during planning) — document the KanbanFlow-degraded behavior inline.
+- `skills/jared/references/operations.md` — a capability/degradation section; scope the MCP-first three-tier guidance to `MCP_TIER` (GitHub-only).
+- `skills/jared/SKILL.md` — note the capability model and where degradation is doctrine vs. code.
+- `docs/project-board.md` — a "capabilities on this backend" note so a KanbanFlow-stewarded project documents what degrades.
+- `CLAUDE.md` — capability-consumption note alongside the existing board-provider abstraction paragraph.
+- `CHANGELOG.md` + GitHub Release — at ship, under **Features**.
+- A new implementation plan in `docs/superpowers/plans/` at activation, citing `## Issue: #319`.

--- a/docs/superpowers/specs/archived/2026-06/2026-06-04-phase4-init-backend-selection-design.md
+++ b/docs/superpowers/specs/archived/2026-06/2026-06-04-phase4-init-backend-selection-design.md
@@ -1,6 +1,14 @@
+---
+**Shipped in #317 on 2026-06-05. Final decisions captured in issue body.**
+---
+
 # Phase 4 — Init-time backend selection (design)
 
 Epic #313 ("Make jared board-backend-agnostic"), Phase 4 of 6. Issue #317.
+
+## Issue
+
+- #317
 
 Predecessors (shipped): Phase 1 (#314, `BoardProvider` extraction), Phase 2 (#315,
 KanbanFlow REST client), Phase 3 (#316, `KanbanFlowProvider`). This phase makes the


### PR DESCRIPTION
Epic-doc housekeeping surfaced by the 2026-06-09 structural review (`/jared-reshape`).

## What's in here

**Archive shipped Phase 4 docs.** Phase 4 (#317, init-time backend selection) shipped in v0.29.0, but its plan + spec were still in the active dirs with no `## Issue` linkage (the sweep flagged them as orphans). Added the `## Issue: #317` section to each and ran `archive-plan.py`, which moved them to `archived/2026-06/` and repointed #317's `## Planning` section at the archived paths.

**Draft Phase 5 + 6 specs.** With Phase 4 landed, Phases 5 (#318, `jared migrate`) and 6 (#319, capability declaration + graceful degradation) are unblocked and run in parallel. Both specs carry the frozen forward constraints from the Phase 1 Appendix A (migration fidelity; the capability-omission list) and follow the existing phase-spec shape.

Design decisions that are *genuinely open* are left as explicit "Open design questions" for the activation session rather than decided here — e.g. migrate-closed-items, KF→GitHub cross-ref rewriting, resumability, the markdown-surface capability mechanism.

**Live verification is in both acceptance gates.** Per the #317 / PR #334 lesson (the KanbanFlow fake returns full task objects where the live API returns `{taskId}` / `null` on write), both specs require a real-board round-trip, not a fake-only green run. The same acceptance line now lives on #318 and #319.

**Contract gap flagged.** Phase 5's spec notes that `BoardProvider` has no comment-*read* method (`comment()` is write-only; the `list_comments()` Phase 1 sketched did not ship), so session-note portage needs a contract extension or a named loss.

## Scope

Docs only — no code, no behavior change. No CLI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)