### PR TITLE
fix(313): correct Related-references paths in Phase 5/6 specs

### DIFF
--- a/docs/superpowers/specs/2026-06-09-phase5-jared-migrate-design.md
+++ b/docs/superpowers/specs/2026-06-09-phase5-jared-migrate-design.md
@@ -3,7 +3,7 @@
 **Issue:** #318 (Phase 5). Parent epic: #313.
 **Date:** 2026-06-09
 **Status:** Design — not yet started. Drafted during the 2026-06-09 structural review; **open design questions below are unresolved and must be settled (with the operator) before a plan is written.**
-**Related references:** `skills/jared/scripts/lib/board_provider.py`, `lib/github_provider.py`, `lib/kanbanflow_provider.py`, `docs/superpowers/specs/archived/2026-06/2026-06-02-board-provider-abstraction-design.md` (§ "Appendix A — Migration fidelity"), `docs/project-board.md`.
+**Related references:** `skills/jared/scripts/lib/board_provider.py`, `skills/jared/scripts/lib/github_provider.py`, `skills/jared/scripts/lib/kanbanflow_provider.py`, `docs/superpowers/specs/2026-06-02-board-provider-abstraction-design.md` (§ "Appendix A — Migration fidelity"), `docs/project-board.md`.
 
 ## Context — the larger feature
 

--- a/docs/superpowers/specs/2026-06-09-phase6-capability-declaration-design.md
+++ b/docs/superpowers/specs/2026-06-09-phase6-capability-declaration-design.md
@@ -3,7 +3,7 @@
 **Issue:** #319 (Phase 6). Parent epic: #313.
 **Date:** 2026-06-09
 **Status:** Design — not yet started. Drafted during the 2026-06-09 structural review; **open design questions below are unresolved and must be settled (with the operator) before a plan is written.**
-**Related references:** `skills/jared/scripts/lib/board_provider.py` (the `Capability` enum), `lib/github_provider.py`, `lib/kanbanflow_provider.py`, `docs/superpowers/specs/archived/2026-06/2026-06-02-board-provider-abstraction-design.md` (§ "`Capability` enum", § "Appendix A — Capabilities KanbanFlow will omit"), the slash-command stubs under `commands/`, `skills/jared/SKILL.md`, `skills/jared/references/operations.md`.
+**Related references:** `skills/jared/scripts/lib/board_provider.py` (the `Capability` enum), `skills/jared/scripts/lib/github_provider.py`, `skills/jared/scripts/lib/kanbanflow_provider.py`, `docs/superpowers/specs/2026-06-02-board-provider-abstraction-design.md` (§ "`Capability` enum", § "Appendix A — Capabilities KanbanFlow will omit"), the slash-command stubs under `commands/`, `skills/jared/SKILL.md`, `skills/jared/references/operations.md`.
 
 ## Context — the larger feature
 


### PR DESCRIPTION
Follow-up to #336. Both new specs cited the Phase 1 spec (`§ Appendix A`, their primary source) at a `docs/superpowers/specs/archived/2026-06/...` path — but that file was never archived and *can't* be: it references the still-open epic #313, so "all referenced issues closed" is false. Repointed at the active path. Also normalized the two provider-file references that were written with a bare `lib/` prefix to the full `skills/jared/scripts/lib/` form.

All 11 path references in both specs now resolve. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)