### PR TITLE
Retry transient GitHub source reads on the migrate path (#342)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ uv.lock
 
 # Editable install metadata
 *.egg-info/
+
+# Playwright MCP browser-session artifacts
+.playwright-mcp/

--- a/skills/jared/scripts/capture-context.py
+++ b/skills/jared/scripts/capture-context.py
@@ -70,9 +70,10 @@ def _make_provider(repo: str) -> GitHubProjectsProvider:
 
 
 def fetch_body(repo: str, number: int) -> str:
-    # REST `core` bucket with ETag/conditional GET (#216): delegates to
-    # provider.get_body → lib.board.fetch_issue_body_rest, the body-read twin
-    # of fetch_issue_state_rest, so repeat reads can short-circuit to a 304.
+    # Delegates to provider.get_body, a REST `core`-bucket read. As of #342 that
+    # read retries transient GitHub failures and raises a persistent one (rather
+    # than masquerading as an empty body); it no longer uses the ETag/304 layer,
+    # since capture-context reads each body once and the cache bought nothing.
     # cast: GitHubProjectsProvider imported with type: ignore[import-not-found]
     # is opaque to mypy, so .get_body() is typed Any; we know it returns str.
     return cast("str", _make_provider(repo).get_body(number))

--- a/skills/jared/scripts/lib/github_provider.py
+++ b/skills/jared/scripts/lib/github_provider.py
@@ -7,11 +7,16 @@ patching is preserved.
 
 from __future__ import annotations
 
+import re
+import sys
 import tempfile
+import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from .board import (
+    _TOKEN_SCOPE_ERROR_SIGNATURE,
     FieldNotFound,
     GhInvocationError,
     ItemNotFound,
@@ -82,6 +87,103 @@ class IssueResolutionError(GhInvocationError):
     carries that GitHub-specific phrasing so the CLI can print it verbatim
     without itself referencing node-ids.
     """
+
+
+# --------------------------------------------------------------------------- #
+# Transient-read retry (#342)                                                   #
+#                                                                               #
+# `jared migrate`'s GitHub source reads (list_open_items / fetch_blocked_by_    #
+# edges / list_comments) abort the whole migration when GitHub returns a        #
+# transient failure — most often its intermittent `read:project` scope          #
+# enforcement on ProjectV2 fields, which 401s on one call and succeeds seconds  #
+# later. These reads are idempotent, so a bounded retry is always write-safe.   #
+# A genuinely persistent failure (a token actually missing `project` scope)     #
+# still surfaces clearly: every retry fails and the original error re-raises    #
+# after exhaustion — persistence, not pattern-matching, separates transient     #
+# from terminal. Mirrors the kanbanflow_client retry shape (`_sleep`/`_backoff` #
+# module-level seams; tests patch `_sleep` so the suite never really waits).    #
+# --------------------------------------------------------------------------- #
+
+_T = TypeVar("_T")
+
+# initial attempt + this many retries (4 total attempts: backoffs of 1s, 2s, 4s).
+_MAX_READ_RETRIES = 3
+
+# GitHub's flaky read:project scope enforcement surfaces in TWO wire forms, and
+# the classifier must catch both:
+#   1. transport 401 — `gh: Bad credentials (HTTP 401)` / `HTTP 401: ...`: a
+#      status line the regex below reads. (This is the form observed in PR #341.)
+#   2. GraphQL errors[] (HTTP 200, NO status line) — `gh: Your token has not
+#      been granted the required scopes to execute this query. ... ['read:project']`:
+#      gh exits 1 on any GraphQL errors[] and writes only that message, so the
+#      signature list is the only thing that can catch it.
+#
+# HTTP statuses GitHub returns on a transient blip: 401 (transport scope
+# rejection / "Requires authentication"), 429 + 5xx (rate / server). 403 is
+# deliberately EXCLUDED — a genuine permission 403 stays terminal, and a primary
+# rate-limit 403's reset window far exceeds the bounded 1/2/4s backoff.
+_TRANSIENT_HTTP_STATUSES = frozenset({401, 429, 500, 502, 503, 504})
+
+# Substring signatures (matched case-insensitively) for transient failures that
+# don't carry an HTTP status line in gh's stderr — notably the GraphQL
+# insufficient-scopes form (wire form 2 above). The token-scope signature is
+# imported from board.py so the two stay in lockstep if GitHub's phrasing shifts.
+_TRANSIENT_SIGNATURES = (
+    "requires authentication",
+    "secondary rate limit",
+    "not been granted the required scopes",  # GraphQL INSUFFICIENT_SCOPES (read:project)
+    _TOKEN_SCOPE_ERROR_SIGNATURE.lower(),
+)
+
+_HTTP_STATUS_IN_MESSAGE_RE = re.compile(r"HTTP(?:/[\d.]+)?\s+(\d{3})")
+
+
+def _sleep(seconds: float) -> None:
+    """Module-level sleep seam — patched in tests so retries don't really wait."""
+    time.sleep(seconds)
+
+
+def _backoff(attempt: int) -> float:
+    """Exponential backoff in seconds, capped at 30 (mirrors kanbanflow_client)."""
+    return float(min(2**attempt, 30))
+
+
+def _is_transient_gh_error(exc: GhInvocationError) -> bool:
+    """True when a gh read failure is the retryable kind (flaky scope / 401 / 5xx /
+    secondary rate limit). Everything else — 404, 422, genuine 403, non-JSON
+    output, the list_open_items pagination guard — is terminal and raised at once.
+
+    Classification is a positive allowlist over the error message: a status code
+    in `_TRANSIENT_HTTP_STATUSES`, or one of `_TRANSIENT_SIGNATURES`.
+    """
+    message = str(exc)
+    for match in _HTTP_STATUS_IN_MESSAGE_RE.finditer(message):
+        if int(match.group(1)) in _TRANSIENT_HTTP_STATUSES:
+            return True
+    lowered = message.lower()
+    return any(sig in lowered for sig in _TRANSIENT_SIGNATURES)
+
+
+def _retry_transient_read(fn: Callable[[], _T]) -> _T:
+    """Call `fn`, retrying transient GhInvocationErrors with bounded backoff.
+
+    Terminal errors (and the final exhausted retry) propagate unchanged, so a
+    real auth misconfiguration is never masked — only delayed by the backoffs.
+    """
+    for attempt in range(_MAX_READ_RETRIES + 1):
+        try:
+            return fn()
+        except GhInvocationError as exc:
+            if attempt >= _MAX_READ_RETRIES or not _is_transient_gh_error(exc):
+                raise
+            delay = _backoff(attempt)
+            print(
+                f"note: transient GitHub read failure, retrying in {delay:.0f}s "
+                f"(attempt {attempt + 2}/{_MAX_READ_RETRIES + 1}): {exc}",
+                file=sys.stderr,
+            )
+            _sleep(delay)
+    raise AssertionError("unreachable: retry loop must return or raise")  # pragma: no cover
 
 
 _OPEN_ITEMS_QUERY = """
@@ -246,10 +348,8 @@ class GitHubProjectsProvider:
           keyed by lowercased field name.
         """
         owner, repo_name = self.repo.split("/", 1)
-        data = run_graphql(
-            _OPEN_ITEMS_QUERY,
-            owner=owner,
-            repo=repo_name,
+        data = _retry_transient_read(
+            lambda: run_graphql(_OPEN_ITEMS_QUERY, owner=owner, repo=repo_name)
         )
         issues_node = (data.get("data") or {}).get("repository", {}).get("issues") or {}
         if (issues_node.get("pageInfo") or {}).get("hasNextPage"):
@@ -306,7 +406,19 @@ class GitHubProjectsProvider:
         return item
 
     def get_body(self, ref: IssueRef) -> str:
-        """Return the issue's Markdown body via REST (with ETag/conditional GET)."""
+        """Return the issue's Markdown body via REST (with ETag/conditional GET).
+
+        NOT wrapped in `_retry_transient_read` (#342): `fetch_issue_body_rest`
+        already swallows a transient failure to "" rather than raising, so a
+        naive wrap is a no-op and it never *aborts* a migration. KNOWN GAP, not
+        a clean carve-out: because `_OPEN_ITEMS_QUERY` omits the body, migrate's
+        pass-2 `get_body` is the SOLE body-transfer step — so a transient blip
+        there silently ports an empty body and durably marks it done (tension
+        with #342 criterion 3, "persistent failure must surface"). The fix is a
+        raising read under retry, but it changes get_body's failure contract for
+        the other consumer (capture-context) and its ETag caching — surfaced for
+        an explicit decision rather than folded into the scoped retry change.
+        """
         return fetch_issue_body_rest(self.repo, ref)
 
     def fetch_blocked_by_edges(self) -> list[Edge]:
@@ -317,7 +429,7 @@ class GitHubProjectsProvider:
         `state` is discarded. cache=None (no advisory caching at the provider
         level — callers that want caching pass their own cache kwarg via Board).
         """
-        raw = _fetch_blocked_by_edges(self.repo)
+        raw = _retry_transient_read(lambda: _fetch_blocked_by_edges(self.repo))
         edges: list[Edge] = []
         for dependent_num, blockers in raw.items():
             for blocker_node in blockers:
@@ -337,7 +449,9 @@ class GitHubProjectsProvider:
         `createdAt` is mapped to Comment.created_at here so it never crosses
         the neutral boundary.
         """
-        data = run_gh(["issue", "view", str(ref), "--repo", self.repo, "--json", "comments"])
+        data = _retry_transient_read(
+            lambda: run_gh(["issue", "view", str(ref), "--repo", self.repo, "--json", "comments"])
+        )
         raw = data.get("comments", []) if isinstance(data, dict) else []
         return [
             Comment(

--- a/skills/jared/scripts/lib/github_provider.py
+++ b/skills/jared/scripts/lib/github_provider.py
@@ -22,7 +22,6 @@ from .board import (
     ItemNotFound,
     OptionNotFound,
     _flatten_project_item_for_project,
-    fetch_issue_body_rest,
     run_gh,
     run_gh_raw,
     run_graphql,
@@ -406,20 +405,26 @@ class GitHubProjectsProvider:
         return item
 
     def get_body(self, ref: IssueRef) -> str:
-        """Return the issue's Markdown body via REST (with ETag/conditional GET).
+        """Return the issue's Markdown body via REST, retrying transient failures.
 
-        NOT wrapped in `_retry_transient_read` (#342): `fetch_issue_body_rest`
-        already swallows a transient failure to "" rather than raising, so a
-        naive wrap is a no-op and it never *aborts* a migration. KNOWN GAP, not
-        a clean carve-out: because `_OPEN_ITEMS_QUERY` omits the body, migrate's
-        pass-2 `get_body` is the SOLE body-transfer step — so a transient blip
-        there silently ports an empty body and durably marks it done (tension
-        with #342 criterion 3, "persistent failure must surface"). The fix is a
-        raising read under retry, but it changes get_body's failure contract for
-        the other consumer (capture-context) and its ETag caching — surfaced for
-        an explicit decision rather than folded into the scoped retry change.
+        Reads the body through a *raising* `gh api` call wrapped in
+        `_retry_transient_read` (#342) — NOT the shared `fetch_issue_body_rest`,
+        which swallows every failure to "". That swallow matters because
+        `_OPEN_ITEMS_QUERY` omits the body, so migrate's pass-2 `get_body` is the
+        SOLE body-transfer step: a transient blip there used to silently port an
+        empty body and durably mark it done. Now a transient failure retries and
+        a genuinely persistent one surfaces clearly after exhaustion (criterion 3),
+        while a 200 whose `body` field is absent/empty still returns "".
+
+        Trade-off (accepted, #342 review): this bypasses the ETag/conditional-GET
+        layer, so repeat reads of the same body no longer short-circuit to a 304.
+        get_body's callers — migrate and capture-context — read each body once,
+        so the cache bought nothing here; and a persistently-failing read now
+        raises rather than masquerading as an empty body.
         """
-        return fetch_issue_body_rest(self.repo, ref)
+        data = _retry_transient_read(lambda: run_gh(["api", f"repos/{self.repo}/issues/{ref}"]))
+        body = data.get("body") if isinstance(data, dict) else None
+        return body or ""
 
     def fetch_blocked_by_edges(self) -> list[Edge]:
         """Return all blocked-by edges for open issues in this repo.

--- a/tests/test_github_provider_retry.py
+++ b/tests/test_github_provider_retry.py
@@ -56,8 +56,9 @@ def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
         "gh issue view 5 exited 1: You have exceeded a secondary rate limit",
         "gh api graphql exited 1: HTTP 429: too many requests",
         # GraphQL insufficient-scopes wire form: HTTP 200 + errors[], so gh's
-        # stderr carries NO status line — only the message text. This is the
-        # second wire form of the exact #342 read:project trigger (#342 review).
+        # stderr carries NO status line — only the message text. NOT locally
+        # observed (the PR #341 occurrence was the 401 form); added defensively
+        # from GitHub's documented GraphQL error phrasing per the #342 review.
         "gh api graphql exited 1: gh: Your token has not been granted the required "
         "scopes to execute this query. The 'id' field requires one of the following "
         "scopes: ['read:project'], but your token has only been granted the: [] scopes.",
@@ -259,3 +260,56 @@ def test_fetch_blocked_by_edges_recovers_from_a_transient_read(
 
     assert _provider().fetch_blocked_by_edges() == []
     assert calls["n"] == 2
+
+
+def test_get_body_recovers_from_a_transient_read(
+    monkeypatch: pytest.MonkeyPatch, _no_real_sleep: list[float]
+) -> None:
+    calls = {"n": 0}
+
+    def fake_run_gh(args: list[str], **kwargs: object) -> object:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise GhInvocationError(
+                "gh api repos/o/r/issues/5 exited 1: gh: Bad gateway (HTTP 502)"
+            )
+        return {"body": "the real body"}
+
+    monkeypatch.setattr(gp, "run_gh", fake_run_gh)
+
+    assert _provider().get_body(5) == "the real body"
+    assert calls["n"] == 2  # one transient failure, then the real body
+
+
+def test_get_body_surfaces_a_persistent_read_failure(
+    monkeypatch: pytest.MonkeyPatch, _no_real_sleep: list[float]
+) -> None:
+    """A persistent body-read failure must RAISE (criterion 3), never silently
+    port an empty body — the migrate data-loss vector the #342 review found."""
+
+    def always_fail(args: list[str], **kwargs: object) -> object:
+        raise GhInvocationError(
+            "gh api repos/o/r/issues/5 exited 1: gh: Bad credentials (HTTP 401)"
+        )
+
+    monkeypatch.setattr(gp, "run_gh", always_fail)
+
+    with pytest.raises(GhInvocationError, match="HTTP 401"):
+        _provider().get_body(5)
+
+
+def test_get_body_returns_empty_for_a_genuinely_absent_body(
+    monkeypatch: pytest.MonkeyPatch, _no_real_sleep: list[float]
+) -> None:
+    """A 200 with no body field is a real empty body, not a failure: return ""
+    immediately, no retry (preserves the pre-existing empty-body contract)."""
+    calls = {"n": 0}
+
+    def fake_run_gh(args: list[str], **kwargs: object) -> object:
+        calls["n"] += 1
+        return {"number": 5}  # valid response, body field absent
+
+    monkeypatch.setattr(gp, "run_gh", fake_run_gh)
+
+    assert _provider().get_body(5) == ""
+    assert calls["n"] == 1  # no retry on a genuine empty body

--- a/tests/test_github_provider_retry.py
+++ b/tests/test_github_provider_retry.py
@@ -1,0 +1,261 @@
+"""Tests for transient-read retry on GitHubProjectsProvider (#342).
+
+`jared migrate` reads from the GitHub source via list_open_items /
+fetch_blocked_by_edges / list_comments, which raise GhInvocationError on a
+transient GitHub failure (the flaky `read:project` scope rejection, HTTP 401
+"Requires authentication", 5xx, secondary rate limits). Before #342 a single
+blip aborted the whole migration. These tests pin the retry behaviour:
+
+- transient failures retry with bounded backoff, then succeed (criteria 1-2);
+- a genuinely persistent failure surfaces a clear error after retries are
+  exhausted — retry never masks a real auth misconfiguration (criterion 3);
+- terminal (non-transient) errors raise immediately, no wasted retries.
+
+The module-level `_sleep` seam is patched so the suite never actually sleeps.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from skills.jared.scripts.lib import github_provider as gp
+from skills.jared.scripts.lib.board import GhInvocationError
+from skills.jared.scripts.lib.github_provider import (
+    _MAX_READ_RETRIES,
+    _backoff,
+    _is_transient_gh_error,
+    _retry_transient_read,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Patch the module-level _sleep seam; record the durations it was asked to wait."""
+    waited: list[float] = []
+    monkeypatch.setattr(gp, "_sleep", lambda s: waited.append(s))
+    return waited
+
+
+# --------------------------------------------------------------------------- #
+# _is_transient_gh_error — the transient/terminal classifier                   #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "gh api graphql exited 1: gh: Requires authentication (HTTP 401)",
+        "gh api graphql exited 1: gh: Bad credentials (HTTP 401)",
+        "gh api graphql exited 1: HTTP 401: Bad credentials",
+        "gh api graphql exited 1: Resource not accessible by personal access token",
+        "gh issue view 5 exited 1: HTTP 502: Bad gateway",
+        "gh api graphql exited 1: HTTP 503 Service Unavailable",
+        "gh api graphql exited 1: HTTP 500 Internal Server Error",
+        "gh issue view 5 exited 1: You have exceeded a secondary rate limit",
+        "gh api graphql exited 1: HTTP 429: too many requests",
+        # GraphQL insufficient-scopes wire form: HTTP 200 + errors[], so gh's
+        # stderr carries NO status line — only the message text. This is the
+        # second wire form of the exact #342 read:project trigger (#342 review).
+        "gh api graphql exited 1: gh: Your token has not been granted the required "
+        "scopes to execute this query. The 'id' field requires one of the following "
+        "scopes: ['read:project'], but your token has only been granted the: [] scopes.",
+    ],
+)
+def test_is_transient_accepts_known_transient_signatures(message: str) -> None:
+    assert _is_transient_gh_error(GhInvocationError(message)) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "gh issue view 9999 exited 1: HTTP 404: Not Found",
+        "gh api graphql exited 1: HTTP 422: Validation failed",
+        "gh api graphql exited 1: HTTP 403: Forbidden",  # genuine permission, not rate limit
+        "gh returned non-JSON output: <html>...",
+        # list_open_items' own pagination guard must NOT be retried.
+        "list_open_items() query returned hasNextPage=true; >100 open issues",
+    ],
+)
+def test_is_transient_rejects_terminal_signatures(message: str) -> None:
+    assert _is_transient_gh_error(GhInvocationError(message)) is False
+
+
+# --------------------------------------------------------------------------- #
+# _retry_transient_read — the bounded-backoff retry wrapper                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_retry_returns_immediately_when_call_succeeds(_no_real_sleep: list[float]) -> None:
+    calls = {"n": 0}
+
+    def fn() -> str:
+        calls["n"] += 1
+        return "ok"
+
+    assert _retry_transient_read(fn) == "ok"
+    assert calls["n"] == 1
+    assert _no_real_sleep == []  # no sleep on the happy path
+
+
+def test_retry_recovers_after_transient_failures(_no_real_sleep: list[float]) -> None:
+    calls = {"n": 0}
+
+    def fn() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise GhInvocationError("gh api graphql exited 1: HTTP 401: Requires authentication")
+        return "recovered"
+
+    assert _retry_transient_read(fn) == "recovered"
+    assert calls["n"] == 3  # failed twice, succeeded on the third attempt
+    # bounded EXPONENTIAL backoff, not just "some sleeps" — guards against the
+    # schedule silently collapsing to 0s (criterion: "bounded backoff").
+    assert _no_real_sleep == [1.0, 2.0]
+
+
+def test_backoff_is_bounded_exponential() -> None:
+    assert [_backoff(n) for n in (0, 1, 2, 3)] == [1.0, 2.0, 4.0, 8.0]
+    assert _backoff(20) == 30.0  # capped, never unbounded
+
+
+def test_retry_raises_the_transient_error_after_exhaustion(_no_real_sleep: list[float]) -> None:
+    """A genuinely persistent failure (e.g. a token actually missing project scope)
+    must surface clearly after retries are exhausted — never silently swallowed."""
+    calls = {"n": 0}
+    persistent = GhInvocationError(
+        "gh api graphql exited 1: Resource not accessible by personal access token"
+    )
+
+    def fn() -> str:
+        calls["n"] += 1
+        raise persistent
+
+    with pytest.raises(GhInvocationError) as excinfo:
+        _retry_transient_read(fn)
+
+    assert excinfo.value is persistent  # the real error is surfaced, not masked
+    assert calls["n"] == _MAX_READ_RETRIES + 1  # initial attempt + all retries
+    assert len(_no_real_sleep) == _MAX_READ_RETRIES
+
+
+def test_retry_does_not_retry_terminal_errors(_no_real_sleep: list[float]) -> None:
+    calls = {"n": 0}
+
+    def fn() -> str:
+        calls["n"] += 1
+        raise GhInvocationError("gh issue view 9999 exited 1: HTTP 404: Not Found")
+
+    with pytest.raises(GhInvocationError):
+        _retry_transient_read(fn)
+
+    assert calls["n"] == 1  # raised on the first attempt, no retry
+    assert _no_real_sleep == []  # and no backoff sleep
+
+
+def test_retry_emits_a_stderr_note_on_transient(
+    _no_real_sleep: list[float], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A retry is announced on stderr so the operator sees why migrate paused —
+    the recovery is bounded, not silent."""
+    calls = {"n": 0}
+
+    def fn() -> str:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise GhInvocationError("gh api graphql exited 1: HTTP 502: Bad gateway")
+        return "ok"
+
+    _retry_transient_read(fn)
+    err = capsys.readouterr().err.lower()
+    assert "retr" in err  # mentions retrying
+
+
+# --------------------------------------------------------------------------- #
+# Wiring — the provider read methods route through the retry wrapper            #
+# --------------------------------------------------------------------------- #
+
+
+def _provider() -> gp.GitHubProjectsProvider:
+    return gp.GitHubProjectsProvider(
+        project_number=7,
+        project_id="PVT_x",
+        owner="brockamer",
+        repo="brockamer/findajob",
+        field_ids={"Status": "F1", "Priority": "F2"},
+        field_options={
+            "Status": {"Backlog": "OID_B", "Up Next": "OID_U", "In Progress": "OID_I"},
+            "Priority": {"High": "OID_H", "Medium": "OID_M", "Low": "OID_L"},
+        },
+    )
+
+
+_EMPTY_OPEN_ITEMS = json.dumps(
+    {"data": {"repository": {"issues": {"pageInfo": {"hasNextPage": False}, "nodes": []}}}}
+)
+
+
+def test_list_open_items_recovers_from_a_transient_read(
+    monkeypatch: pytest.MonkeyPatch, _no_real_sleep: list[float]
+) -> None:
+    calls = {"n": 0}
+
+    def fake_graphql(query: str, **kwargs: object) -> object:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise GhInvocationError("gh api graphql exited 1: HTTP 401: Requires authentication")
+        return json.loads(_EMPTY_OPEN_ITEMS)
+
+    monkeypatch.setattr(gp, "run_graphql", fake_graphql)
+
+    assert _provider().list_open_items() == []
+    assert calls["n"] == 2  # one transient failure, then success
+
+
+def test_list_open_items_surfaces_a_persistent_scope_error(
+    monkeypatch: pytest.MonkeyPatch, _no_real_sleep: list[float]
+) -> None:
+    def always_scope_error(query: str, **kwargs: object) -> object:
+        raise GhInvocationError(
+            "gh api graphql exited 1: Resource not accessible by personal access token"
+        )
+
+    monkeypatch.setattr(gp, "run_graphql", always_scope_error)
+
+    with pytest.raises(GhInvocationError, match="personal access token"):
+        _provider().list_open_items()
+
+
+def test_list_comments_recovers_from_a_transient_read(
+    monkeypatch: pytest.MonkeyPatch, _no_real_sleep: list[float]
+) -> None:
+    calls = {"n": 0}
+
+    def fake_run_gh(args: list[str], **kwargs: object) -> object:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise GhInvocationError("gh issue view 5 exited 1: HTTP 502: Bad gateway")
+        return {"comments": []}
+
+    monkeypatch.setattr(gp, "run_gh", fake_run_gh)
+
+    assert _provider().list_comments(5) == []
+    assert calls["n"] == 2
+
+
+def test_fetch_blocked_by_edges_recovers_from_a_transient_read(
+    monkeypatch: pytest.MonkeyPatch, _no_real_sleep: list[float]
+) -> None:
+    calls = {"n": 0}
+
+    def fake_edges(repo: str, **kwargs: object) -> dict[int, list[dict[str, object]]]:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise GhInvocationError("gh api graphql exited 1: HTTP 503 Service Unavailable")
+        return {}
+
+    monkeypatch.setattr(gp, "_fetch_blocked_by_edges", fake_edges)
+
+    assert _provider().fetch_blocked_by_edges() == []
+    assert calls["n"] == 2


### PR DESCRIPTION
Closes #342.

`jared migrate` reads from the GitHub source on the migrate path; before this change a single transient GitHub failure aborted the whole migration. The Phase 4.1 resume ledger caught the fall (re-run resumes), but bailing mid-migration on a momentary blip is brittle. This makes the source reads ride out the bump with bounded retry, while still surfacing a *real* auth misconfiguration loudly.

## What changed

A small retry seam in `github_provider.py`, mirroring the existing `kanbanflow_client` retry shape (module-level `_sleep`/`_backoff` seams; tests patch `_sleep` so the suite never really waits):

- **`_retry_transient_read(fn)`** — runs `fn`, retrying a transient `GhInvocationError` with bounded exponential backoff (1s / 2s / 4s, 4 attempts total). Reads are idempotent, so retry is always write-safe.
- **`_is_transient_gh_error(exc)`** — a positive allowlist: HTTP 401 / 429 / 5xx, secondary rate limit, and the `read:project` scope rejection. Everything else (404, 422, genuine 403, non-JSON, the pagination guard) is terminal and raised at once.
- The four migrate read methods now route through it: **`list_open_items`**, **`fetch_blocked_by_edges`**, **`list_comments`**, and **`get_body`**.

A **genuinely persistent** failure (a token actually missing `project` scope) is never masked — every retry fails and the original error re-raises after exhaustion. *Persistence, not pattern-matching, separates transient from terminal* — which is also why a flaky-vs-genuine scope error needs no perfect single-shot classifier.

## On the two wire forms of the `read:project` rejection

The classifier catches both, but they have different evidentiary status — flagging this honestly:

1. **Transport 401** — `gh: Bad credentials (HTTP 401)` / `HTTP 401: ...`. **Empirically verified** this session against real `gh` (forced a 401, confirmed the stderr format the status-regex matches). This is the form observed during the #318 live run / PR #341.
2. **GraphQL `INSUFFICIENT_SCOPES`** — HTTP 200 + `errors[]`, so gh's stderr carries *no* status line, only `Your token has not been granted the required scopes...`. **Not locally reproducible this session** (the scope query succeeded — itself a demonstration of the intermittent enforcement). Caught by a signature added **defensively from GitHub's documented GraphQL error format** per review, not from an observation. Safe either way: it's a positive-allowlist addition — inert if it never matches, and it cannot regress the verified 401 path.

## `get_body` — the review's material find

All three review lenses flagged it. Because `_OPEN_ITEMS_QUERY` omits the issue body, migrate's pass-2 `get_body` is the **sole** body-transfer step (GH→KF). It used to route through `fetch_issue_body_rest`, which swallows *any* failure to `""` — so a transient blip there silently ported an empty body, durably marked the item done, and flipped the backend on apparent success. That's silent data loss that violates the issue's own criterion 3 ("persistent failure must surface").

`get_body` now reads via a raising `gh api` call wrapped in the same retry helper: retries transient failures, raises a persistent one after exhaustion, and still returns `""` for a genuinely absent/empty body field. **Behavior changes worth noting:**
- It now **raises** on a persistent failure (incl. a 404 / issue-not-found) where it previously returned `""`. Migrate and capture-context both pass known-existing issue numbers, and a clear raise beats a silent empty body.
- It **bypasses the ETag/304 layer** — its callers (migrate, capture-context) read each body once, so the cache bought nothing. `capture-context`'s comment is updated to match.

## Tests & verification

- 28 new unit tests in `tests/test_github_provider_retry.py`: classification (transient vs terminal), retry-then-succeed, retry-then-exhaust, terminal-immediate, bounded-exponential backoff schedule + cap, and per-method seam wiring for all four reads.
- All four acceptance criteria covered.
- Full suite **884 passed**, `ruff check` clean, `ruff format` clean, `mypy --strict` clean.

The retry is proven at the provider seam; there's no migrate-*level* integration test (`test_cmd_migrate` uses a stub provider) — migrate gets the behavior by composition, which the review judged acceptable.

## Review

TDD throughout (red → green per method). A 3-lens adversarial review (classifier correctness / write-safety / regression) ran against the diff; its two real findings — the INSUFFICIENT_SCOPES second wire form and the `get_body` silent-empty-body — are both addressed here. Findings were verified independently against real `gh` output rather than accepted on faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)