### PR TITLE
chore: archive shipped epic #313 plans + specs

### DIFF
--- a/docs/superpowers/plans/archived/2026-06/2026-06-02-board-provider-interface-extraction.md
+++ b/docs/superpowers/plans/archived/2026-06/2026-06-02-board-provider-interface-extraction.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #313, #314 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # BoardProvider Interface Extraction Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/archived/2026-06/2026-06-09-phase5-jared-migrate.md
+++ b/docs/superpowers/plans/archived/2026-06/2026-06-09-phase5-jared-migrate.md
@@ -1,8 +1,12 @@
+---
+**Shipped in #318 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # `jared migrate` Between Backends — Implementation Plan (Phase 5)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-## Issue: #318
+**Issue:** #318
 
 **Goal:** Add a one-shot, operator-confirmed `jared migrate` command that copies a project's board from its current backend (GitHub Projects v2 or KanbanFlow) to the other, surfacing every named, accepted loss before the first write.
 

--- a/docs/superpowers/plans/archived/2026-06/2026-06-09-phase6-capability-degradation.md
+++ b/docs/superpowers/plans/archived/2026-06/2026-06-09-phase6-capability-degradation.md
@@ -1,8 +1,12 @@
+---
+**Shipped in #319 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # Phase 6 — Capability Declaration + Graceful Degradation Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-## Issue: #319
+**Issue:** #319
 
 **Goal:** Make every jared surface that assumes a GitHub-only board capability instead check `board.capabilities()` and degrade with a single consistent note (or, on KanbanFlow, omit a misleading value / refuse a whole-scope-absent invocation) — so the core board loop works on both backends and GitHub-only richness degrades gracefully instead of erroring or lying.
 

--- a/docs/superpowers/plans/archived/2026-06/2026-06-09-phase6-capability-inventory.md
+++ b/docs/superpowers/plans/archived/2026-06/2026-06-09-phase6-capability-inventory.md
@@ -1,6 +1,12 @@
+---
+**Shipped in #319 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # Phase 6 capability-surface inventory (completeness proof)
 
 > Generated 2026-06-09 from the `phase6-design-resolution` workflow (four-region fan-out, sonnet). This is the exhaustive enumeration the spec's acceptance criterion #1 requires ("a grep/inventory proves no capability-assuming surface was missed"). **84 surfaces / 24 files / 47 misleading-if-shown.** `SUB_ISSUES` rows are deliberate non-findings (phantom capability — see plan Task 0 / spec Resolved decision 4). The implementation plan ([2026-06-09-phase6-capability-degradation.md](2026-06-09-phase6-capability-degradation.md)) groups these into tasks; each row's `degrade_to` is the per-surface spec.
+
+**Issue:** #319
 
 ## CLOSED_STATE — 13 surface(s), 5 misleading
 

--- a/docs/superpowers/specs/archived/2026-06/2026-06-02-board-provider-abstraction-design.md
+++ b/docs/superpowers/specs/archived/2026-06/2026-06-02-board-provider-abstraction-design.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #313, #314 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # Board provider abstraction — Phase 1: interface extraction
 
 **Issue:** #314 (Phase 1). Parent epic: #313.

--- a/docs/superpowers/specs/archived/2026-06/2026-06-02-kanbanflow-rest-client-design.md
+++ b/docs/superpowers/specs/archived/2026-06/2026-06-02-kanbanflow-rest-client-design.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #313, #315, #316 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # KanbanFlow REST client — Phase 2 (#315)
 
 **Issue:** #315 (Phase 2). Parent epic: #313. Consumed by: #316 (`KanbanFlowProvider`).

--- a/docs/superpowers/specs/archived/2026-06/2026-06-03-kanbanflow-provider-design.md
+++ b/docs/superpowers/specs/archived/2026-06/2026-06-03-kanbanflow-provider-design.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #313, #316 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # KanbanFlowProvider — Phase 3: implement the BoardProvider contract over KanbanFlow
 
 **Issue:** #316 (Phase 3). Parent epic: #313.

--- a/docs/superpowers/specs/archived/2026-06/2026-06-09-phase5-jared-migrate-design.md
+++ b/docs/superpowers/specs/archived/2026-06/2026-06-09-phase5-jared-migrate-design.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #313, #318 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # `jared migrate` between backends — Phase 5: migration command (design)
 
 **Issue:** #318 (Phase 5). Parent epic: #313.

--- a/docs/superpowers/specs/archived/2026-06/2026-06-09-phase6-capability-declaration-design.md
+++ b/docs/superpowers/specs/archived/2026-06/2026-06-09-phase6-capability-declaration-design.md
@@ -1,3 +1,7 @@
+---
+**Shipped in #313, #319 on 2026-06-10. Final decisions captured in issue body.**
+---
+
 # Capability declaration + graceful degradation — Phase 6 (design)
 
 **Issue:** #319 (Phase 6). Parent epic: #313.


### PR DESCRIPTION
Epic #313 (pluggable backends) shipped in v0.30.0; this archives its 9 design docs to `docs/superpowers/{plans,specs}/archived/2026-06/` via `archive-plan.py --scan`, repointing each issue's `## Planning` link. The active plan/spec dirs are now clear.

Note: the three most recent plans used `## Issue: #N` (jared's documented convention), which `archive-plan.py`'s `parse_referenced_issues` doesn't recognize (it wants `**Issue:**` / a standalone `## Issue`). Converted them to `**Issue:**` to unblock archival; the scanner/convention mismatch is worth a separate fix so future plans don't silently skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)