### PR TITLE
fix(jared): recognize the documented `## Issue: #N` plan-header convention

### DIFF
--- a/skills/jared/scripts/lib/board.py
+++ b/skills/jared/scripts/lib/board.py
@@ -1233,21 +1233,38 @@ _PLAN_LINE_REF_RE = re.compile(
 
 
 def _parse_plan_section(plan_text: str, heading_pattern: str) -> list[int] | None:
-    """Find a heading-bounded section and return line-start refs from its body.
+    """Find a heading-bounded section and return refs from it.
 
     Returns None if the heading is absent — distinguishes "section missing"
     from "section present but empty" so callers can fall back to alternate
     parsers (e.g. the `**Issue:**` bold-line fallback).
+
+    Two ref-bearing positions count (#346):
+
+    1. **Inline on the heading line** — the documented `## Issue: #N` plan
+       convention (CLAUDE.md, plan/spec templates). The heading line is itself
+       a designated ref carrier, like the `**Issue:**` bold line, so *all*
+       refs in the inline content count (`## Issues: #12, #13` → both).
+    2. **Body lines below the heading** — only lines whose meaningful content
+       STARTS with a ref (the stricter line-start rule that skips mid-line
+       prose refs, guarding against the #86/#87 false positives).
+
+    The body sub-match is `*?` (allows empty) so a file ending exactly at an
+    inline header — `## Issue: #N` with no body, no trailing newline — still
+    parses rather than failing the whole match.
     """
     section_match = re.search(
-        rf"^{heading_pattern}\s*$([\s\S]+?)(?=^#{{1,3}}\s|\Z)",
+        rf"^{heading_pattern}\s*(?::\s*(?P<inline>.*))?$(?P<body>[\s\S]*?)(?=^#{{1,3}}\s|\Z)",
         plan_text,
         re.MULTILINE,
     )
     if not section_match:
         return None
     refs: list[int] = []
-    for line in section_match.group(1).splitlines():
+    inline = section_match.group("inline")
+    if inline:
+        refs.extend(int(n) for ref in _PLAN_ISSUE_REF_RE.findall(inline) for n in ref if n)
+    for line in section_match.group("body").splitlines():
         m = _PLAN_LINE_REF_RE.match(line)
         if not m:
             continue
@@ -1261,11 +1278,14 @@ def _parse_plan_section(plan_text: str, heading_pattern: str) -> list[int] | Non
 def parse_referenced_issues(plan_text: str) -> list[int]:
     """Extract issue numbers from a plan/spec.
 
-    Primary source: a `## Issue` / `## Issues` / `## Issue(s)` section. Inside
-    that section, only lines whose meaningful content STARTS with a ref count
-    — list-item form (`- #42`, `* https://github.com/.../issues/42`) and
-    bare line-start form (`#229 — Metric Layer C.0`) both qualify.
-    Mid-line refs in prose, blockquotes, or bold lines are skipped.
+    Primary source: a `## Issue` / `## Issues` / `## Issue(s)` section. The ref
+    may sit either inline on the heading line itself — the documented
+    `## Issue: #N` convention (#346) — or on body lines below the heading. For
+    body lines, only those whose meaningful content STARTS with a ref count:
+    list-item form (`- #42`, `* https://github.com/.../issues/42`) and bare
+    line-start form (`#229 — Metric Layer C.0`) both qualify; mid-line refs in
+    prose, blockquotes, or bold lines are skipped. The inline-heading carrier
+    is less restrictive (all refs in it count), like the `**Issue:**` line.
 
     Fallback (when no `## Issue` heading is present): a `**Issue:**` /
     `**Issues:**` / `**Tracking issue:**` bold line near the top of the file

--- a/tests/test_archive_plan.py
+++ b/tests/test_archive_plan.py
@@ -209,6 +209,47 @@ def test_parse_referenced_issues_bold_form_does_not_match_mid_line_prose() -> No
     assert ap.parse_referenced_issues(text) == [408, 310]
 
 
+def test_parse_referenced_issues_inline_header_form() -> None:
+    """#346 — the documented `## Issue: #N` convention carries the ref ON the
+    heading line. The #318/#319 plans wrote exactly this form (`## Issue: #318`,
+    verified in git at a53249b) and silently skipped archival until #345
+    hand-converted them to `**Issue:**`. The scanner must recognize the
+    documented header form directly.
+    """
+    text = "# Phase 5 plan\n\n## Issue: #318\n\n## Goal\n\nStuff.\n"
+    assert ap.parse_referenced_issues(text) == [318]
+
+
+def test_parse_referenced_issues_inline_header_with_trailing_description() -> None:
+    """The inline header may carry a trailing em-dash description after the
+    ref — findall ignores the prose, same as the `**Issue:**` bold line."""
+    text = "# Plan\n\n## Issue: #318 — Phase 5 migrate\n\n## Goal\n"
+    assert ap.parse_referenced_issues(text) == [318]
+
+
+def test_parse_referenced_issues_inline_header_plural_multiple_refs() -> None:
+    """`## Issues: #12, #13` — plural heading with multiple inline refs,
+    mirroring the bold-line plural case."""
+    text = "# Plan\n\n## Issues: #12, #13\n\n## Goal\n"
+    assert ap.parse_referenced_issues(text) == [12, 13]
+
+
+def test_parse_referenced_issues_inline_header_at_eof_no_trailing_newline() -> None:
+    """A plan whose file ends exactly at the inline header — no body, no
+    trailing newline. The body sub-match must allow empty (`*?`, not `+?`),
+    or the heading match fails outright and the ref is lost to the `[]` path.
+    """
+    text = "# Plan\n\n## Issue: #346"
+    assert ap.parse_referenced_issues(text) == [346]
+
+
+def test_parse_referenced_issues_inline_header_wins_over_bold_line() -> None:
+    """Precedence holds for the inline form too: a `## Issue: #N` header wins
+    over a `**Issue:**` bold line, same as the bare `## Issue` section does."""
+    text = "# Plan\n\n**Issue:** #99\n\n## Issue: #1\n\n## Body\n"
+    assert ap.parse_referenced_issues(text) == [1]
+
+
 def test_parse_shipped_section_returns_pr_numbers() -> None:
     """The `## Shipped` section is the same shape as `## Issue` — list-item
     refs whose meaningful content starts with `#NNN` or a URL.
@@ -230,6 +271,15 @@ def test_parse_shipped_section_ignores_inline_prose_refs() -> None:
         "Adapter #2 was the first one merged.\n"
         "**Note:** also see #888 follow-up.\n\n## Body\n"
     )
+    assert ap.parse_shipped_section(text) == [415]
+
+
+def test_parse_shipped_section_inline_header_form() -> None:
+    """#346 — the shared `_parse_plan_section` change makes the inline-header
+    form parse for `## Shipped:` too. This test owns that blast-radius change
+    explicitly rather than letting the shared-helper behavior shift silently.
+    """
+    text = "# Plan\n\n## Shipped: #415\n\n## Body\n"
     assert ap.parse_shipped_section(text) == [415]
 
 


### PR DESCRIPTION
## Summary

`parse_referenced_issues` only recognized a `**Issue:**` bold line or a bare `## Issue` section (refs on body lines below) — never the `## Issue: #N` **inline-header** form the plan/spec templates actually prescribe. Plans written to the documented convention silently skipped archival: `archive-plan.py --scan` printed `no ## Issue section; skipping` and moved on. The #318/#319 plans hit this during the epic #313 archival and had to be hand-converted to `**Issue:**` in PR #345.

## What changed

- `_parse_plan_section` (shared helper) now captures an **optional inline ref on the heading line** via named groups; the heading is a designated ref-carrier like the bold line, so all refs in it count (`## Issues: #12, #13` → both).
- Body sub-match relaxed `+?`→`*?` so a file ending exactly at `## Issue: #N` (no body, no trailing newline) still parses instead of failing the whole match.
- Body lines keep the stricter line-start rule (the #86/#87 mid-line-prose guard is untouched).
- Docstrings on `_parse_plan_section` and `parse_referenced_issues` now document the inline-header form.

Chose the **recommended direction**: teach the scanner the documented form rather than changing the convention. The shared-helper change also benefits `parse_shipped_section` (`## Shipped: #N`) and `sweep.py`'s active-plan-without-issue check — both owned by tests / verified.

## Acceptance criteria

- [x] `parse_referenced_issues` recognizes `## Issue: #N` alongside `**Issue:**` and bare `## Issue`.
- [x] `archive-plan.py --scan` picks up a plan whose only ref is a `## Issue: #N` header.
- [x] Unit tests in `tests/test_archive_plan.py` cover the form (6 new tests, incl. the `## Shipped:` blast-radius case).
- [x] One direction chosen and applied.

## Validation

- **TDD:** 6 new tests written first, watched fail (returned `[]` / fell through to bold-line), then green.
- Full suite: **890 passed**; `ruff check` + `ruff format` clean; `mypy --strict` clean.
- **End-to-end** against the real consumer — `archive-plan.py --scan` on inline-header fixtures:
  - `## Issue: #342` (closed) → `Referenced issues: [342] (all closed)` → archives (dry-run).
  - `## Issue: #346` (open) → `not all issues closed (open: [346]); skipping` — **not** `no ## Issue section`, proving the ref is now parsed.
- Test fixture grounded in the verified pre-conversion shape `## Issue: #318` (from git `a53249b`), not a synthetic ref.

Closes #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)