### PR TITLE
KanbanFlow parity: Phase 0 design + Phase 1a recently_closed via board events

### DIFF
--- a/docs/superpowers/plans/2026-06-11-kanbanflow-events-recently-closed.md
+++ b/docs/superpowers/plans/2026-06-11-kanbanflow-events-recently-closed.md
@@ -16,9 +16,11 @@ This is **Phase 1a** of epic #357 (see `docs/superpowers/specs/2026-06-11-kanban
 
 **Explicitly NOT in this plan** (each planned separately when pulled):
 - **Phase 1b — CLOSED_STATE flip** (`find_orphaned` via Done-membership). Touches `dependency-graph.py` and may add a `@runtime_checkable BoardProvider` method → the atomic-coupling constraint (both provider impls in one commit).
-- **Phase 1c — VELOCITY_TIMESTAMPS flag decision.** Needs per-task `createdAt`/activity reconstruction across all open items **and** the event-retention ceiling (Task 4 records the first observation). The `VELOCITY_TIMESTAMPS` flag is **not** flipped in this plan; `recently_closed` returning data is independent of the flag (no surface gates `recently_closed` on it — verified by grep: the five gates are all created-at/activity surfaces).
+- **Phase 1c — VELOCITY_TIMESTAMPS flag decision.** Needs per-task `createdAt`/activity reconstruction across all open items **and** the event-retention ceiling (Task 4 records the first observation). The `VELOCITY_TIMESTAMPS` flag is **not** flipped in this plan.
 
-**Per-capability outcome of this plan:** no `_OMITTED_CAPABILITIES` change. `recently_closed` ships real data; the capability declaration is untouched.
+**Per-capability outcome of this plan:** no `_OMITTED_CAPABILITIES` change. `recently_closed` ships real data — but it is **dormant**: its only production consumer, the next-session-prompt "Recently closed" section (`skills/jared/scripts/jared:1190`), *also* gates on `VELOCITY_TIMESTAMPS`, so on KanbanFlow it shows the degraded note and never calls `recently_closed` until the flag flips (Phase 1b/1c). Phase 1a is correct foundational plumbing, not a user-visible KanbanFlow change.
+
+> **Correction (Phase 1a final review):** an earlier draft of this plan claimed "no surface gates `recently_closed` on [VELOCITY_TIMESTAMPS]." That was wrong — the grep behind it used `--include=*.py` and missed the extension-less `jared` CLI entry point, where the recently-closed section is a 6th VELOCITY_TIMESTAMPS gate. The spec's §6 Phase-1c design note records the un-gating decision this creates.
 
 ## File Structure
 
@@ -527,10 +529,9 @@ print('windowed event count (expect a small subset):', len(narrow))
 
 Expected: a strict subset of the full history. **If the count equals the full history**, the server ignores ISO `from`/`to` → record that `get_board_events` must rely on client-side timestamp filtering (already present in `recently_closed`) and note the format question for Phase 1c. **Either outcome is acceptable for this plan** — `recently_closed` already filters client-side defensively.
 
-- [ ] **Step 3: Confirm the integration surface**
+- [ ] **Step 3: Confirm the consumer is gated (dormancy), not the data**
 
-Run: `source /home/brockamer/.secrets && /home/brockamer/Code/jared/skills/jared/scripts/jared next-session-prompt` **against a KanbanFlow-backed `docs/project-board.md`** (the test board), and confirm the "Recently closed" section is now populated rather than empty.
-Expected: at least the `1eTJRipf` close appears (or however the test board stands at run time).
+The next-session-prompt "Recently closed" section gates on `VELOCITY_TIMESTAMPS` (`jared:1190`), which KanbanFlow omits — so the CLI would show the *degraded note*, not the data, even though `recently_closed` now works. Confirm the dormancy at the provider level instead (Step 1 already does): the data is correct-but-dormant until Phase 1b/1c un-gates the section. **Do not** expect `jared next-session-prompt` to surface the close on KanbanFlow in Phase 1a.
 
 - [ ] **Step 4: Record findings in the spec**
 

--- a/docs/superpowers/plans/2026-06-11-kanbanflow-events-recently-closed.md
+++ b/docs/superpowers/plans/2026-06-11-kanbanflow-events-recently-closed.md
@@ -1,0 +1,560 @@
+# KanbanFlow event-history client + `recently_closed` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `KanbanFlowProvider.recently_closed()` real data by reading the `GET /board/events` history for `columnId`→Done transitions, replacing today's `return []` stub.
+
+**Architecture:** Add a `KfEvent` dataclass family + parser and a `get_board_events()` method to the stdlib KanbanFlow client (mirroring the existing `KfRelation`/`get_relations` and `list_tasks`-paging idioms), then rewrite the provider's `recently_closed` to scan events for moves into the Done column (resolved via the Status column map) and map each to a `ClosedItem`. A final task live-verifies on board `p9vK6cR`.
+
+**Tech Stack:** Python 3 (stdlib-only client), pytest, the `_raw_http`/`patch_kf` test seam, `mypy --strict`, `ruff`.
+
+---
+
+## Scope (read first)
+
+This is **Phase 1a** of epic #357 (see `docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md`). It is a complete, testable deliverable on its own: `recently_closed` returns real data, which populates `jared next-session-prompt`'s "Recently closed" section on a KanbanFlow board.
+
+**Explicitly NOT in this plan** (each planned separately when pulled):
+- **Phase 1b — CLOSED_STATE flip** (`find_orphaned` via Done-membership). Touches `dependency-graph.py` and may add a `@runtime_checkable BoardProvider` method → the atomic-coupling constraint (both provider impls in one commit).
+- **Phase 1c — VELOCITY_TIMESTAMPS flag decision.** Needs per-task `createdAt`/activity reconstruction across all open items **and** the event-retention ceiling (Task 4 records the first observation). The `VELOCITY_TIMESTAMPS` flag is **not** flipped in this plan; `recently_closed` returning data is independent of the flag (no surface gates `recently_closed` on it — verified by grep: the five gates are all created-at/activity surfaces).
+
+**Per-capability outcome of this plan:** no `_OMITTED_CAPABILITIES` change. `recently_closed` ships real data; the capability declaration is untouched.
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `skills/jared/scripts/lib/kanbanflow_client.py` | Modify | Add `KfChangedProperty`/`KfDetailedEvent`/`KfEvent` dataclasses, their `_parse_*` functions, and `get_board_events()` |
+| `skills/jared/scripts/lib/kanbanflow_provider.py` | Modify | Add `get_board_events` to the `KanbanFlowClientLike` Protocol; import `KfEvent`; rewrite `recently_closed` |
+| `tests/fake_kanbanflow.py` | Modify | Add `board_events` attribute + `get_board_events()` to `FakeKanbanFlowClient` |
+| `tests/test_kanbanflow_client.py` | Modify | Tests for `_parse_event` and `get_board_events` (single call + paging) |
+| `tests/test_kanbanflow_provider.py` | Modify | Replace `test_recently_closed_is_empty_degraded` with real-data tests |
+
+---
+
+### Task 1: `KfEvent` dataclass family + parsers (client)
+
+**Files:**
+- Modify: `skills/jared/scripts/lib/kanbanflow_client.py` (dataclass block ~L176-188; parser block ~L265-277)
+- Test: `tests/test_kanbanflow_client.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_kanbanflow_client.py` (and add `_parse_event` + `KfEvent` to the existing `from ...kanbanflow_client import (...)` block at the top):
+
+```python
+def test_parse_event_maps_nested_shape() -> None:
+    raw = {
+        "_id": "Nn1Xdp",
+        "timestamp": "2026-06-05T13:20:56.216Z",
+        "userId": "u-1",
+        "detailedEvents": [
+            {
+                "eventType": "taskChanged",
+                "taskId": "1eTJRipf",
+                "changedProperties": [
+                    {"property": "columnId", "oldValue": "col-inprog", "newValue": "col-done"}
+                ],
+            }
+        ],
+    }
+    ev = kf._parse_event(raw)
+    assert ev.id == "Nn1Xdp"
+    assert ev.timestamp == "2026-06-05T13:20:56.216Z"
+    assert ev.user_id == "u-1"
+    assert len(ev.detailed_events) == 1
+    de = ev.detailed_events[0]
+    assert de.event_type == "taskChanged"
+    assert de.task_id == "1eTJRipf"
+    assert de.changed_properties[0].property == "columnId"
+    assert de.changed_properties[0].old_value == "col-inprog"
+    assert de.changed_properties[0].new_value == "col-done"
+
+
+def test_parse_event_taskcreated_has_no_changed_properties() -> None:
+    ev = kf._parse_event(
+        {"_id": "e2", "timestamp": "t", "detailedEvents": [{"eventType": "taskCreated", "taskId": "x"}]}
+    )
+    assert ev.detailed_events[0].changed_properties == []
+    assert ev.user_id == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_kanbanflow_client.py::test_parse_event_maps_nested_shape -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_parse_event'` (and the import line fails to resolve `KfEvent`/`_parse_event`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `kanbanflow_client.py`, add the dataclasses after `KfUser` (~L188):
+
+```python
+@dataclass
+class KfChangedProperty:
+    property: str
+    old_value: str | None = None
+    new_value: str | None = None
+
+
+@dataclass
+class KfDetailedEvent:
+    event_type: str
+    task_id: str | None = None
+    changed_properties: list[KfChangedProperty] = field(default_factory=list)
+
+
+@dataclass
+class KfEvent:
+    id: str
+    timestamp: str
+    user_id: str = ""
+    detailed_events: list[KfDetailedEvent] = field(default_factory=list)
+```
+
+And add the parsers after `_parse_user` (~L277):
+
+```python
+def _parse_changed_property(raw: dict[str, Any]) -> KfChangedProperty:
+    return KfChangedProperty(
+        property=str(raw.get("property", "")),
+        old_value=str(raw["oldValue"]) if raw.get("oldValue") is not None else None,
+        new_value=str(raw["newValue"]) if raw.get("newValue") is not None else None,
+    )
+
+
+def _parse_detailed_event(raw: dict[str, Any]) -> KfDetailedEvent:
+    return KfDetailedEvent(
+        event_type=str(raw.get("eventType", "")),
+        task_id=str(raw["taskId"]) if raw.get("taskId") is not None else None,
+        changed_properties=[
+            _parse_changed_property(cp) for cp in raw.get("changedProperties", [])
+        ],
+    )
+
+
+def _parse_event(raw: dict[str, Any]) -> KfEvent:
+    return KfEvent(
+        id=str(raw.get("_id", "")),
+        timestamp=str(raw.get("timestamp", "")),
+        user_id=str(raw.get("userId", "")),
+        detailed_events=[_parse_detailed_event(de) for de in raw.get("detailedEvents", [])],
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_kanbanflow_client.py -k parse_event -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/jared/scripts/lib/kanbanflow_client.py tests/test_kanbanflow_client.py
+git commit -m "feat(jared): add KfEvent dataclasses + parser (Phase 1a.1)"
+```
+
+---
+
+### Task 2: `get_board_events()` client method (single call + windowed paging)
+
+**Files:**
+- Modify: `skills/jared/scripts/lib/kanbanflow_client.py` (add method after `get_relations`, ~L544)
+- Test: `tests/test_kanbanflow_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_get_board_events_single_call_returns_parsed_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = json.dumps(
+        {
+            "eventsLimited": False,
+            "events": [
+                {
+                    "_id": "e1",
+                    "timestamp": "2026-06-05T13:20:56.216Z",
+                    "detailedEvents": [
+                        {
+                            "eventType": "taskChanged",
+                            "taskId": "t1",
+                            "changedProperties": [
+                                {"property": "columnId", "oldValue": "a", "newValue": "b"}
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    calls = patch_kf(monkeypatch, status=200, body=body)
+    events = _client().get_board_events(limit=100, order="descending")
+    assert len(events) == 1
+    assert events[0].id == "e1"
+    assert events[0].detailed_events[0].changed_properties[0].new_value == "b"
+    assert "/board/events" in cast(str, calls[0]["url"])
+    assert "limit=100" in cast(str, calls[0]["url"])
+    assert "order=descending" in cast(str, calls[0]["url"])
+
+
+def test_get_board_events_pages_backward_when_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seq = [
+        (
+            200,
+            {},
+            json.dumps(
+                {
+                    "eventsLimited": True,
+                    "events": [
+                        {"_id": "e2", "timestamp": "2026-06-05T13:00:00.000Z", "detailedEvents": []},
+                        {"_id": "e1", "timestamp": "2026-06-05T12:00:00.000Z", "detailedEvents": []},
+                    ],
+                }
+            ).encode(),
+        ),
+        (
+            200,
+            {},
+            json.dumps(
+                {
+                    "eventsLimited": False,
+                    "events": [
+                        {"_id": "e0", "timestamp": "2026-06-05T11:00:00.000Z", "detailedEvents": []}
+                    ],
+                }
+            ).encode(),
+        ),
+    ]
+    urls: list[str] = []
+
+    def fake(method: str, url: str, headers: dict[str, str], data: bytes | None):
+        urls.append(url)
+        return seq.pop(0)
+
+    monkeypatch.setattr(kf, "_raw_http", fake)
+    events = _client().get_board_events(order="descending")
+    assert [e.id for e in events] == ["e2", "e1", "e0"]
+    assert len(urls) == 2
+    # Second window ends just before the oldest event of the first batch.
+    assert "to=2026-06-05T12%3A00%3A00.000Z" in urls[1] or "to=2026-06-05T12:00:00.000Z" in urls[1]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_kanbanflow_client.py -k get_board_events -v`
+Expected: FAIL — `AttributeError: 'KanbanFlowClient' object has no attribute 'get_board_events'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `kanbanflow_client.py`, add after `get_relations` (~L544):
+
+```python
+def get_board_events(
+    self,
+    *,
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+    limit: int = 100,
+    order: str = "descending",
+    max_pages: int = 20,
+) -> list[KfEvent]:
+    """Read board event history (GET /board/events).
+
+    Returns events newest-first (order='descending'). The endpoint has no
+    cursor — when the response sets `eventsLimited`, this walks the time
+    window backward by setting `to` to the oldest event seen, bounded by
+    `from_ts` (server-side floor) and `max_pages` (safety cap). The
+    `{eventsLimited, events}` envelope shape is confirmed live on p9vK6cR.
+    """
+    out: list[KfEvent] = []
+    window_to = to_ts
+    for _ in range(max_pages):
+        params: dict[str, object] = {
+            "from": from_ts,
+            "to": window_to,
+            "limit": limit,
+            "order": order,
+        }
+        raw = self._request("GET", "/board/events", params=params)
+        if not isinstance(raw, dict):
+            break
+        batch = [_parse_event(e) for e in (raw.get("events") or [])]
+        out.extend(batch)
+        if not raw.get("eventsLimited") or not batch:
+            break
+        oldest = min((e.timestamp for e in batch if e.timestamp), default=None)
+        if oldest is None or oldest == window_to:
+            break
+        window_to = oldest
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_kanbanflow_client.py -k get_board_events -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/jared/scripts/lib/kanbanflow_client.py tests/test_kanbanflow_client.py
+git commit -m "feat(jared): add get_board_events with windowed paging (Phase 1a.2)"
+```
+
+---
+
+### Task 3: Rewrite `recently_closed` to scan events for moves into Done
+
+**Files:**
+- Modify: `tests/fake_kanbanflow.py` (add `board_events` + `get_board_events` to the fake)
+- Modify: `skills/jared/scripts/lib/kanbanflow_provider.py` (Protocol L65-101; import L20-28; `recently_closed` L287-291)
+- Test: `tests/test_kanbanflow_provider.py` (replace `test_recently_closed_is_empty_degraded`, L106-109)
+
+- [ ] **Step 1: Extend the fake client**
+
+In `tests/fake_kanbanflow.py`: add `KfEvent` to the import from `kanbanflow_client` (L13-24), add `self.board_events: list[KfEvent] = []` in `__init__` (after L67 `self.users = []`), and add this method (after `iter_all_tasks`, ~L82):
+
+```python
+    def get_board_events(
+        self,
+        *,
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+        limit: int = 100,
+        order: str = "descending",
+    ) -> list[KfEvent]:
+        return list(self.board_events)
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Replace `test_recently_closed_is_empty_degraded` (L106-109) in `tests/test_kanbanflow_provider.py` with these. They need helpers to build events and seed a Done task — add the imports `from skills.jared.scripts.lib.kanbanflow_client import KfChangedProperty, KfDetailedEvent, KfEvent, KfTask` at the top if not present:
+
+```python
+def _move_event(ev_id: str, ts: str, task_id: str, new_col: str) -> KfEvent:
+    return KfEvent(
+        id=ev_id,
+        timestamp=ts,
+        detailed_events=[
+            KfDetailedEvent(
+                event_type="taskChanged",
+                task_id=task_id,
+                changed_properties=[
+                    KfChangedProperty(property="columnId", old_value="col-inprog", new_value=new_col)
+                ],
+            )
+        ],
+    )
+
+
+def test_recently_closed_maps_columnid_into_done(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)  # see note below
+    # A task currently in Done with number 7, and an event moving it there.
+    client.tasks["task-A"] = KfTask(id="task-A", name="Closed thing", column_id="col-done", number_value=7)
+    client.board_events = [_move_event("e1", "2026-06-05T13:20:56.216Z", "task-A", "col-done")]
+    closed = provider.recently_closed(days=36500)  # wide window: exercise mapping, not cutoff
+    assert len(closed) == 1
+    assert closed[0].number == 7
+    assert closed[0].title == "Closed thing"
+    assert closed[0].closed_at == "2026-06-05T13:20:56.216Z"
+
+
+def test_recently_closed_most_recent_move_wins(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)
+    client.tasks["task-A"] = KfTask(id="task-A", name="T", column_id="col-done", number_value=7)
+    # Descending order: newest first. Two moves into Done for the same task.
+    client.board_events = [
+        _move_event("e2", "2026-06-05T15:00:00.000Z", "task-A", "col-done"),
+        _move_event("e1", "2026-06-05T13:00:00.000Z", "task-A", "col-done"),
+    ]
+    closed = provider.recently_closed(days=36500)
+    assert len(closed) == 1
+    assert closed[0].closed_at == "2026-06-05T15:00:00.000Z"
+
+
+def test_recently_closed_skips_moves_into_non_done(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)
+    client.tasks["task-A"] = KfTask(id="task-A", name="T", column_id="col-inprog", number_value=7)
+    client.board_events = [_move_event("e1", "2026-06-05T13:00:00.000Z", "task-A", "col-inprog")]
+    assert provider.recently_closed(days=36500) == []
+
+
+def test_recently_closed_skips_unresolvable_task(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)
+    # Event references a task that no longer exists (deleted after close).
+    client.board_events = [_move_event("e1", "2026-06-05T13:00:00.000Z", "ghost", "col-done")]
+    assert provider.recently_closed(days=36500) == []
+```
+
+Add this provider-builder helper near the top of `tests/test_kanbanflow_provider.py` if an equivalent does not already exist (the file already constructs providers inline at L19/L347 — reuse that exact shape):
+
+```python
+def _provider(tmp_path: Path) -> tuple[KanbanFlowProvider, FakeKanbanFlowClient]:
+    client = FakeKanbanFlowClient()
+    index = KfNumberIndex(tmp_path / "kf-index-B1.json")
+    provider = KanbanFlowProvider(
+        client=client, board=client.board, field_defs=client.field_defs, index=index
+    )
+    return provider, client
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest tests/test_kanbanflow_provider.py -k recently_closed -v`
+Expected: FAIL — `recently_closed` still returns `[]`, so the mapping/most-recent assertions fail.
+
+- [ ] **Step 4: Add `get_board_events` to the Protocol + rewrite `recently_closed`**
+
+In `kanbanflow_provider.py`, add `KfEvent` to the import from `.kanbanflow_client` (L20-28). Add to the `KanbanFlowClientLike` Protocol (after `iter_all_tasks`, ~L67):
+
+```python
+    def get_board_events(
+        self,
+        *,
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+        limit: int = 100,
+        order: str = "descending",
+    ) -> list[KfEvent]: ...
+```
+
+Add `from datetime import datetime, timedelta, timezone` to the imports at the top. Replace `recently_closed` (L287-291):
+
+```python
+    def recently_closed(self, *, days: int) -> list[ClosedItem]:
+        """Closed items = tasks whose most recent event is a move into Done.
+
+        Scans GET /board/events (descending) for changedProperties columnId
+        transitions whose newValue is the Done column (resolved via the Status
+        column map), within the `days` window. Maps each task's most-recent
+        such move to a ClosedItem; the task's number/title come from the live
+        task set, so a deleted task (history outlives the task) is skipped.
+        """
+        done_col_id = self._column_id_by_status.get("Done")
+        if done_col_id is None:
+            return []
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat().replace(
+            "+00:00", "Z"
+        )
+        events = self._client.get_board_events(from_ts=cutoff, order="descending", limit=100)
+        task_by_id = {t.id: t for t in self._client.iter_all_tasks()}
+        seen: set[str] = set()
+        out: list[ClosedItem] = []
+        for ev in events:  # descending → first move per task is the most recent
+            if ev.timestamp and ev.timestamp < cutoff:
+                continue
+            for de in ev.detailed_events:
+                tid = de.task_id
+                if not tid or tid in seen:
+                    continue
+                moved_to_done = any(
+                    cp.property == "columnId" and cp.new_value == done_col_id
+                    for cp in de.changed_properties
+                )
+                if not moved_to_done:
+                    continue
+                task = task_by_id.get(tid)
+                if task is not None and task.number_value is not None:
+                    out.append(
+                        ClosedItem(number=task.number_value, title=task.name, closed_at=ev.timestamp)
+                    )
+                seen.add(tid)
+        return out
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_kanbanflow_provider.py -k recently_closed -v`
+Expected: PASS (all four tests).
+
+- [ ] **Step 6: Run the full gate (suite + types + lint)**
+
+Run: `pytest && mypy && ruff check .`
+Expected: all pass. (mypy verifies `FakeKanbanFlowClient` and the real client both still satisfy `KanbanFlowClientLike` with the new method.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/jared/scripts/lib/kanbanflow_provider.py tests/fake_kanbanflow.py tests/test_kanbanflow_provider.py
+git commit -m "feat(jared): recently_closed reads board events for moves into Done (Phase 1a.3)"
+```
+
+---
+
+### Task 4: Live verification on board `p9vK6cR` (verification folded into the phase)
+
+This is a verification task, not TDD. It satisfies the spec's "each phase live-verifies on p9vK6cR before merge" and records the **event-retention** and **`from`/`to` format** observations that Phase 1c needs.
+
+- [ ] **Step 1: Confirm `recently_closed` returns real data via the real client**
+
+Run (token from `~/.secrets`, never printed):
+
+```bash
+source /home/brockamer/.secrets && python3 -c "
+from skills.jared.scripts.lib.kanbanflow_client import KanbanFlowClient
+from skills.jared.scripts.lib.kanbanflow_provider import KanbanFlowProvider
+from skills.jared.scripts.lib.kf_number_index import KfNumberIndex
+import tempfile, pathlib
+c = KanbanFlowClient.from_env()
+board = c.get_board()
+# GTD column map for the test board (canonical Status -> board column name):
+status_map = {'Backlog':'Planned One Day','Up Next':'Planned This Week','In Progress':'Doing Now','Blocked':'Blocked','Done':'Done'}
+idx = KfNumberIndex(pathlib.Path(tempfile.mkdtemp())/'idx.json')
+p = KanbanFlowProvider(client=c, board=board, field_defs=c.list_custom_field_defs(), index=idx, status_column_map=status_map)
+print('recently_closed(60):', [(ci.number, ci.title, ci.closed_at) for ci in p.recently_closed(days=60)])
+evs = c.get_board_events(limit=100, order='descending')
+ts = sorted(e.timestamp for e in evs if e.timestamp)
+print('event count:', len(evs), '| oldest:', ts[0] if ts else None, '| newest:', ts[-1] if ts else None)
+"
+```
+
+Expected: a non-empty `recently_closed` list **iff** the board has a task that was moved into Done within 60 days (the probe saw `task=1eTJRipf` move `Doing Now → Done` on 2026-06-05). Record the oldest event timestamp as the **retention floor observation**.
+
+- [ ] **Step 2: Confirm the `from`/`to` window format**
+
+Run a windowed call and confirm server-side filtering works with ISO timestamps (the format `get_board_events` passes):
+
+```bash
+source /home/brockamer/.secrets && python3 -c "
+from skills.jared.scripts.lib.kanbanflow_client import KanbanFlowClient
+c = KanbanFlowClient.from_env()
+narrow = c.get_board_events(from_ts='2026-06-05T13:20:00.000Z', to_ts='2026-06-05T13:21:30.000Z', order='descending')
+print('windowed event count (expect a small subset):', len(narrow))
+"
+```
+
+Expected: a strict subset of the full history. **If the count equals the full history**, the server ignores ISO `from`/`to` → record that `get_board_events` must rely on client-side timestamp filtering (already present in `recently_closed`) and note the format question for Phase 1c. **Either outcome is acceptable for this plan** — `recently_closed` already filters client-side defensively.
+
+- [ ] **Step 3: Confirm the integration surface**
+
+Run: `source /home/brockamer/.secrets && /home/brockamer/Code/jared/skills/jared/scripts/jared next-session-prompt` **against a KanbanFlow-backed `docs/project-board.md`** (the test board), and confirm the "Recently closed" section is now populated rather than empty.
+Expected: at least the `1eTJRipf` close appears (or however the test board stands at run time).
+
+- [ ] **Step 4: Record findings in the spec**
+
+Append a short "Phase 1a live-verify (date)" note to `docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md` §11 capturing: the retention floor observed, whether ISO `from`/`to` filters server-side, and the next-session-prompt result. Commit:
+
+```bash
+git add docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md
+git commit -m "docs(jared): record Phase 1a live-verify findings on p9vK6cR (Phase 1a.4)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (against the §7 Phase 1 scope):**
+- "events client method + `KfEvent`" → Tasks 1, 2. ✓
+- "rewrite `recently_closed`" → Task 3. ✓
+- "Done resolved via the Status column map" → Task 3 uses `_column_id_by_status['Done']`; Task 4 passes the GTD `status_map`. ✓
+- "`{eventsLimited, events}` envelope + windowed paging" → Task 2. ✓
+- "live-verify on p9vK6cR" → Task 4. ✓
+- CLOSED_STATE flip, per-task createdAt/VELOCITY flip → **deliberately deferred** to Phase 1b/1c (stated in Scope). Not a gap — a scoping decision.
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to". Every code step shows complete code. `_provider`/`_move_event` helpers are defined inline. ✓
+
+**3. Type consistency:** `get_board_events` signature is identical across the real client (Task 2), the `KanbanFlowClientLike` Protocol (Task 3), and `FakeKanbanFlowClient` (Task 3). `KfEvent`/`KfDetailedEvent`/`KfChangedProperty` field names (`property`, `old_value`, `new_value`, `task_id`, `detailed_events`, `timestamp`) are used consistently in parser, provider scan, and tests. `ClosedItem(number, title, closed_at)` matches `board_provider.py`. ✓
+
+**Constraint check:** No new `@runtime_checkable BoardProvider` method is added (the atomic-coupling trap is avoided) — `recently_closed` already exists on the Protocol; only `KanbanFlowClient` gains a method (safe). ✓

--- a/docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md
+++ b/docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md
@@ -103,14 +103,24 @@ build phases inherit, not to be re-derived:
 - **CLOSED_STATE → flips (clean, cheap, not retention-dependent).** Its only consumer,
   `find_orphaned`, needs closed-or-not; route that through Done-membership on KanbanFlow.
   The impossible orthogonal-closed flag stays a documented, *unused* limit.
-- **VELOCITY_TIMESTAMPS → `recently_closed` ships real data; flag flip is CONTINGENT.**
-  Building `recently_closed` delivers value (next-session-prompt "Recently closed";
-  velocity inputs) but clears **none** of the five gated surfaces — they need per-task
-  `createdAt`/activity reconstructed from the event log, which is (a) more build and (b)
-  retention-ceiling-dependent. The flag flips **only if** a retention probe confirms the
-  ceiling covers the aging windows (sweep default 14d; audit default-staleness clamp
-  `[14,60]`). **If retention is insufficient, `recently_closed` value still ships, the flag
-  stays omitted, and its note is refined** — the epic does *not* promise this flip.
+- **VELOCITY_TIMESTAMPS → `recently_closed` ships real data, but DORMANT; flag flip is
+  CONTINGENT.** Building `recently_closed` does the plumbing, but its only production
+  consumer — the next-session-prompt "Recently closed" section (`skills/jared/scripts/jared:1190`)
+  — *also* gates on VELOCITY_TIMESTAMPS, so on KanbanFlow it stays suppressed (shows the
+  degraded note, never calls `recently_closed`) until the flag flips. The data is
+  correct-but-dormant. And the flip clears **none** of the five aging gates by itself — they
+  need per-task `createdAt`/activity reconstructed from the event log, which is (a) more build
+  and (b) retention-ceiling-dependent. The flag flips **only if** a retention probe confirms
+  the ceiling covers the aging windows (sweep default 14d; audit default-staleness clamp
+  `[14,60]`). **If retention is insufficient, the flag stays omitted with a refined note** —
+  the epic does *not* promise this flip.
+  - **Phase 1c design note (discovered in the Phase 1a final review):** the recently-closed
+    section needs only *closed-at* (which works after Phase 1a), not *created-at*, yet it gates
+    on the created-at/aging flag VELOCITY_TIMESTAMPS. This is the coarse-flag tension in the
+    flesh. Phase 1c should decide whether to un-gate that section on a *closed-at* signal
+    (CLOSED_STATE, which flips cleanly in Phase 1b) independently of the created-at/aging flip —
+    so the dormant `recently_closed` data surfaces as soon as Phase 1b lands, without waiting on
+    the retention-gated VELOCITY flip.
 - **NATIVE_DEPENDENCIES → stays omitted; note refined.** Read wired (native
   `dependsOn`/`requiredBy` merged + reconciled vs `blocked-by:<N>` labels); writes remain
   label-only (no API). New note: *blocked-by writes are label markers; native relations are
@@ -186,8 +196,10 @@ value anchor; Phase 5 (MCP) is the heaviest and gets its own sub-spec.
    `kanbanflow_provider.py`'s capability declaration reflects the outcome.
 2. **No `degraded:` note overstates the actual loss** (asserted in Phase 6; the MARKDOWN_BODY
    correction is the canonical example).
-3. `recently_closed()` returns real data on KanbanFlow, **live-verified on `p9vK6cR`**;
-   next-session-prompt's "Recently closed" is populated.
+3. `recently_closed()` returns real data on KanbanFlow, **live-verified on `p9vK6cR`**. (The
+   next-session-prompt "Recently closed" section that would surface it *also* gates on
+   VELOCITY_TIMESTAMPS, so it stays dormant until Phase 1b/1c un-gates it — Phase 1a delivers
+   correct plumbing, not yet a user-visible change. See §6 Phase-1c design note.)
 4. CLOSED_STATE flips: `find_orphaned` works on KanbanFlow via Done-membership.
 5. Native `dependsOn`/`requiredBy` relations are read into the dependency graph and reconciled
    against label markers.
@@ -244,4 +256,7 @@ Run after Phase 1a code landed, via the real client+provider (not the fake):
   flag flip stays retention-gated for Phase 1c.
 - **next-session-prompt integration** was not exercised against a KanbanFlow-backed
   `docs/project-board.md` (none is configured), but the provider call it depends on
-  (`recently_closed`) is verified above.
+  (`recently_closed`) is verified above. Note (from the Phase 1a final review): even with a KF
+  board configured, the "Recently closed" section would currently show the *degraded note*, not
+  the data — it gates on VELOCITY_TIMESTAMPS (`jared:1190`), which KanbanFlow omits. So the new
+  `recently_closed` data is correct-but-dormant until Phase 1b/1c un-gates that section (§6).

--- a/docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md
+++ b/docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md
@@ -1,0 +1,223 @@
+# KanbanFlow → GitHub capability parity — design (Phase 0 brainstorm output)
+
+- **Issue:** #357 (epic) — "Bring KanbanFlow backend to capability parity with GitHub Projects"
+- **Date:** 2026-06-11
+- **Status:** design approved; per-phase plans to follow (one spec/plan/PR each, per the epic body)
+- **Successor to:** epic #313 (closed) — which shipped KanbanFlow as a deliberately *reduced* backend
+
+## 1. What this is
+
+Epic #313 made jared board-backend-agnostic and shipped `KanbanFlowProvider` with the
+**entire** `Capability` set in `_OMITTED_CAPABILITIES` ("KF supports only the core board
+loop"). Every `degraded:` gate in jared's prose and CLI fires on a KanbanFlow board today.
+
+This epic systematically closes that gap. The operator's chosen posture (Phase-0 decision):
+**treat KanbanFlow as a backend a marketplace user could genuinely run day-to-day — close
+every *feasibly*-closable gap; document only the true limits as non-goals.** This is the
+build-mode reading, aligned with the in-scope marketplace-ship goal (epic #348), not the
+"document non-goals and close" reading.
+
+## 2. Governing principle — what a capability *means*
+
+A `Capability` flag means **"no jared surface degrades on this backend for lack of it."**
+That is already the flag's operational job: it gates `degraded_or_none` (`lib/capabilities.py`).
+From this definition every flip/keep decision derives, rather than being argued case by case:
+
+- **Flip a flag to present only when every consumer that gates on it stops degrading.** Not
+  "the feature now half-works" — every gated surface must be satisfied.
+- **A partial improvement ships, but keeps the flag omitted and *refines the `degraded:`
+  note*** to describe the precise residual loss. Honesty over optimism: a still-degrading
+  surface keeps its (now sharper) note.
+- **Do not split the `Capability` enum into finer flags unless a real consumer branches
+  differently on the halves.** Splitting a flag no surface reads is the dead-field
+  anti-pattern (CLAUDE.md: "reach for parsing only when a CLI surface gates on the value").
+- **Every phase live-verifies on the `p9vK6cR` test board before merge.** Verification is
+  folded into the producing phase, never deferred (`feedback_deferred_verification_drift`).
+
+## 3. How feasibility was established (and its limits)
+
+KanbanFlow's v1 REST API **does not self-describe** — no OpenAPI/Swagger spec, no discovery
+endpoint, no `OPTIONS` affordance listing. So truth comes from docs + probing, graded by
+source strength (strongest → weakest):
+
+1. **jared's shipped client/provider code** — encodes a read contract live-confirmed in the
+   #318/#319 runs. Ground truth, but only for the slice the client already exercises.
+2. **Primary non-KF sources** — npm registry JSON, GitHub API JSON (the MCP-server verdict).
+3. **KanbanFlow doc sub-pages** (re-fetched by an adversarial verifier) — good for *what
+   exists*, weak for *what does not*.
+4. **Third-party integrations** (Pipedream "Task Moved" trigger) — corroboration, not proof.
+5. **Doc inference** — "the example shows `color`, so `columnId` works the same way." Weakest.
+
+The feasibility pass was a 15-agent workflow (1 API-surface map + 7 classifiers + 7
+adversarial verifiers). The verifiers earned their keep: they **overturned** the
+VELOCITY_TIMESTAMPS verdict (classifier said "true parity"; verifier downgraded it to
+"feasible pending a live probe" because the load-bearing `columnId`-in-events mechanism is
+*never shown* in any KF doc example — only inferred). That single correction motivated the
+live probe below.
+
+> **Discipline for implementers:** the read contract is live-confirmed below, but
+> `feedback_kanbanflow_fake_masks_live_contract` is about **write** contracts — the fake
+> returns full objects while real create/update return `{taskId}`/`null`. Each build phase
+> must live-verify its **writes** on `p9vK6cR` before merge, not trust the fake.
+
+## 4. Live probe findings (read-only, run 2026-06-11 on `p9vK6cR`)
+
+A read-only `GET /board/events` probe (same Bearer/`/api/v1` protocol as the production
+client) resolved the gated uncertainty. **No write was needed** — the board's existing
+history already contained a column move into Done. Findings — these are ground truth the
+build phases inherit, not to be re-derived:
+
+- **`GET /board/events` exists** (200) and returns **`{eventsLimited, events}`** — an
+  envelope object, **not** the bare list the research assumed. `eventsLimited` is the
+  pagination signal.
+- **`columnId` transitions are in the stream** — observed `{columnId: 3, groupingDate: 1}`
+  across `detailedEvents[].changedProperties[]`. The inference is now a fact.
+- **A move into Done is timestamped** — `2026-06-05T13:20:56Z  Doing Now → Done`. The #313
+  "settled" premise ("KanbanFlow exposes no reliable moved-to-Done timestamp") is
+  **empirically false**.
+- **`columnId` value == the column's `uniqueId`** (`get_board`) — so Done resolves cleanly,
+  **through the `### Status column map`** (the test board uses GTD column names; "Done"
+  matched only by coincidence — implementers must resolve Done via the map, not a literal).
+- **`groupingDate` changes are tracked** — the zero-extra-call, day-granularity closed-date
+  fallback is real.
+- **Retention caveat (open):** events reach back to the board's oldest activity (~6 days on
+  this young board), which covers `recently_closed(14d)` comfortably. The **deep-history
+  retention ceiling is unprobed** — the board is too young to show it, and there is no
+  `_dateCreated` on the task object, so on KanbanFlow **created-at is reconstructable only
+  from the event log**. This is the load-bearing contingency for §6.
+
+## 5. Per-capability verdicts (verified) + consumer analysis
+
+| Capability | Verified verdict | Real consumers (grepped) |
+|---|---|---|
+| VELOCITY_TIMESTAMPS | feasible for `recently_closed`; **flag flip contingent** | 5 gates, **all created-at/activity-based**: sweep stale-High-Backlog, stalled-In-Progress, Blocked-aging; `board.py` audit-window sort; `stage.py` Backlog-age tiebreaker. **None consume `recently_closed`.** |
+| CLOSED_STATE | partial overall, but **flag flips cleanly** | 1 gate: `find_orphaned` (dependency-graph.py) — needs only *closed-or-not*, which Done-membership answers. Orthogonal-closed flag is unused. |
+| NATIVE_DEPENDENCIES | partial — read closeable, **write impossible** | `get_relations` exists in the client but is **dead** (never called). `dependsOn`/`requiredBy` readable; no relations write endpoint exists (confirmed 3 ways). |
+| MARKDOWN_BODY | partial | KF **does** render bold/italic/links/lists/code (the #313 "plain text" premise was wrong). `##` headings + `<details>` do **not** render — those are exactly jared's body-template scaffolding. |
+| MILESTONE_STATE | partial — state derivable, **due a non-goal** | State = all-swimlane-tasks-in-Done (reuses shipped logic). No native container due date; per-task `dates[]` is the wrong granularity. |
+| MCP_TIER | feasible-but-declined → **build a shim** (operator ruling) | A third-party server exists but is frozen + bypasses the atomic `file` invariant. Build a thin shim over provider methods instead. |
+| SUB_ISSUES | **non-goal** | KF subtasks are checklist lines (no `#N`/status). jared consumes sub-issues **nowhere — even on GitHub**; the `epic` label is the hierarchy primitive. A `parent:<N>` marker would be dead code. |
+
+## 6. Capability outcomes (grep-grounded — corrected from first draft)
+
+- **CLOSED_STATE → flips (clean, cheap, not retention-dependent).** Its only consumer,
+  `find_orphaned`, needs closed-or-not; route that through Done-membership on KanbanFlow.
+  The impossible orthogonal-closed flag stays a documented, *unused* limit.
+- **VELOCITY_TIMESTAMPS → `recently_closed` ships real data; flag flip is CONTINGENT.**
+  Building `recently_closed` delivers value (next-session-prompt "Recently closed";
+  velocity inputs) but clears **none** of the five gated surfaces — they need per-task
+  `createdAt`/activity reconstructed from the event log, which is (a) more build and (b)
+  retention-ceiling-dependent. The flag flips **only if** a retention probe confirms the
+  ceiling covers the aging windows (sweep default 14d; audit default-staleness clamp
+  `[14,60]`). **If retention is insufficient, `recently_closed` value still ships, the flag
+  stays omitted, and its note is refined** — the epic does *not* promise this flip.
+- **NATIVE_DEPENDENCIES → stays omitted; note refined.** Read wired (native
+  `dependsOn`/`requiredBy` merged + reconciled vs `blocked-by:<N>` labels); writes remain
+  label-only (no API). New note: *blocked-by writes are label markers; native relations are
+  read.*
+- **MARKDOWN_BODY → stays omitted; note refined + corrected.** Inline formatting renders;
+  block structure (headings, `<details>`) is downgraded. The current note **overstates** the
+  loss and must be corrected.
+- **MILESTONE_STATE → stays omitted; note refined.** State derived; due is a documented
+  non-goal. **Not** splitting the enum (no consumer branches state-vs-due today).
+- **MCP_TIER → flips** once the shim ships.
+- **SUB_ISSUES → non-goal** (formalized; already in the spec/inventory/migrate.py loss msg).
+
+## 7. Phase plan
+
+Phases 2/3/4 are mutually independent (no probe dependency) — parallelizable. Phase 1 is the
+value anchor; Phase 5 (MCP) is the heaviest and gets its own sub-spec.
+
+- **Phase 0 ✅ — Live events probe** (this session). Findings in §4. Gate resolved.
+- **Phase 1 — Events + closed-state.**
+  - `KanbanFlowClient.get_board_events(...)` + `get_task_events(...)`, a `KfEvent` dataclass
+    + parser; handle the `{eventsLimited, events}` envelope and `from/to/limit≤100/order`
+    windowed paging (no cursor); respect the 1000/hr · 5000/day budget.
+  - Rewrite `KanbanFlowProvider.recently_closed` from `return []` to an event scan for
+    `columnId`→Done (Done resolved via the Status column map), emitting `ClosedItem`.
+  - Route `find_orphaned`'s closed-detection through the provider (Done-membership) →
+    **flip CLOSED_STATE.**
+  - **Retention sub-probe** + per-task `createdAt`/activity reconstruction: decide whether
+    **VELOCITY_TIMESTAMPS flips** or stays omitted-with-refined-note. Do **not** assume the
+    flip.
+  - Live-verify on `p9vK6cR` (reads *and* any new write paths).
+- **Phase 2 — Native dependency reads.** Wire the dead `get_relations` into the provider edge
+  fetch; map `dependsOn`→`Edge(dependent,blocker)`, `requiredBy`→inverse, drop `relatesTo`;
+  reconcile/dedup vs `blocked-by:<N>` labels (surface divergence as a groom/audit finding).
+  Refine the NATIVE_DEPENDENCIES note; flag stays omitted (write impossible).
+- **Phase 3 — Markdown downgrade.** A one-way GFM→KF-subset transform at the KanbanFlow
+  provider's `set_body` boundary: `## Heading`→`**Heading**`, `<details><summary>X</summary>…`
+  → `**X**` + visible list (content preserved, collapsibility lost), leave bold/lists/code/
+  links as-is. No new client methods. Correct + refine the MARKDOWN_BODY note.
+- **Phase 4 — Milestone state.** Derive milestone closed = all tasks in that swimlane in Done
+  (reuses `_status_by_column_id` + swimlane maps; zero new client methods). Suppress state for
+  empty swimlanes (avoid a misleading "closed"). Due = explicit non-goal. Refine the
+  MILESTONE_STATE note.
+- **Phase 5 — MCP shim (own sub-spec).** A thin MCP server over the **provider** methods
+  (`file`/`move`/`close`/`comment`), preserving the atomic `file` invariant — **not** the
+  third-party server's raw `create-task`/`update-task` CRUD. Flips MCP_TIER. Sequenced last;
+  different build domain (its own design + plan).
+- **Phase 6 — Document + reconcile + close.** Formalize SUB_ISSUES (and milestone-due,
+  orthogonal-closed, native-write) as rationale-backed non-goals; finalize
+  `_OMITTED_CAPABILITIES`; assert **every still-firing `degraded:` note is accurate** (none
+  overstates the loss); update the convention-doc capability prose; close the epic.
+
+## 8. Constraints for implementers
+
+- **`runtime_checkable` atomic-coupling (`reference_runtime_checkable_protocol_atomic_coupling`,
+  #318).** Prefer folding into **existing** `BoardProvider` methods (`recently_closed`,
+  `fetch_blocked_by_edges`, `set_body`, `list_milestones`) and adding new methods only on
+  `KanbanFlowClient` (safe — not the Protocol). If a phase genuinely needs a **new**
+  `@runtime_checkable` `BoardProvider` method (e.g. a closed-state or created-at lookup for
+  `find_orphaned`/aging), it must land in **both** provider impls in **one commit** —
+  `isinstance()` + `mypy --strict` break with no green intermediate otherwise.
+- **Done is resolved via the Status column map**, never a literal "Done" match (the live
+  board uses GTD column names).
+- **Rate budget:** 1000 req/hr/board, 5000/day token-lock. Event scans use `from/to`
+  windows, not unbounded crawls. The relations read has no bulk endpoint (one GET per task) —
+  budget it (lazy/on-demand vs full-board sweep).
+- **`GH_TOKEN`/auth:** unrelated to KF, but the GitHub-side surfaces still follow
+  `project_gh_token_pat_shadows_oauth_flaky_project_scope`.
+
+## 9. Acceptance criteria (epic)
+
+1. Every member of `_OMITTED_CAPABILITIES` is either (a) removed at true parity, (b) retained
+   with a precise residual-loss note, or (c) a rationale-backed non-goal — and
+   `kanbanflow_provider.py`'s capability declaration reflects the outcome.
+2. **No `degraded:` note overstates the actual loss** (asserted in Phase 6; the MARKDOWN_BODY
+   correction is the canonical example).
+3. `recently_closed()` returns real data on KanbanFlow, **live-verified on `p9vK6cR`**;
+   next-session-prompt's "Recently closed" is populated.
+4. CLOSED_STATE flips: `find_orphaned` works on KanbanFlow via Done-membership.
+5. Native `dependsOn`/`requiredBy` relations are read into the dependency graph and reconciled
+   against label markers.
+6. KanbanFlow issue bodies render jared's section structure acceptably (content never lost).
+7. The MCP shim preserves the atomic `file` invariant (no raw task CRUD).
+8. Each phase's writes are live-verified on `p9vK6cR` before merge.
+
+> Deliberately **not** an acceptance criterion: "VELOCITY_TIMESTAMPS flips." That is
+> contingent on the retention probe (§6) and would overstate parity if promised.
+
+## 10. Non-goals (rationale-backed)
+
+- **SUB_ISSUES** — no consumer on either backend; the `epic` label is the hierarchy
+  primitive; a `parent:<N>` marker would be dead code.
+- **Milestone due dates** — no native container date; a non-live config registry fights "the
+  board is the single source of truth." Ship the derived *state* half only.
+- **Orthogonal closed state** (a closed flag independent of the Done column) — genuine KF
+  platform limit; unused by jared (Done == closed).
+- **Native blocked-by *writes*** — no relations write endpoint exists; writes stay label-only.
+- **Markdown block structure** (headings, `<details>`, tables) on KF — renderer doesn't
+  support it; downgraded with content preserved.
+
+## 11. Open questions / contingencies
+
+- **Event retention ceiling** (§4, §6) — gates the VELOCITY_TIMESTAMPS flag flip. Probe in
+  Phase 1; cannot be answered by the young test board's history alone.
+- **Events endpoint tier-gating** — docs silent on whether `/board/events` is premium-only;
+  confirm on `p9vK6cR` (it returned 200 there, so at minimum the current token has it).
+- **`groupingDate`** as a zero-call day-granularity closed-date fallback — confirm it is
+  populated for Done tasks by default vs only when date-grouping is enabled.
+- **Optional absence-probe** (not yet run): `POST /tasks/<id>/relations` → expect `404/405`
+  to harden the NATIVE_DEPENDENCIES write-impossible verdict beyond doc-absence. Low-risk
+  (a 404 mutates nothing); offer before Phase 2.

--- a/docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md
+++ b/docs/superpowers/specs/2026-06-11-kanbanflow-parity-design.md
@@ -221,3 +221,27 @@ value anchor; Phase 5 (MCP) is the heaviest and gets its own sub-spec.
 - **Optional absence-probe** (not yet run): `POST /tasks/<id>/relations` → expect `404/405`
   to harden the NATIVE_DEPENDENCIES write-impossible verdict beyond doc-absence. Low-risk
   (a 404 mutates nothing); offer before Phase 2.
+
+## 12. Phase 1a live-verify findings (2026-06-11, read-only on `p9vK6cR`)
+
+Run after Phase 1a code landed, via the real client+provider (not the fake):
+
+- **Mechanism confirmed.** `get_board_events` returned the real `columnId`→Done transition
+  (`1eTJRipf → Done @ 2026-06-05T13:20:56Z`). The event scan + Done-column-id match works on
+  live data — the inferred mechanism is now doubly confirmed (probe + provider path).
+- **`recently_closed(days=60)` returned `[]` — correct for the board's current state.** The
+  test board has **no task currently in Done carrying a jared `#N`** (the moved task is no
+  longer a numbered Done item), so the `#N`-resolution step correctly skips it
+  (`test_recently_closed_skips_unresolvable_task`). The empty result is a board-data artifact,
+  not a code defect; the resolved-task path is covered by `test_recently_closed_maps_columnid_into_done`.
+  A full end-to-end demo would require a jared-numbered task moved to Done on the board (a
+  write — deferred, not in the read-only verify scope).
+- **ISO `from`/`to` filters server-side, and `to` is INCLUSIVE.** A `to == oldest_timestamp`
+  query returned 1 event vs 12 for the full history. Inclusivity means backward paging re-fetches
+  the boundary event — which **validates the cross-page `seen`-set dedup** added in Phase 1a.2.
+- **Retention floor ≥ 6 days** (events back to the board's 2026-06-05 creation); the deep
+  retention ceiling is still unprobed (board too young). Confirms §6/§11: the VELOCITY_TIMESTAMPS
+  flag flip stays retention-gated for Phase 1c.
+- **next-session-prompt integration** was not exercised against a KanbanFlow-backed
+  `docs/project-board.md` (none is configured), but the provider call it depends on
+  (`recently_closed`) is verified above.

--- a/skills/jared/scripts/lib/kanbanflow_client.py
+++ b/skills/jared/scripts/lib/kanbanflow_client.py
@@ -592,6 +592,47 @@ class KanbanFlowClient:
         raw = self._request("GET", f"/tasks/{task_id}/relations")
         return [_parse_relation(r) for r in raw]  # type: ignore[attr-defined]
 
+    def get_board_events(
+        self,
+        *,
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+        limit: int = 100,
+        order: str = "descending",
+        max_pages: int = 20,
+    ) -> list[KfEvent]:
+        """Read board event history (GET /board/events).
+
+        Returns events newest-first (order='descending'). The endpoint has no
+        cursor — when the response sets `eventsLimited`, this walks the time
+        window backward by setting `to` to the oldest event seen, bounded by
+        `from_ts` (server-side floor) and `max_pages` (safety cap). The
+        `{eventsLimited, events}` envelope shape is confirmed live on p9vK6cR.
+        """
+        out: list[KfEvent] = []
+        window_to = to_ts
+        for _ in range(max_pages):
+            params: dict[str, object] = {
+                "from": from_ts,
+                "to": window_to,
+                "limit": limit,
+                "order": order,
+            }
+            raw = self._request("GET", "/board/events", params=params)
+            if not isinstance(raw, dict):
+                break
+            batch = [_parse_event(e) for e in (raw.get("events") or [])]
+            out.extend(batch)
+            if not raw.get("eventsLimited") or not batch:
+                break
+            oldest = min(
+                (e.timestamp for e in batch if e.timestamp), default=None
+            )
+            if oldest is None or oldest == window_to:
+                break
+            window_to = oldest
+        return out
+
     def _budget_gate(self) -> None:
         if self._daily_count >= self._daily_ceiling:
             raise KanbanFlowRateLimitError(

--- a/skills/jared/scripts/lib/kanbanflow_client.py
+++ b/skills/jared/scripts/lib/kanbanflow_client.py
@@ -187,6 +187,28 @@ class KfUser:
     name: str = ""
 
 
+@dataclass
+class KfChangedProperty:
+    property: str
+    old_value: str | None = None
+    new_value: str | None = None
+
+
+@dataclass
+class KfDetailedEvent:
+    event_type: str
+    task_id: str | None = None
+    changed_properties: list[KfChangedProperty] = field(default_factory=list)
+
+
+@dataclass
+class KfEvent:
+    id: str
+    timestamp: str
+    user_id: str = ""
+    detailed_events: list[KfDetailedEvent] = field(default_factory=list)
+
+
 def _parse_label(raw: dict[str, Any]) -> KfLabel:
     return KfLabel(name=str(raw["name"]), pinned=bool(raw.get("pinned", False)))
 
@@ -275,6 +297,33 @@ def _parse_relation(raw: dict[str, Any]) -> KfRelation:
 
 def _parse_user(raw: dict[str, Any]) -> KfUser:
     return KfUser(id=str(raw["_id"]), name=str(raw.get("name", "")))
+
+
+def _parse_changed_property(raw: dict[str, Any]) -> KfChangedProperty:
+    return KfChangedProperty(
+        property=str(raw.get("property", "")),
+        old_value=str(raw["oldValue"]) if raw.get("oldValue") is not None else None,
+        new_value=str(raw["newValue"]) if raw.get("newValue") is not None else None,
+    )
+
+
+def _parse_detailed_event(raw: dict[str, Any]) -> KfDetailedEvent:
+    return KfDetailedEvent(
+        event_type=str(raw.get("eventType", "")),
+        task_id=str(raw["taskId"]) if raw.get("taskId") is not None else None,
+        changed_properties=[
+            _parse_changed_property(cp) for cp in raw.get("changedProperties", [])
+        ],
+    )
+
+
+def _parse_event(raw: dict[str, Any]) -> KfEvent:
+    return KfEvent(
+        id=str(raw.get("_id", "")),
+        timestamp=str(raw.get("timestamp", "")),
+        user_id=str(raw.get("userId", "")),
+        detailed_events=[_parse_detailed_event(de) for de in raw.get("detailedEvents", [])],
+    )
 
 
 class KanbanFlowClient:

--- a/skills/jared/scripts/lib/kanbanflow_client.py
+++ b/skills/jared/scripts/lib/kanbanflow_client.py
@@ -603,13 +603,18 @@ class KanbanFlowClient:
     ) -> list[KfEvent]:
         """Read board event history (GET /board/events).
 
-        Returns events newest-first (order='descending'). The endpoint has no
-        cursor — when the response sets `eventsLimited`, this walks the time
-        window backward by setting `to` to the oldest event seen, bounded by
-        `from_ts` (server-side floor) and `max_pages` (safety cap). The
-        `{eventsLimited, events}` envelope shape is confirmed live on p9vK6cR.
+        Returns events newest-first for order='descending' (the default). The
+        endpoint has no cursor — when the response sets `eventsLimited`, this walks
+        the time window backward by setting `to` to the oldest event seen, bounded
+        by `from_ts` (server-side floor) and `max_pages` (safety cap). Backward
+        paging is performed ONLY for order='descending'; any other order returns a
+        single page (the `to`-walk is descending-only by construction). Events are
+        de-duplicated by id across the page seam, so an inclusive `to` bound cannot
+        double-count the boundary event. The `{eventsLimited, events}` envelope
+        shape is confirmed live on p9vK6cR.
         """
         out: list[KfEvent] = []
+        seen: set[str] = set()
         window_to = to_ts
         for _ in range(max_pages):
             params: dict[str, object] = {
@@ -622,12 +627,17 @@ class KanbanFlowClient:
             if not isinstance(raw, dict):
                 break
             batch = [_parse_event(e) for e in (raw.get("events") or [])]
-            out.extend(batch)
-            if not raw.get("eventsLimited") or not batch:
+            for ev in batch:
+                if ev.id and ev.id in seen:
+                    continue
+                if ev.id:
+                    seen.add(ev.id)
+                out.append(ev)
+            # Backward paging is descending-only: `to=oldest` walks toward the past.
+            if not raw.get("eventsLimited") or not batch or order != "descending":
                 break
-            oldest = min(
-                (e.timestamp for e in batch if e.timestamp), default=None
-            )
+            # Timestamps are ISO-8601 UTC 'Z' strings; lexical order == chronological.
+            oldest = min((e.timestamp for e in batch if e.timestamp), default=None)
             if oldest is None or oldest == window_to:
                 break
             window_to = oldest

--- a/skills/jared/scripts/lib/kanbanflow_provider.py
+++ b/skills/jared/scripts/lib/kanbanflow_provider.py
@@ -295,13 +295,26 @@ class KanbanFlowProvider:
         return edges
 
     def recently_closed(self, *, days: int) -> list[ClosedItem]:
-        """Closed items = tasks whose most recent event is a move into Done.
+        """Closed items = tasks whose most recent move INTO the Done column
+        falls within the `days` window.
 
         Scans GET /board/events (descending) for changedProperties columnId
         transitions whose newValue is the Done column (resolved via the Status
-        column map), within the `days` window. Maps each task's most-recent
-        such move to a ClosedItem; the task's number/title come from the live
-        task set, so a deleted task (history outlives the task) is skipped.
+        column map). Each task's most-recent move-into-Done maps to a ClosedItem;
+        the task's number/title come from the live task set, so a deleted task
+        (history outlives the task) is skipped.
+
+        Asymmetry vs GitHub: GitHub's recently_closed reflects CURRENT closed
+        state, so a reopened issue drops out. This KanbanFlow version keys off the
+        move-into-Done event and does NOT check for a later move back out — a task
+        moved to Done then reopened still appears (with its Done timestamp). That
+        is acceptable for velocity / recently-closed surfaces, which care about
+        the close event, not current state.
+
+        No truncation guard: get_board_events pages up to max_pages*limit events;
+        a window exceeding that silently truncates (the GitHub sibling raises at
+        its 200-item cap). Acceptable while no caller drives large windows on
+        KanbanFlow; revisit if a high-traffic board surfaces.
         """
         done_col_id = self._column_id_by_status.get("Done")
         if done_col_id is None:
@@ -313,7 +326,7 @@ class KanbanFlowProvider:
         task_by_id = {t.id: t for t in self._client.iter_all_tasks()}
         seen: set[str] = set()
         out: list[ClosedItem] = []
-        for ev in events:  # descending → first move per task is the most recent
+        for ev in events:  # descending → first move-into-Done per task is the most recent
             if ev.timestamp and ev.timestamp < cutoff:
                 continue
             for de in ev.detailed_events:

--- a/skills/jared/scripts/lib/kanbanflow_provider.py
+++ b/skills/jared/scripts/lib/kanbanflow_provider.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import contextlib
 import sys
+from datetime import UTC, datetime, timedelta
 from typing import Protocol
 
 from .board import FieldNotFound, ItemNotFound, OptionNotFound
@@ -22,6 +23,7 @@ from .kanbanflow_client import (
     KfBoard,
     KfComment,
     KfCustomFieldDef,
+    KfEvent,
     KfLabel,
     KfTask,
     KfUser,
@@ -65,6 +67,14 @@ class KanbanFlowClientLike(Protocol):
     def get_board(self) -> KfBoard: ...
     def list_custom_field_defs(self) -> list[KfCustomFieldDef]: ...
     def iter_all_tasks(self) -> list[KfTask]: ...
+    def get_board_events(
+        self,
+        *,
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+        limit: int = 100,
+        order: str = "descending",
+    ) -> list[KfEvent]: ...
     def get_task(self, task_id: str) -> KfTask: ...
     def create_task(
         self,
@@ -285,10 +295,48 @@ class KanbanFlowProvider:
         return edges
 
     def recently_closed(self, *, days: int) -> list[ClosedItem]:
-        # KanbanFlow exposes no reliable moved-to-Done timestamp
-        # (VELOCITY_TIMESTAMPS omitted). Degrade to empty; Phase 6 gates callers
-        # on the capability.
-        return []
+        """Closed items = tasks whose most recent event is a move into Done.
+
+        Scans GET /board/events (descending) for changedProperties columnId
+        transitions whose newValue is the Done column (resolved via the Status
+        column map), within the `days` window. Maps each task's most-recent
+        such move to a ClosedItem; the task's number/title come from the live
+        task set, so a deleted task (history outlives the task) is skipped.
+        """
+        done_col_id = self._column_id_by_status.get("Done")
+        if done_col_id is None:
+            return []
+        cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat().replace(
+            "+00:00", "Z"
+        )
+        events = self._client.get_board_events(from_ts=cutoff, order="descending", limit=100)
+        task_by_id = {t.id: t for t in self._client.iter_all_tasks()}
+        seen: set[str] = set()
+        out: list[ClosedItem] = []
+        for ev in events:  # descending → first move per task is the most recent
+            if ev.timestamp and ev.timestamp < cutoff:
+                continue
+            for de in ev.detailed_events:
+                tid = de.task_id
+                if not tid or tid in seen:
+                    continue
+                moved_to_done = any(
+                    cp.property == "columnId" and cp.new_value == done_col_id
+                    for cp in de.changed_properties
+                )
+                if not moved_to_done:
+                    continue
+                task = task_by_id.get(tid)
+                if task is not None and task.number_value is not None:
+                    out.append(
+                        ClosedItem(
+                            number=task.number_value,
+                            title=task.name,
+                            closed_at=ev.timestamp,
+                        )
+                    )
+                seen.add(tid)
+        return out
 
     def _user_name(self, user_id: str) -> str:
         if not hasattr(self, "_user_name_by_id"):

--- a/tests/fake_kanbanflow.py
+++ b/tests/fake_kanbanflow.py
@@ -17,6 +17,7 @@ from skills.jared.scripts.lib.kanbanflow_client import (
     KfComment,
     KfCustomFieldDef,
     KfCustomFieldValue,
+    KfEvent,
     KfLabel,
     KfSwimlane,
     KfTask,
@@ -65,6 +66,7 @@ class FakeKanbanFlowClient:
         self.tasks: dict[str, KfTask] = {}
         self.comments: dict[str, list[KfComment]] = {}
         self.users: list[KfUser] = []
+        self.board_events: list[KfEvent] = []
         self._next_id = 0
         self.fail_set_custom_field = False
 
@@ -80,6 +82,16 @@ class FakeKanbanFlowClient:
 
     def iter_all_tasks(self) -> list[KfTask]:
         return list(self.tasks.values())
+
+    def get_board_events(
+        self,
+        *,
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+        limit: int = 100,
+        order: str = "descending",
+    ) -> list[KfEvent]:
+        return list(self.board_events)
 
     def get_task(self, task_id: str) -> KfTask:
         if task_id not in self.tasks:

--- a/tests/test_kanbanflow_client.py
+++ b/tests/test_kanbanflow_client.py
@@ -771,3 +771,47 @@ def test_get_board_events_pages_backward_when_limited(
     assert [e.id for e in events] == ["e2", "e1", "e0"]
     assert len(urls) == 2
     assert "to=2026-06-05T12%3A00%3A00.000Z" in urls[1] or "to=2026-06-05T12:00:00.000Z" in urls[1]
+
+
+def test_get_board_events_respects_max_pages_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    counter = {"n": 0}
+
+    def fake(
+        method: str, url: str, headers: dict[str, str], data: bytes | None
+    ) -> tuple[int, dict[str, str], bytes]:
+        counter["n"] += 1
+        hour = 20 - counter["n"]  # strictly-decreasing oldest so paging keeps advancing
+        body = json.dumps(
+            {
+                "eventsLimited": True,
+                "events": [
+                    {
+                        "_id": f"e{counter['n']}",
+                        "timestamp": f"2026-06-05T{hour:02d}:00:00.000Z",
+                        "detailedEvents": [],
+                    }
+                ],
+            }
+        ).encode()
+        return (200, {}, body)
+
+    monkeypatch.setattr(kf, "_raw_http", fake)
+    events = _client().get_board_events(order="descending", max_pages=3)
+    assert counter["n"] == 3
+    assert len(events) == 3
+
+
+def test_get_board_events_ascending_does_not_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = patch_kf(
+        monkeypatch,
+        status=200,
+        body=json.dumps(
+            {
+                "eventsLimited": True,
+                "events": [{"_id": "e1", "timestamp": "t", "detailedEvents": []}],
+            }
+        ),
+    )
+    events = _client().get_board_events(order="ascending")
+    assert len(events) == 1
+    assert len(calls) == 1  # no backward paging for non-descending order

--- a/tests/test_kanbanflow_client.py
+++ b/tests/test_kanbanflow_client.py
@@ -645,3 +645,43 @@ def test_update_task_follows_up_with_get_after_null_post(monkeypatch: pytest.Mon
     assert methods == ["POST", "GET"], (
         "update_task must POST to /tasks/{id} then GET the updated task"
     )
+
+
+def test_parse_event_maps_nested_shape() -> None:
+    raw = {
+        "_id": "Nn1Xdp",
+        "timestamp": "2026-06-05T13:20:56.216Z",
+        "userId": "u-1",
+        "detailedEvents": [
+            {
+                "eventType": "taskChanged",
+                "taskId": "1eTJRipf",
+                "changedProperties": [
+                    {"property": "columnId", "oldValue": "col-inprog", "newValue": "col-done"}
+                ],
+            }
+        ],
+    }
+    ev = kf._parse_event(raw)
+    assert ev.id == "Nn1Xdp"
+    assert ev.timestamp == "2026-06-05T13:20:56.216Z"
+    assert ev.user_id == "u-1"
+    assert len(ev.detailed_events) == 1
+    de = ev.detailed_events[0]
+    assert de.event_type == "taskChanged"
+    assert de.task_id == "1eTJRipf"
+    assert de.changed_properties[0].property == "columnId"
+    assert de.changed_properties[0].old_value == "col-inprog"
+    assert de.changed_properties[0].new_value == "col-done"
+
+
+def test_parse_event_taskcreated_has_no_changed_properties() -> None:
+    ev = kf._parse_event(
+        {
+            "_id": "e2",
+            "timestamp": "t",
+            "detailedEvents": [{"eventType": "taskCreated", "taskId": "x"}],
+        }
+    )
+    assert ev.detailed_events[0].changed_properties == []
+    assert ev.user_id == ""

--- a/tests/test_kanbanflow_client.py
+++ b/tests/test_kanbanflow_client.py
@@ -685,3 +685,89 @@ def test_parse_event_taskcreated_has_no_changed_properties() -> None:
     )
     assert ev.detailed_events[0].changed_properties == []
     assert ev.user_id == ""
+
+
+def test_get_board_events_single_call_returns_parsed_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = json.dumps(
+        {
+            "eventsLimited": False,
+            "events": [
+                {
+                    "_id": "e1",
+                    "timestamp": "2026-06-05T13:20:56.216Z",
+                    "detailedEvents": [
+                        {
+                            "eventType": "taskChanged",
+                            "taskId": "t1",
+                            "changedProperties": [
+                                {"property": "columnId", "oldValue": "a", "newValue": "b"}
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    calls = patch_kf(monkeypatch, status=200, body=body)
+    events = _client().get_board_events(limit=100, order="descending")
+    assert len(events) == 1
+    assert events[0].id == "e1"
+    assert events[0].detailed_events[0].changed_properties[0].new_value == "b"
+    assert "/board/events" in cast(str, calls[0]["url"])
+    assert "limit=100" in cast(str, calls[0]["url"])
+    assert "order=descending" in cast(str, calls[0]["url"])
+
+
+def test_get_board_events_pages_backward_when_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seq: list[tuple[int, dict[str, str], bytes]] = [
+        (
+            200,
+            {},
+            json.dumps(
+                {
+                    "eventsLimited": True,
+                    "events": [
+                        {
+                            "_id": "e2",
+                            "timestamp": "2026-06-05T13:00:00.000Z",
+                            "detailedEvents": [],
+                        },
+                        {
+                            "_id": "e1",
+                            "timestamp": "2026-06-05T12:00:00.000Z",
+                            "detailedEvents": [],
+                        },
+                    ],
+                }
+            ).encode(),
+        ),
+        (
+            200,
+            {},
+            json.dumps(
+                {
+                    "eventsLimited": False,
+                    "events": [
+                        {"_id": "e0", "timestamp": "2026-06-05T11:00:00.000Z", "detailedEvents": []}
+                    ],
+                }
+            ).encode(),
+        ),
+    ]
+    urls: list[str] = []
+
+    def fake(
+        method: str, url: str, headers: dict[str, str], data: bytes | None
+    ) -> tuple[int, dict[str, str], bytes]:
+        urls.append(url)
+        return seq.pop(0)
+
+    monkeypatch.setattr(kf, "_raw_http", fake)
+    events = _client().get_board_events(order="descending")
+    assert [e.id for e in events] == ["e2", "e1", "e0"]
+    assert len(urls) == 2
+    assert "to=2026-06-05T12%3A00%3A00.000Z" in urls[1] or "to=2026-06-05T12:00:00.000Z" in urls[1]

--- a/tests/test_kanbanflow_provider.py
+++ b/tests/test_kanbanflow_provider.py
@@ -165,6 +165,18 @@ def test_recently_closed_skips_unresolvable_task(tmp_path: Path) -> None:
     assert provider.recently_closed(days=36500) == []
 
 
+def test_recently_closed_excludes_events_before_cutoff(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)
+    client.tasks["task-A"] = KfTask(
+        id="task-A", name="Old close", column_id="col-done", number_value=7
+    )
+    # Event far in the past; a 30-day window must exclude it (deterministic — 2020 is
+    # always > 30 days ago). Exercises the provider's own `ev.timestamp < cutoff` gate,
+    # which is the only window enforcement in the test path (the fake ignores from_ts).
+    client.board_events = [_move_event("e1", "2020-01-01T00:00:00.000Z", "task-A", "col-done")]
+    assert provider.recently_closed(days=30) == []
+
+
 def test_validate_fields_passes_for_valid(tmp_path: Path) -> None:
     provider, _ = _provider(tmp_path)
     provider.validate_fields(priority="High", status="Backlog", fields=[("Work Stream", "alpha")])

--- a/tests/test_kanbanflow_provider.py
+++ b/tests/test_kanbanflow_provider.py
@@ -8,6 +8,12 @@ import pytest
 
 from skills.jared.scripts.lib.board import FieldNotFound, OptionNotFound
 from skills.jared.scripts.lib.board_provider import BoardProvider
+from skills.jared.scripts.lib.kanbanflow_client import (
+    KfChangedProperty,
+    KfDetailedEvent,
+    KfEvent,
+    KfTask,
+)
 from skills.jared.scripts.lib.kanbanflow_provider import KanbanFlowProvider
 from skills.jared.scripts.lib.kf_number_index import KfNumberIndex
 from tests.fake_kanbanflow import FakeKanbanFlowClient
@@ -103,10 +109,60 @@ def test_fetch_blocked_by_edges_parses_labels(tmp_path: Path) -> None:
     assert sorted((e.dependent, e.blocker) for e in edges) == [(10, 3), (10, 4)]
 
 
-def test_recently_closed_is_empty_degraded(tmp_path: Path) -> None:
+def _move_event(ev_id: str, ts: str, task_id: str, new_col: str) -> KfEvent:
+    return KfEvent(
+        id=ev_id,
+        timestamp=ts,
+        detailed_events=[
+            KfDetailedEvent(
+                event_type="taskChanged",
+                task_id=task_id,
+                changed_properties=[
+                    KfChangedProperty(
+                        property="columnId", old_value="col-inprog", new_value=new_col
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def test_recently_closed_maps_columnid_into_done(tmp_path: Path) -> None:
     provider, client = _provider(tmp_path)
-    client.create_task(name="done", column_id="col-done", number_value=1)
-    assert provider.recently_closed(days=7) == []
+    client.tasks["task-A"] = KfTask(
+        id="task-A", name="Closed thing", column_id="col-done", number_value=7
+    )
+    client.board_events = [_move_event("e1", "2026-06-05T13:20:56.216Z", "task-A", "col-done")]
+    closed = provider.recently_closed(days=36500)  # wide window: exercise mapping, not cutoff
+    assert len(closed) == 1
+    assert closed[0].number == 7
+    assert closed[0].title == "Closed thing"
+    assert closed[0].closed_at == "2026-06-05T13:20:56.216Z"
+
+
+def test_recently_closed_most_recent_move_wins(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)
+    client.tasks["task-A"] = KfTask(id="task-A", name="T", column_id="col-done", number_value=7)
+    client.board_events = [
+        _move_event("e2", "2026-06-05T15:00:00.000Z", "task-A", "col-done"),
+        _move_event("e1", "2026-06-05T13:00:00.000Z", "task-A", "col-done"),
+    ]
+    closed = provider.recently_closed(days=36500)
+    assert len(closed) == 1
+    assert closed[0].closed_at == "2026-06-05T15:00:00.000Z"
+
+
+def test_recently_closed_skips_moves_into_non_done(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)
+    client.tasks["task-A"] = KfTask(id="task-A", name="T", column_id="col-inprog", number_value=7)
+    client.board_events = [_move_event("e1", "2026-06-05T13:00:00.000Z", "task-A", "col-inprog")]
+    assert provider.recently_closed(days=36500) == []
+
+
+def test_recently_closed_skips_unresolvable_task(tmp_path: Path) -> None:
+    provider, client = _provider(tmp_path)
+    client.board_events = [_move_event("e1", "2026-06-05T13:00:00.000Z", "ghost", "col-done")]
+    assert provider.recently_closed(days=36500) == []
 
 
 def test_validate_fields_passes_for_valid(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Phase 0 (design) + Phase 1a (implementation) of epic #357 — bringing the KanbanFlow backend toward capability parity with GitHub Projects.

**Phase 0 — design (`docs/superpowers/`):**
- A cited, adversarially-verified feasibility study graded all 7 capability gaps; a read-only live `/board/events` probe on the test board empirically refuted the #313 "no reliable moved-to-Done timestamp" premise and corrected the response shape to `{eventsLimited, events}`.
- The spec defines the parity rule ("no jared surface degrades on this backend"), a 6-phase plan, and grep-grounded capability outcomes (`CLOSED_STATE` flips cleanly; `VELOCITY_TIMESTAMPS` flip is contingent on the event-retention ceiling; MCP via a thin shim; milestone-due + sub-issues as documented non-goals).

**Phase 1a — `recently_closed` plumbing:**
- `KfEvent` / `KfDetailedEvent` / `KfChangedProperty` dataclasses + parser on the KanbanFlow client.
- `get_board_events()` — reads `GET /board/events` with windowed backward paging over the `{eventsLimited, events}` envelope; descending-only paging guard + cross-page id dedup (the live board confirmed the `to` bound is inclusive).
- `recently_closed()` rewritten from `return []` to scan events for `columnId`→Done transitions (Done resolved via the Status column map), most-recent-move-wins, deleted-task skip.

## Dormancy — read before merging

`recently_closed` returns real data, but it is **correct-but-dormant** on KanbanFlow: its only production consumer — the next-session-prompt "Recently closed" section (`skills/jared/scripts/jared:1190`) — *also* gates on `VELOCITY_TIMESTAMPS`, which KanbanFlow omits, so nothing surfaces the data yet. **Un-gating is Phase 1b/1c work** (the section needs only closed-at, so it can un-gate on `CLOSED_STATE` in Phase 1b, independent of the retention-gated VELOCITY flip). There is **no `_OMITTED_CAPABILITIES` change** in this PR. See the spec §6 "Phase 1c design note".

## Validation
- `pytest` 900 passed; `mypy --strict` clean; `ruff check .` clean.
- Live-verified read-only on KanbanFlow board `p9vK6cR`: `columnId`→Done detection works; ISO `from`/`to` filters server-side; retention floor ~6 days.
- Per-task spec + code-quality review on each implementation task; a final holistic review surfaced (and corrected) the dormancy above.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
